### PR TITLE
chore(rawkode.dev): cleanup the design system and lean more into rose pine

### DIFF
--- a/websites/rawkode.dev/astro.config.mjs
+++ b/websites/rawkode.dev/astro.config.mjs
@@ -8,8 +8,8 @@ export default defineConfig({
   adapter: cloudflare({ mode: "advanced", imageService: "cloudflare" }),
   integrations: [
     expressiveCode({
-      // Match the site palette: Rosé Pine Dawn (light) + Catppuccin Frappé (dark).
-      themes: ["rose-pine-dawn", "catppuccin-frappe"],
+      // Match the dark-first Rosé Pine system used by the site.
+      themes: ["rose-pine-dawn", "rose-pine"],
       // Selector that matches our explicit theme override.
       themeCssSelector: (theme) =>
         `[data-theme='${theme.name === "rose-pine-dawn" ? "light" : "dark"}']`,

--- a/websites/rawkode.dev/panda.config.ts
+++ b/websites/rawkode.dev/panda.config.ts
@@ -157,7 +157,7 @@ export default defineConfig({
 
   globalCss: {
     ':root': {
-      colorScheme: 'dark',
+      colorScheme: 'dark light',
       '--shadows-sm': '0 1px 2px oklch(0% 0 0 / 0.24), 0 0 0 1px oklch(100% 0 0 / 0.02)',
       '--shadows-md': '0 12px 34px oklch(0% 0 0 / 0.32), 0 1px 0 oklch(100% 0 0 / 0.04) inset',
       '--shadows-lg': '0 24px 70px oklch(0% 0 0 / 0.42), 0 1px 0 oklch(100% 0 0 / 0.06) inset',

--- a/websites/rawkode.dev/panda.config.ts
+++ b/websites/rawkode.dev/panda.config.ts
@@ -3,13 +3,9 @@ import { defineConfig } from '@pandacss/dev';
 /**
  * Design system for rawkode.dev.
  *
- * Two palettes drive every surface, text and accent token:
- *   • Light: Rosé Pine Dawn  (https://rosepinetheme.com/palette/ingredients/)
- *   • Dark : Catppuccin Frappé (https://catppuccin.com/palette/)
- *
- * Theme reactivity is handled by the platform — `color-scheme` + `light-dark()`
- * — so OS preference changes apply with zero JavaScript. The Nav toggle only
- * writes an explicit `[data-theme]` override when the user opts out of system.
+ * The site is dark-first and mobile-first. Rosé Pine drives the primary
+ * palette, with a restrained light variant kept for explicit user overrides.
+ * Theme reactivity still uses the existing `[data-theme]` contract.
  */
 export default defineConfig({
   preflight: true,
@@ -26,8 +22,7 @@ export default defineConfig({
       tokens: {
         fonts: {
           sans: { value: "'Figtree Variable', 'Figtree', system-ui, sans-serif" },
-          serif: { value: "'Newsreader Variable', 'Newsreader', Georgia, serif" },
-          mono: { value: "ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, monospace" },
+          mono: { value: "'SFMono-Regular', 'Cascadia Code', 'Source Code Pro', ui-monospace, Menlo, monospace" },
         },
 
         spacing: {
@@ -35,26 +30,30 @@ export default defineConfig({
           '2': { value: '0.5rem' },
           '3': { value: '0.75rem' },
           '4': { value: '1rem' },
+          '5': { value: '1.25rem' },
           '6': { value: '1.5rem' },
           '8': { value: '2rem' },
+          '10': { value: '2.5rem' },
           '12': { value: '3rem' },
           '16': { value: '4rem' },
+          '20': { value: '5rem' },
           '24': { value: '6rem' },
           '32': { value: '8rem' },
         },
 
         radii: {
-          sm: { value: '4px' },
+          xs: { value: '4px' },
+          sm: { value: '6px' },
           md: { value: '8px' },
-          lg: { value: '16px' },
-          xl: { value: '24px' },
+          lg: { value: '10px' },
+          xl: { value: '14px' },
           full: { value: '9999px' },
         },
 
         durations: {
           fast: { value: '120ms' },
           normal: { value: '240ms' },
-          slow: { value: '400ms' },
+          slow: { value: '420ms' },
         },
 
         easings: {
@@ -72,94 +71,84 @@ export default defineConfig({
         },
 
         colors: {
-          /* Rosé Pine Dawn — light palette */
+          rosePine: {
+            base: { value: '#191724' },
+            surface: { value: '#1f1d2e' },
+            overlay: { value: '#26233a' },
+            muted: { value: '#6e6a86' },
+            subtle: { value: '#908caa' },
+            text: { value: '#e0def4' },
+            love: { value: '#eb6f92' },
+            gold: { value: '#f6c177' },
+            rose: { value: '#ebbcba' },
+            pine: { value: '#31748f' },
+            foam: { value: '#9ccfd8' },
+            iris: { value: '#c4a7e7' },
+            highlightLow: { value: '#21202e' },
+            highlightMed: { value: '#403d52' },
+            highlightHigh: { value: '#524f67' },
+          },
+
           rosePineDawn: {
-            base: { value: '#faf4ed' },
-            surface: { value: '#fffaf3' },
-            overlay: { value: '#f2e9e1' },
-            muted: { value: '#9893a5' },
-            subtle: { value: '#797593' },
-            text: { value: '#575279' },
+            base: { value: '#f8f7fb' },
+            surface: { value: '#ffffff' },
+            overlay: { value: '#f0eef6' },
+            muted: { value: '#797593' },
+            subtle: { value: '#6e6a86' },
+            text: { value: '#232136' },
             love: { value: '#b4637a' },
             gold: { value: '#ea9d34' },
             rose: { value: '#d7827e' },
             pine: { value: '#286983' },
             foam: { value: '#56949f' },
             iris: { value: '#907aa9' },
-            highlightLow: { value: '#f4ede8' },
-            highlightMed: { value: '#dfdad9' },
+            highlightLow: { value: '#f1eff7' },
+            highlightMed: { value: '#ddd9ea' },
             highlightHigh: { value: '#cecacd' },
-          },
-
-          /* Catppuccin Frappé — dark palette */
-          catppuccinFrappe: {
-            rosewater: { value: '#f2d5cf' },
-            flamingo: { value: '#eebebe' },
-            pink: { value: '#f4b8e4' },
-            mauve: { value: '#ca9ee6' },
-            red: { value: '#e78284' },
-            maroon: { value: '#ea999c' },
-            peach: { value: '#ef9f76' },
-            yellow: { value: '#e5c890' },
-            green: { value: '#a6d189' },
-            teal: { value: '#81c8be' },
-            sky: { value: '#99d1db' },
-            sapphire: { value: '#85c1dc' },
-            blue: { value: '#8caaee' },
-            lavender: { value: '#babbf1' },
-            text: { value: '#c6d0f5' },
-            subtext1: { value: '#b5bfe2' },
-            subtext0: { value: '#a5adce' },
-            overlay2: { value: '#949cbb' },
-            overlay1: { value: '#838ba7' },
-            overlay0: { value: '#737994' },
-            surface2: { value: '#626880' },
-            surface1: { value: '#51576d' },
-            surface0: { value: '#414559' },
-            base: { value: '#303446' },
-            mantle: { value: '#292c3c' },
-            crust: { value: '#232634' },
           },
         },
       },
 
-      /**
-       * Semantic colours use CSS `light-dark()`. The browser picks the right
-       * value based on the active `color-scheme`, so a user toggling their OS
-       * preference flips the theme without any JS reacting to media changes.
-       */
       semanticTokens: {
         colors: {
           surface: {
-            '1':     { value: 'light-dark({colors.rosePineDawn.base},          {colors.catppuccinFrappe.base})' },
-            '2':     { value: 'light-dark({colors.rosePineDawn.surface},       {colors.catppuccinFrappe.surface0})' },
-            '3':     { value: 'light-dark({colors.rosePineDawn.overlay},       {colors.catppuccinFrappe.surface1})' },
-            invert:  { value: 'light-dark({colors.catppuccinFrappe.base},      {colors.rosePineDawn.base})' },
+            '1':       { value: 'light-dark(#f8f7fb, #191724)' },
+            '2':       { value: 'light-dark(#ffffff, #1f1d2e)' },
+            '3':       { value: 'light-dark(#f0eef6, #26233a)' },
+            glass:     { value: 'light-dark(rgb(255 255 255 / 0.72), rgb(38 35 58 / 0.64))' },
+            raised:    { value: 'light-dark(rgb(255 255 255 / 0.86), rgb(44 40 66 / 0.72))' },
+            invert:    { value: 'light-dark(#191724, #ffffff)' },
           },
 
           text: {
-            primary:   { value: 'light-dark({colors.rosePineDawn.text},   {colors.catppuccinFrappe.text})' },
-            secondary: { value: 'light-dark({colors.rosePineDawn.subtle}, {colors.catppuccinFrappe.subtext0})' },
-            tertiary:  { value: 'light-dark({colors.rosePineDawn.muted},  {colors.catppuccinFrappe.overlay1})' },
-            invert:    { value: 'light-dark({colors.rosePineDawn.base},   {colors.catppuccinFrappe.base})' },
+            primary:   { value: 'light-dark(#232136, #e0def4)' },
+            secondary: { value: 'light-dark(#6e6a86, #908caa)' },
+            tertiary:  { value: 'light-dark(#797593, #6e6a86)' },
+            invert:    { value: 'light-dark(#ffffff, #191724)' },
           },
 
           accent: {
-            DEFAULT: { value: 'light-dark({colors.rosePineDawn.pine},          {colors.catppuccinFrappe.blue})' },
-            hover:   { value: 'light-dark({colors.rosePineDawn.foam},          {colors.catppuccinFrappe.lavender})' },
-            muted:   { value: 'light-dark({colors.rosePineDawn.highlightMed},  {colors.catppuccinFrappe.surface1})' },
+            DEFAULT: { value: 'light-dark(#907aa9, #c4a7e7)' },
+            hover:   { value: 'light-dark(#286983, #9ccfd8)' },
+            muted:   { value: 'light-dark(#f1eff7, #21202e)' },
+            soft:    { value: 'light-dark(rgb(144 122 169 / 0.16), rgb(196 167 231 / 0.18))' },
+            cyan:    { value: 'light-dark(#56949f, #9ccfd8)' },
+            gold:    { value: 'light-dark(#ea9d34, #f6c177)' },
+            rose:    { value: 'light-dark(#d7827e, #ebbcba)' },
+            success: { value: 'light-dark(#56949f, #6bd98f)' },
           },
 
           border: {
-            subtle:  { value: 'light-dark({colors.rosePineDawn.highlightMed},  {colors.catppuccinFrappe.surface0})' },
-            DEFAULT: { value: 'light-dark({colors.rosePineDawn.highlightHigh}, {colors.catppuccinFrappe.surface1})' },
+            subtle:  { value: 'light-dark(#ddd9ea, rgb(224 222 244 / 0.16))' },
+            DEFAULT: { value: 'light-dark(#cecacd, rgb(224 222 244 / 0.24))' },
+            strong:  { value: 'light-dark(#6e6a86, rgb(224 222 244 / 0.38))' },
           },
 
           status: {
-            danger:  { value: 'light-dark({colors.rosePineDawn.love}, {colors.catppuccinFrappe.red})' },
-            warning: { value: 'light-dark({colors.rosePineDawn.gold}, {colors.catppuccinFrappe.yellow})' },
-            success: { value: 'light-dark({colors.rosePineDawn.foam}, {colors.catppuccinFrappe.green})' },
-            info:    { value: 'light-dark({colors.rosePineDawn.iris}, {colors.catppuccinFrappe.mauve})' },
+            danger:  { value: 'light-dark(#b4637a, #eb6f92)' },
+            warning: { value: 'light-dark(#ea9d34, #f6c177)' },
+            success: { value: 'light-dark(#56949f, #6bd98f)' },
+            info:    { value: 'light-dark(#286983, #9ccfd8)' },
           },
         },
       },
@@ -167,54 +156,49 @@ export default defineConfig({
   },
 
   globalCss: {
-    /* Wire the platform up: declare which schemes :root supports, and let
-       explicit overrides constrain it. light-dark() resolves accordingly. */
     ':root': {
-      colorScheme: 'light dark',
-
-      /* Shadows can't use light-dark() (it's colour-only), so they remain
-         CSS-only with a media-query default + data-theme overrides. */
-      '--shadows-sm': '0 1px 3px oklch(0% 0 0 / 0.06), 0 1px 2px oklch(0% 0 0 / 0.04)',
-      '--shadows-md': '0 4px 12px oklch(0% 0 0 / 0.08), 0 2px 4px oklch(0% 0 0 / 0.04)',
-      '--shadows-lg': '0 8px 32px oklch(0% 0 0 / 0.12), 0 4px 8px oklch(0% 0 0 / 0.06)',
-    },
-
-    '@media (prefers-color-scheme: dark)': {
-      ':root:not([data-theme=light])': {
-        '--shadows-sm': '0 1px 3px oklch(0% 0 0 / 0.4), 0 1px 2px oklch(0% 0 0 / 0.24)',
-        '--shadows-md': '0 4px 12px oklch(0% 0 0 / 0.5), 0 2px 4px oklch(0% 0 0 / 0.3)',
-        '--shadows-lg': '0 8px 32px oklch(0% 0 0 / 0.6), 0 4px 8px oklch(0% 0 0 / 0.4)',
-      },
+      colorScheme: 'dark',
+      '--shadows-sm': '0 1px 2px oklch(0% 0 0 / 0.24), 0 0 0 1px oklch(100% 0 0 / 0.02)',
+      '--shadows-md': '0 12px 34px oklch(0% 0 0 / 0.32), 0 1px 0 oklch(100% 0 0 / 0.04) inset',
+      '--shadows-lg': '0 24px 70px oklch(0% 0 0 / 0.42), 0 1px 0 oklch(100% 0 0 / 0.06) inset',
+      '--page-glow':
+        'radial-gradient(circle at 78% 10%, oklch(68% 0.12 292 / 0.16), transparent 34rem), radial-gradient(circle at 12% 18%, oklch(74% 0.10 205 / 0.10), transparent 30rem)',
     },
 
     '[data-theme=light]': {
       colorScheme: 'light',
-      '--shadows-sm': '0 1px 3px oklch(0% 0 0 / 0.06), 0 1px 2px oklch(0% 0 0 / 0.04)',
-      '--shadows-md': '0 4px 12px oklch(0% 0 0 / 0.08), 0 2px 4px oklch(0% 0 0 / 0.04)',
-      '--shadows-lg': '0 8px 32px oklch(0% 0 0 / 0.12), 0 4px 8px oklch(0% 0 0 / 0.06)',
+      '--shadows-sm': '0 1px 3px oklch(0% 0 0 / 0.08), 0 1px 2px oklch(0% 0 0 / 0.04)',
+      '--shadows-md': '0 12px 34px oklch(0% 0 0 / 0.10), 0 1px 0 oklch(100% 0 0 / 0.70) inset',
+      '--shadows-lg': '0 24px 70px oklch(0% 0 0 / 0.14), 0 1px 0 oklch(100% 0 0 / 0.80) inset',
+      '--page-glow':
+        'radial-gradient(circle at 78% 10%, oklch(72% 0.12 292 / 0.14), transparent 34rem), radial-gradient(circle at 12% 18%, oklch(70% 0.10 205 / 0.12), transparent 30rem)',
     },
 
     '[data-theme=dark]': {
       colorScheme: 'dark',
-      '--shadows-sm': '0 1px 3px oklch(0% 0 0 / 0.4), 0 1px 2px oklch(0% 0 0 / 0.24)',
-      '--shadows-md': '0 4px 12px oklch(0% 0 0 / 0.5), 0 2px 4px oklch(0% 0 0 / 0.3)',
-      '--shadows-lg': '0 8px 32px oklch(0% 0 0 / 0.6), 0 4px 8px oklch(0% 0 0 / 0.4)',
+      '--shadows-sm': '0 1px 2px oklch(0% 0 0 / 0.24), 0 0 0 1px oklch(100% 0 0 / 0.02)',
+      '--shadows-md': '0 12px 34px oklch(0% 0 0 / 0.32), 0 1px 0 oklch(100% 0 0 / 0.04) inset',
+      '--shadows-lg': '0 24px 70px oklch(0% 0 0 / 0.42), 0 1px 0 oklch(100% 0 0 / 0.06) inset',
+      '--page-glow':
+        'radial-gradient(circle at 78% 10%, oklch(68% 0.12 292 / 0.16), transparent 34rem), radial-gradient(circle at 12% 18%, oklch(74% 0.10 205 / 0.10), transparent 30rem)',
     },
 
-    /* Legacy aliases — keeps existing components working unchanged while
-       components migrate to css() / token() over time. */
     'html': {
       '--space-1': 'var(--spacing-1)',
       '--space-2': 'var(--spacing-2)',
       '--space-3': 'var(--spacing-3)',
       '--space-4': 'var(--spacing-4)',
+      '--space-5': 'var(--spacing-5)',
       '--space-6': 'var(--spacing-6)',
       '--space-8': 'var(--spacing-8)',
+      '--space-10': 'var(--spacing-10)',
       '--space-12': 'var(--spacing-12)',
       '--space-16': 'var(--spacing-16)',
+      '--space-20': 'var(--spacing-20)',
       '--space-24': 'var(--spacing-24)',
       '--space-32': 'var(--spacing-32)',
 
+      '--radius-xs': 'var(--radii-xs)',
       '--radius-sm': 'var(--radii-sm)',
       '--radius-md': 'var(--radii-md)',
       '--radius-lg': 'var(--radii-lg)',
@@ -238,6 +222,8 @@ export default defineConfig({
       '--surface-1': 'var(--colors-surface-1)',
       '--surface-2': 'var(--colors-surface-2)',
       '--surface-3': 'var(--colors-surface-3)',
+      '--surface-glass': 'var(--colors-surface-glass)',
+      '--surface-raised': 'var(--colors-surface-raised)',
       '--surface-invert': 'var(--colors-surface-invert)',
 
       '--text-primary': 'var(--colors-text-primary)',
@@ -248,9 +234,15 @@ export default defineConfig({
       '--color-accent': 'var(--colors-accent)',
       '--color-accent-hover': 'var(--colors-accent-hover)',
       '--color-accent-muted': 'var(--colors-accent-muted)',
+      '--color-accent-soft': 'var(--colors-accent-soft)',
+      '--color-accent-cyan': 'var(--colors-accent-cyan)',
+      '--color-accent-gold': 'var(--colors-accent-gold)',
+      '--color-accent-rose': 'var(--colors-accent-rose)',
+      '--color-accent-success': 'var(--colors-accent-success)',
 
       '--border-subtle': 'var(--colors-border-subtle)',
       '--border-default': 'var(--colors-border)',
+      '--border-strong': 'var(--colors-border-strong)',
 
       '--shadow-sm': 'var(--shadows-sm)',
       '--shadow-md': 'var(--shadows-md)',

--- a/websites/rawkode.dev/src/components/AppCard.astro
+++ b/websites/rawkode.dev/src/components/AppCard.astro
@@ -8,248 +8,229 @@ interface Props {
 const { app } = Astro.props;
 
 const repoUrl = app.repoUrl ?? (app.repoPath ? `https://github.com/rawkode/rawkode/tree/main/${app.repoPath}` : null);
+const href = app.websiteUrl ?? repoUrl;
+const statusLabel = app.status === 'in-development' ? 'Dev' : app.status === 'beta' ? 'Beta' : 'Live';
+const mark = app.name === 'kubectl-ditto' ? '>_' : app.name.slice(0, 1).toUpperCase();
 ---
 
 <article class:list={['app-card', { 'app-card--featured': app.featured }]}>
-  <header class="app-card__head">
-    <p class="app-card__eyebrow">
-      {app.featured && (
-        <>
-          <span class="app-card__featured">Featured</span>
-          <span class="app-card__sep" aria-hidden="true">·</span>
-        </>
-      )}
-      <span>{app.platform.join(' / ')}</span>
-    </p>
-  </header>
+  <div class="app-card__mark" aria-hidden="true">{mark}</div>
 
-  <div class="app-card__body">
-    <h3 class="app-card__name">{app.name}</h3>
+  <div class="app-card__main">
+    <header class="app-card__head">
+      <h3 class="app-card__name">{app.name}</h3>
+      <span class:list={['app-card__status', `app-card__status--${app.status}`]}>
+        <span aria-hidden="true"></span>{statusLabel}
+      </span>
+    </header>
     <p class="app-card__tagline">{app.tagline}</p>
     <p class="app-card__description">{app.description}</p>
-  </div>
-
-  <footer class="app-card__foot">
     <ul class="app-card__tags" role="list" aria-label="Tags">
-      {app.tags.map((tag) => (
-        <li class="app-card__tag">{tag}</li>
+      {app.tags.slice(0, 4).map((tag) => (
+        <li>{tag}</li>
       ))}
     </ul>
+  </div>
 
-    <div class="app-card__actions">
-      {repoUrl && (
-        <a href={repoUrl} target="_blank" rel="noopener noreferrer" class="app-card__icon-link" aria-label={`View ${app.name} on GitHub`}>
-          <svg width="17" height="17" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-            <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/>
-          </svg>
-        </a>
-      )}
-      {app.websiteUrl && (
-        <a href={app.websiteUrl} target="_blank" rel="noopener noreferrer" class="app-card__icon-link" aria-label={`Visit ${app.name} website`}>
-          <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <circle cx="12" cy="12" r="9"/>
-            <path d="M3 12h18"/>
-            <path d="M12 3a14 14 0 0 1 0 18 14 14 0 0 1 0-18z"/>
-          </svg>
-        </a>
-      )}
-    </div>
-  </footer>
+  <aside class="app-card__meta" aria-label={`${app.name} metadata`}>
+    <span>{app.platform.join(' / ')}</span>
+    {href && (
+      <a href={href} target="_blank" rel="noopener noreferrer" class="app-card__action" aria-label={`Open ${app.name}`}>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M7 17 17 7M9 7h8v8"/>
+        </svg>
+      </a>
+    )}
+  </aside>
 </article>
 
 <style>
   .app-card {
-    position: relative;
-    background: var(--surface-2);
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: var(--space-4);
+    align-items: start;
+    padding: var(--space-4);
     border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-xl);
-    padding: var(--space-8);
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-6);
-    height: 100%;
+    border-radius: var(--radius-lg);
+    background: color-mix(in oklch, var(--surface-raised) 86%, transparent);
+    box-shadow: var(--shadow-sm);
     transition:
-      border-color 0.3s var(--ease-out-expo),
-      transform 0.4s var(--ease-out-expo),
-      box-shadow 0.4s var(--ease-out-expo);
+      border-color var(--dur-fast) var(--ease-out-expo),
+      background var(--dur-fast) var(--ease-out-expo),
+      transform var(--dur-fast) var(--ease-out-expo);
   }
 
-  @media (hover: hover) {
-    .app-card:hover {
-      border-color: var(--border-default);
-      transform: translateY(-2px);
-      box-shadow: var(--shadow-md);
-    }
+  .app-card:hover {
+    border-color: var(--border-default);
+    background: var(--surface-raised);
+    transform: translateY(-1px);
   }
 
-  /* ─── Header eyebrow ────────────────────────────────────────────────────── */
-  .app-card__head { min-height: 1.25rem; }
+  .app-card--featured {
+    border-color: color-mix(in oklch, var(--color-accent) 42%, var(--border-default));
+    background:
+      linear-gradient(135deg, color-mix(in oklch, var(--color-accent-soft) 72%, transparent), transparent 46%),
+      color-mix(in oklch, var(--surface-raised) 90%, transparent);
+  }
 
-  .app-card__eyebrow {
-    display: inline-flex;
-    align-items: center;
-    flex-wrap: wrap;
-    margin: 0;
-    font-family: var(--fonts-sans);
-    font-size: 0.7rem;
+  .app-card__mark {
+    display: grid;
+    place-items: center;
+    width: 44px;
+    aspect-ratio: 1;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    background:
+      linear-gradient(135deg, color-mix(in oklch, var(--color-accent) 50%, transparent), transparent),
+      var(--surface-3);
+    color: var(--text-primary);
+    font-family: var(--fonts-mono);
+    font-size: 1rem;
     font-weight: 700;
-    letter-spacing: 0.18em;
-    text-transform: uppercase;
-    color: var(--text-tertiary);
-    line-height: 1;
   }
 
-  .app-card__featured { color: var(--color-accent); }
-  .app-card__sep {
-    margin-inline: 0.55em;
-    opacity: 0.5;
-    font-weight: 400;
+  .app-card__main {
+    min-width: 0;
+    display: grid;
+    gap: var(--space-2);
   }
 
-  /* ─── Body ──────────────────────────────────────────────────────────────── */
-  .app-card__body {
+  .app-card__head {
     display: flex;
-    flex-direction: column;
+    align-items: baseline;
+    justify-content: space-between;
     gap: var(--space-3);
-    flex: 1;
   }
 
   .app-card__name {
-    font-family: var(--fonts-serif);
-    font-size: clamp(1.5rem, 1.1vw + 1rem, 1.85rem);
-    font-style: normal;
-    font-weight: 600;
-    letter-spacing: -0.022em;
-    line-height: 1.05;
-    color: var(--text-primary);
     margin: 0;
-    text-wrap: balance;
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--text-primary);
+  }
+
+  .app-card__status {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    color: var(--text-tertiary);
+    font-family: var(--fonts-mono);
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .app-card__status span {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--color-accent-success);
+  }
+
+  .app-card__status--in-development span {
+    background: var(--color-accent-gold);
+  }
+
+  .app-card__status--beta span {
+    background: var(--color-accent-cyan);
+  }
+
+  .app-card__tagline,
+  .app-card__description {
+    margin: 0;
   }
 
   .app-card__tagline {
-    font-family: var(--fonts-serif);
-    font-size: 1.0625rem;
-    font-style: italic;
-    font-weight: 400;
-    line-height: 1.4;
-    letter-spacing: -0.005em;
     color: var(--text-primary);
-    margin: 0;
-    max-width: 38ch;
-    text-wrap: balance;
+    font-size: 0.9rem;
+    font-weight: 580;
+    line-height: 1.45;
   }
 
   .app-card__description {
-    font-family: var(--fonts-sans);
-    font-size: 0.92rem;
+    display: none;
     color: var(--text-secondary);
-    line-height: 1.7;
-    margin: 0;
-    flex: 1;
-  }
-
-  /* ─── Footer ────────────────────────────────────────────────────────────── */
-  .app-card__foot {
-    display: flex;
-    align-items: flex-end;
-    justify-content: space-between;
-    gap: var(--space-4);
-    padding-top: var(--space-4);
-    border-top: 1px solid var(--border-subtle);
-    margin-top: auto;
+    font-size: 0.9rem;
+    line-height: 1.6;
   }
 
   .app-card__tags {
-    list-style: none;
-    display: flex;
+    display: none;
     flex-wrap: wrap;
-    flex: 1;
-    min-width: 0;
-    margin: 0;
+    gap: var(--space-2);
+    margin: var(--space-1) 0 0;
     padding: 0;
-    font-family: var(--fonts-sans);
-    font-size: 0.7rem;
-    font-weight: 600;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--text-tertiary);
-    line-height: 1.8;
+    list-style: none;
   }
 
-  /* Separator lives in ::after so it stays attached to the preceding tag
-     when wrapping. white-space: nowrap keeps multi-word tags intact. */
-  .app-card__tag { white-space: nowrap; }
-  .app-card__tag:not(:last-child)::after {
-    content: '·';
-    display: inline-block;
-    padding: 0 0.55em;
+  .app-card__tags li {
+    padding: 0.2rem 0.45rem;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
     color: var(--text-tertiary);
-    opacity: 0.55;
-    font-weight: 400;
+    font-family: var(--fonts-mono);
+    font-size: 0.68rem;
   }
 
-  .app-card__actions {
+  .app-card__meta {
+    grid-column: 2;
     display: flex;
     align-items: center;
-    gap: 2px;
-    flex-shrink: 0;
-    margin-bottom: -4px;
+    justify-content: space-between;
+    gap: var(--space-3);
+    min-width: 0;
+    color: var(--text-tertiary);
+    font-family: var(--fonts-mono);
+    font-size: 0.72rem;
   }
 
-  .app-card__icon-link {
+  .app-card__meta span {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .app-card__action {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     width: 32px;
     height: 32px;
-    border-radius: 999px;
-    color: var(--text-tertiary);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    color: var(--text-secondary);
     text-decoration: none;
-    transition:
-      color 0.25s var(--ease-out-expo),
-      background 0.25s var(--ease-out-expo),
-      transform 0.25s var(--ease-out-expo);
+    flex-shrink: 0;
   }
 
-  .app-card__icon-link:hover {
+  .app-card__action:hover {
     color: var(--text-primary);
-    background: var(--surface-3);
-    transform: translateY(-1px);
+    border-color: var(--border-default);
+    background: var(--surface-glass);
   }
 
-  /* ─── Featured variant ──────────────────────────────────────────────────── */
-  .app-card--featured {
-    background: var(--surface-3);
-    border-color: color-mix(in oklch, var(--color-accent) 22%, var(--border-default));
-    box-shadow: inset 4px 0 0 0 var(--color-accent);
+  .app-card__action svg {
+    width: 15px;
+    height: 15px;
   }
 
-  .app-card--featured .app-card__name {
-    font-size: clamp(2rem, 2vw + 1.2rem, 2.85rem);
-  }
-
-  .app-card--featured .app-card__tagline {
-    font-size: 1.2rem;
-    max-width: 54ch;
-  }
-
-  .app-card--featured .app-card__description {
-    font-size: 0.975rem;
-    max-width: 64ch;
-  }
-
-  @media (hover: hover) {
-    .app-card--featured:hover {
-      border-color: color-mix(in oklch, var(--color-accent) 40%, var(--border-default));
-      box-shadow:
-        inset 4px 0 0 0 var(--color-accent),
-        var(--shadow-md);
+  @media (min-width: 720px) {
+    .app-card {
+      grid-template-columns: auto minmax(0, 1fr) minmax(8rem, auto);
+      align-items: center;
+      padding: var(--space-5);
     }
-  }
 
-  /* ─── Reduced motion ────────────────────────────────────────────────────── */
-  @media (prefers-reduced-motion: reduce) {
-    .app-card,
-    .app-card__icon-link { transition: none; }
+    .app-card__description,
+    .app-card__tags {
+      display: flex;
+    }
+
+    .app-card__meta {
+      grid-column: auto;
+      justify-content: end;
+    }
   }
 </style>

--- a/websites/rawkode.dev/src/components/BlueskyPostCard.astro
+++ b/websites/rawkode.dev/src/components/BlueskyPostCard.astro
@@ -30,74 +30,60 @@ function nl2p(text: string) {
   <footer class="bsky-post__footer">
     <time class="bsky-post__date" datetime={post.createdAt}>{formatDate(post.createdAt)}</time>
     <div class="bsky-post__stats" aria-label="Engagement">
-      {post.likeCount > 0 && (
-        <span class="bsky-post__stat" title="Likes">
-          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
-          {post.likeCount}
-        </span>
-      )}
-      {post.repostCount > 0 && (
-        <span class="bsky-post__stat" title="Reposts">
-          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M17 1l4 4-4 4"/><path d="M3 11V9a4 4 0 0 1 4-4h14"/><path d="M7 23l-4-4 4-4"/><path d="M21 13v2a4 4 0 0 1-4 4H3"/></svg>
-          {post.repostCount}
-        </span>
-      )}
+      {post.likeCount > 0 && <span>{post.likeCount} likes</span>}
+      {post.repostCount > 0 && <span>{post.repostCount} reposts</span>}
     </div>
   </footer>
 </a>
 
 <style>
   .bsky-post {
-    display: flex;
-    flex-direction: column;
+    display: grid;
     gap: var(--space-4);
-    padding: var(--space-6);
-    background: var(--surface-2);
+    padding: var(--space-4);
     border: 1px solid var(--border-subtle);
     border-radius: var(--radius-lg);
+    background: var(--surface-glass);
+    color: var(--text-primary);
     text-decoration: none;
-    transition: border-color var(--dur-fast) var(--ease-out-expo), box-shadow var(--dur-fast) var(--ease-out-expo);
+    transition:
+      border-color var(--dur-fast) var(--ease-out-expo),
+      background var(--dur-fast) var(--ease-out-expo),
+      transform var(--dur-fast) var(--ease-out-expo);
   }
 
-  @media (hover: hover) {
-    .bsky-post:hover {
-      border-color: var(--border-default);
-      box-shadow: var(--shadow-sm);
-    }
+  .bsky-post:hover {
+    border-color: var(--border-default);
+    background: var(--surface-raised);
+    transform: translateY(-1px);
   }
 
-  .bsky-post__body { flex: 1; }
+  .bsky-post__body {
+    display: grid;
+    gap: var(--space-3);
+  }
 
   .bsky-post__text {
-    font-size: 0.9375rem;
-    line-height: 1.65;
+    margin: 0;
     color: var(--text-primary);
+    font-size: 0.92rem;
+    line-height: 1.62;
   }
-
-  .bsky-post__text + .bsky-post__text { margin-top: var(--space-3); }
 
   .bsky-post__footer {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: var(--space-4);
-  }
-
-  .bsky-post__date {
-    font-size: 0.8125rem;
     color: var(--text-tertiary);
+    font-family: var(--fonts-mono);
+    font-size: 0.72rem;
   }
 
   .bsky-post__stats {
     display: flex;
-    gap: var(--space-3);
-  }
-
-  .bsky-post__stat {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    font-size: 0.8125rem;
-    color: var(--text-tertiary);
+    flex-wrap: wrap;
+    justify-content: end;
+    gap: var(--space-2);
   }
 </style>

--- a/websites/rawkode.dev/src/components/Footer.astro
+++ b/websites/rawkode.dev/src/components/Footer.astro
@@ -1,68 +1,133 @@
 ---
 const year = new Date().getFullYear();
 const links = [
-  { href: 'https://bsky.app/profile/rawkode.dev', label: 'Bluesky' },
   { href: 'https://github.com/rawkode', label: 'GitHub' },
-  { href: 'https://rawkode.academy', label: 'Rawkode Academy' },
+  { href: 'https://bsky.app/profile/rawkode.dev', label: 'Bluesky' },
+  { href: 'https://www.youtube.com/@RawkodeAcademy', label: 'YouTube' },
+  { href: 'https://www.linkedin.com/in/rawkode', label: 'LinkedIn' },
+];
+const navLinks = [
+  { href: '/#apps', label: 'Apps' },
+  { href: '/read', label: 'Writing' },
+  { href: '/biography', label: 'Biography' },
+  { href: 'https://rawkode.academy', label: 'Academy' },
 ];
 ---
 
 <footer class="footer">
   <div class="container footer__inner">
-    <p class="footer__copy">&copy; {year} David Flanagan</p>
-    <nav aria-label="Footer links">
-      <ul class="footer__links" role="list">
+    <div class="footer__brand">
+      <a href="/" class="footer__logo">rawkode<span>.dev</span></a>
+      <p>&copy; {year} David Flanagan</p>
+      <p class="footer__signal"><span aria-hidden="true">$</span> build · ship · teach</p>
+    </div>
+
+    <nav class="footer__nav" aria-label="Footer navigation">
+      <p class="footer__label">Navigation</p>
+      <ul role="list">
+        {navLinks.map((link) => (
+          <li><a href={link.href}>{link.label}</a></li>
+        ))}
+      </ul>
+    </nav>
+
+    <nav class="footer__nav" aria-label="Social links">
+      <p class="footer__label">Connect</p>
+      <ul role="list">
         {links.map((link) => (
           <li>
-            <a
-              href={link.href}
-              class="footer__link"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {link.label}
-            </a>
+            <a href={link.href} target="_blank" rel="noopener noreferrer">{link.label}</a>
           </li>
         ))}
       </ul>
     </nav>
+
+    <div class="footer__system">
+      <p class="footer__label">System</p>
+      <p>Based in Glasgow, Scotland</p>
+      <p>Working globally</p>
+      <p>Always building</p>
+    </div>
   </div>
 </footer>
 
 <style>
   .footer {
-    margin-top: var(--space-32);
+    margin-top: var(--space-16);
     border-top: 1px solid var(--border-subtle);
-    padding-block: var(--space-8);
+    background: color-mix(in oklch, var(--surface-1) 70%, transparent);
   }
 
   .footer__inner {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    flex-wrap: wrap;
-    gap: var(--space-4);
+    display: grid;
+    gap: var(--space-8);
+    padding-block: var(--space-8);
   }
 
-  .footer__copy {
-    font-size: 0.875rem;
+  .footer__brand,
+  .footer__nav,
+  .footer__system {
+    display: grid;
+    gap: var(--space-2);
+  }
+
+  .footer__logo {
+    width: fit-content;
+    color: var(--text-primary);
+    font-weight: 700;
+    text-decoration: none;
+  }
+
+  .footer__logo span {
+    color: var(--color-accent);
+  }
+
+  .footer p,
+  .footer a {
+    margin: 0;
     color: var(--text-tertiary);
+    font-size: 0.875rem;
+    text-decoration: none;
   }
 
-  .footer__links {
-    display: flex;
-    gap: var(--space-6);
+  .footer a:hover {
+    color: var(--text-primary);
+  }
+
+  .footer__signal {
+    font-family: var(--fonts-mono);
+  }
+
+  .footer__signal span {
+    color: var(--color-accent-success);
+  }
+
+  .footer__label {
+    color: var(--text-secondary) !important;
+    font-family: var(--fonts-mono);
+    font-size: 0.7rem !important;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .footer ul {
+    display: grid;
+    gap: var(--space-2);
+    margin: 0;
+    padding: 0;
     list-style: none;
   }
 
-  .footer__link {
-    font-size: 0.875rem;
-    color: var(--text-secondary);
-    text-decoration: none;
-    transition: color var(--dur-fast) var(--ease-out-expo);
+  .footer__system p:not(.footer__label)::before {
+    content: "›";
+    margin-right: var(--space-2);
+    color: var(--color-accent-success);
   }
 
-  .footer__link:hover {
-    color: var(--text-primary);
+  @media (min-width: 760px) {
+    .footer__inner {
+      grid-template-columns: minmax(0, 1.5fr) repeat(3, minmax(9rem, 1fr));
+      align-items: start;
+    }
   }
 </style>

--- a/websites/rawkode.dev/src/components/Nav.astro
+++ b/websites/rawkode.dev/src/components/Nav.astro
@@ -6,70 +6,88 @@ const navLinks = [
   { href: 'https://rawkode.academy', label: 'Academy', external: true },
 ];
 const currentPath = Astro.url.pathname;
+
+function isActive(href: string, external?: boolean) {
+  if (external) return false;
+  if (href.startsWith('/#')) return currentPath === '/';
+  return currentPath === href || currentPath.startsWith(`${href}/`);
+}
 ---
 
 <header class="nav">
   <div class="container nav__inner">
     <a href="/" class="nav__logo" aria-label="rawkode.dev home">
-      <span class="nav__logo-name">rawkode<span class="nav__logo-dot">.</span>dev</span>
+      <span>rawkode</span><span class="nav__logo-dot">.dev</span>
     </a>
 
-    <nav aria-label="Primary navigation">
+    <nav class="nav__desktop" aria-label="Primary navigation">
       <ul class="nav__links" role="list">
         {navLinks.map((link) => (
           <li>
             <a
               href={link.href}
-              class:list={['nav__link', { 'nav__link--active': !link.external && currentPath === link.href }]}
+              class:list={['nav__link', { 'nav__link--active': isActive(link.href, link.external) }]}
               {...(link.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
             >
               {link.label}
-              {link.external && (
-                <svg class="nav__external-icon" width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
-                  <path d="M5.5 1H9M9 1V4.5M9 1L4 6M3.5 2H2C1.44772 2 1 2.44772 1 3V8C1 8.55228 1.44772 9 2 9H7C7.55228 9 8 8.55228 8 8V6.5" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-              )}
             </a>
           </li>
         ))}
       </ul>
     </nav>
 
-    <button
-      class="theme-toggle"
-      id="theme-toggle"
-      aria-label="Colour theme: system"
-    >
-      <!-- Sun — shown when in light mode -->
-      <svg class="theme-icon theme-icon--light" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-        <circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/>
-      </svg>
-      <!-- Moon — shown when in dark mode -->
-      <svg class="theme-icon theme-icon--dark" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-        <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/>
-      </svg>
-      <!-- Monitor — shown when following system -->
-      <svg class="theme-icon theme-icon--system" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-        <rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/>
-      </svg>
-    </button>
+    <div class="nav__tools">
+      <button class="theme-toggle" id="theme-toggle" aria-label="Colour theme: system">
+        <svg class="theme-icon theme-icon--light" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/>
+        </svg>
+        <svg class="theme-icon theme-icon--dark" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/>
+        </svg>
+        <svg class="theme-icon theme-icon--system" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/>
+        </svg>
+      </button>
+
+      <details class="mobile-menu">
+        <summary class="mobile-menu__summary" aria-label="Open navigation menu">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true">
+            <path d="M5 7h14M5 12h14M5 17h14"/>
+          </svg>
+        </summary>
+        <nav class="mobile-menu__panel" aria-label="Mobile navigation">
+          {navLinks.map((link) => (
+            <a
+              href={link.href}
+              class:list={['mobile-menu__link', { 'mobile-menu__link--active': isActive(link.href, link.external) }]}
+              {...(link.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+            >
+              <span>{link.label}</span>
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M7 17 17 7M9 7h8v8"/>
+              </svg>
+            </a>
+          ))}
+        </nav>
+      </details>
+    </div>
   </div>
 </header>
 
 <script>
   const toggle = document.getElementById('theme-toggle') as HTMLButtonElement | null;
-  const root   = document.documentElement;
+  const root = document.documentElement;
 
   type Theme = 'light' | 'dark' | 'system';
   const cycle: Record<Theme, Theme> = { light: 'dark', dark: 'system', system: 'light' };
   const labels: Record<Theme, string> = {
-    light:  'Colour theme: light — click for dark',
-    dark:   'Colour theme: dark — click for system',
+    light: 'Colour theme: light — click for dark',
+    dark: 'Colour theme: dark — click for system',
     system: 'Colour theme: system — click for light',
   };
 
   function current(): Theme {
-    return (localStorage.getItem('theme') as Theme | null) ?? 'system';
+    return (localStorage.getItem('theme') as Theme | null) ?? 'dark';
   }
 
   function apply(theme: Theme) {
@@ -92,72 +110,91 @@ const currentPath = Astro.url.pathname;
     position: sticky;
     top: 0;
     z-index: var(--z-sticky);
-    background: color-mix(in oklch, var(--surface-1) 90%, transparent);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
     border-bottom: 1px solid var(--border-subtle);
-    transition: background var(--dur-normal) var(--ease-in-out);
+    background: color-mix(in oklch, var(--surface-1) 78%, transparent);
+    backdrop-filter: blur(18px) saturate(1.2);
+    -webkit-backdrop-filter: blur(18px) saturate(1.2);
   }
 
   .nav__inner {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    height: 64px;
-    gap: var(--space-6);
+    min-height: 64px;
+    gap: var(--space-4);
   }
 
   .nav__logo {
-    text-decoration: none;
-    flex-shrink: 0;
-  }
-
-  .nav__logo-name {
-    font-family: 'Newsreader Variable', serif;
-    font-size: 1.2rem;
-    font-weight: 600;
-    font-style: italic;
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0;
+    font-size: 1rem;
+    font-weight: 700;
     color: var(--text-primary);
-    letter-spacing: -0.02em;
+    text-decoration: none;
+    letter-spacing: 0;
   }
 
   .nav__logo-dot {
     color: var(--color-accent);
+    font-weight: 600;
+  }
+
+  .nav__desktop {
+    display: none;
   }
 
   .nav__links {
     display: flex;
     align-items: center;
-    gap: var(--space-1);
+    gap: var(--space-2);
     list-style: none;
+    margin: 0;
+    padding: 0;
   }
 
   .nav__link {
+    position: relative;
     display: inline-flex;
     align-items: center;
-    gap: var(--space-1);
-    padding: var(--space-2) var(--space-3);
+    padding: 0.5rem 0.75rem;
     border-radius: var(--radius-md);
-    font-size: 0.9rem;
-    font-weight: 500;
     color: var(--text-secondary);
+    font-size: 0.875rem;
+    font-weight: 560;
     text-decoration: none;
-    transition: color var(--dur-fast) var(--ease-out-expo), background var(--dur-fast) var(--ease-out-expo);
+    transition:
+      color var(--dur-fast) var(--ease-out-expo),
+      background var(--dur-fast) var(--ease-out-expo);
   }
 
   .nav__link:hover,
   .nav__link--active {
     color: var(--text-primary);
-    background: var(--surface-2);
+    background: var(--surface-glass);
   }
 
-  .nav__external-icon {
-    opacity: 0.6;
-    flex-shrink: 0;
+  .nav__link--active::after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    bottom: 0.15rem;
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    background: var(--color-accent);
+    transform: translateX(-50%);
   }
 
-  .theme-toggle {
+  .nav__tools {
     display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .theme-toggle,
+  .mobile-menu__summary {
+    display: inline-flex;
     align-items: center;
     justify-content: center;
     width: 36px;
@@ -165,29 +202,95 @@ const currentPath = Astro.url.pathname;
     padding: 0;
     border: 1px solid var(--border-subtle);
     border-radius: var(--radius-md);
-    background: transparent;
+    background: var(--surface-glass);
     color: var(--text-secondary);
     cursor: pointer;
-    transition: color var(--dur-fast) var(--ease-out-expo), border-color var(--dur-fast) var(--ease-out-expo), background var(--dur-fast) var(--ease-out-expo);
-    flex-shrink: 0;
+    transition:
+      color var(--dur-fast) var(--ease-out-expo),
+      border-color var(--dur-fast) var(--ease-out-expo),
+      background var(--dur-fast) var(--ease-out-expo),
+      transform var(--dur-fast) var(--ease-out-expo);
   }
 
-  .theme-toggle:hover {
+  .theme-toggle:hover,
+  .mobile-menu__summary:hover {
     color: var(--text-primary);
-    background: var(--surface-2);
     border-color: var(--border-default);
+    background: var(--surface-raised);
   }
 
-  /* Show correct icon based on active theme state (set by inline script).
-     `[data-ui-theme]` lives on <html> (outside this component), so the
-     ancestor selector must be :global or Astro's scoping prevents a match. */
   .theme-icon { display: none; }
-  :global([data-ui-theme="light"])  .theme-icon--light  { display: block; }
-  :global([data-ui-theme="dark"])   .theme-icon--dark   { display: block; }
+  :global([data-ui-theme="light"]) .theme-icon--light { display: block; }
+  :global([data-ui-theme="dark"]) .theme-icon--dark { display: block; }
   :global([data-ui-theme="system"]) .theme-icon--system { display: block; }
 
-  @media (max-width: 640px) {
-    .nav__links {
+  .mobile-menu {
+    position: relative;
+  }
+
+  .mobile-menu__summary {
+    list-style: none;
+  }
+
+  .mobile-menu__summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .mobile-menu__summary svg {
+    width: 18px;
+    height: 18px;
+  }
+
+  .mobile-menu__panel {
+    position: absolute;
+    top: calc(100% + var(--space-3));
+    right: 0;
+    width: min(78vw, 280px);
+    padding: var(--space-2);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-lg);
+    background: color-mix(in oklch, var(--surface-2) 92%, transparent);
+    box-shadow: var(--shadow-lg);
+    backdrop-filter: blur(20px) saturate(1.2);
+    -webkit-backdrop-filter: blur(20px) saturate(1.2);
+  }
+
+  .mobile-menu__link {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+    padding: var(--space-3);
+    border-radius: var(--radius-md);
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    font-weight: 600;
+    text-decoration: none;
+  }
+
+  .mobile-menu__link:hover,
+  .mobile-menu__link--active {
+    color: var(--text-primary);
+    background: var(--surface-raised);
+  }
+
+  .mobile-menu__link svg {
+    width: 16px;
+    height: 16px;
+    color: var(--text-tertiary);
+  }
+
+  @media (min-width: 760px) {
+    .nav__inner {
+      min-height: 68px;
+    }
+
+    .nav__desktop {
+      display: block;
+      margin-inline: auto;
+    }
+
+    .mobile-menu {
       display: none;
     }
   }

--- a/websites/rawkode.dev/src/components/Nav.astro
+++ b/websites/rawkode.dev/src/components/Nav.astro
@@ -85,9 +85,14 @@ function isActive(href: string, external?: boolean) {
     dark: 'Colour theme: dark — click for system',
     system: 'Colour theme: system — click for light',
   };
+  const themes = new Set<Theme>(['light', 'dark', 'system']);
 
   function current(): Theme {
-    return (localStorage.getItem('theme') as Theme | null) ?? 'dark';
+    const uiTheme = root.getAttribute('data-ui-theme') as Theme | null;
+    if (uiTheme && themes.has(uiTheme)) return uiTheme;
+
+    const saved = localStorage.getItem('theme') as Theme | null;
+    return saved && themes.has(saved) ? saved : 'system';
   }
 
   function apply(theme: Theme) {
@@ -102,6 +107,7 @@ function isActive(href: string, external?: boolean) {
     if (toggle) toggle.setAttribute('aria-label', labels[theme]);
   }
 
+  if (toggle) toggle.setAttribute('aria-label', labels[current()]);
   toggle?.addEventListener('click', () => apply(cycle[current()]));
 </script>
 

--- a/websites/rawkode.dev/src/layouts/Layout.astro
+++ b/websites/rawkode.dev/src/layouts/Layout.astro
@@ -114,7 +114,7 @@ const socialProfiles = [
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="robots" content={robots} />
     <meta name="googlebot" content={robots} />
-    <meta name="color-scheme" content="light dark" />
+    <meta name="color-scheme" content="dark light" />
 
     <!-- Favicons -->
     <link rel="icon" href="/favicon.ico" sizes="32x32" />
@@ -123,8 +123,8 @@ const socialProfiles = [
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />
-    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff" />
-    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0b0b0f" />
+    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f8f7fb" />
+    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#191724" />
     <meta name="application-name" content={siteName} />
     <meta name="apple-mobile-web-app-title" content={siteName} />
 
@@ -180,7 +180,7 @@ const socialProfiles = [
           root.setAttribute('data-theme', saved);
           root.setAttribute('data-ui-theme', saved);
         } else {
-          root.setAttribute('data-ui-theme', 'system');
+          root.setAttribute('data-ui-theme', 'dark');
         }
       })();
     </script>
@@ -197,8 +197,9 @@ const socialProfiles = [
     top: var(--space-4);
     left: var(--space-4);
     padding: var(--space-2) var(--space-4);
-    background: var(--color-accent);
-    color: var(--text-invert);
+    border: 1px solid var(--border-default);
+    background: var(--surface-raised);
+    color: var(--text-primary);
     border-radius: var(--radius-md);
     font-weight: 600;
     text-decoration: none;

--- a/websites/rawkode.dev/src/layouts/Layout.astro
+++ b/websites/rawkode.dev/src/layouts/Layout.astro
@@ -180,7 +180,8 @@ const socialProfiles = [
           root.setAttribute('data-theme', saved);
           root.setAttribute('data-ui-theme', saved);
         } else {
-          root.setAttribute('data-ui-theme', 'dark');
+          root.removeAttribute('data-theme');
+          root.setAttribute('data-ui-theme', 'system');
         }
       })();
     </script>

--- a/websites/rawkode.dev/src/pages/biography.astro
+++ b/websites/rawkode.dev/src/pages/biography.astro
@@ -7,31 +7,30 @@ import Layout from '../layouts/Layout.astro';
 import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
 
-// ─── Speaker-kit content ──────────────────────────────────────────────────────
 const tagline =
   'Helping developers, platform engineers, and infrastructure operators level up with Kubernetes.';
 
 const bios = [
   {
     id: 'short',
-    label: 'Short',
-    note: '1 sentence',
+    label: 'Short bio',
+    note: '50 words',
     paragraphs: [
       'David Flanagan (aka rawkode) is a Senior Solutions Engineer at CoreWeave and the founder of Rawkode Academy, where he teaches engineers the practical work behind Kubernetes, platform engineering, and cloud-native infrastructure.',
     ],
   },
   {
     id: 'medium',
-    label: 'Medium',
-    note: '1 paragraph',
+    label: 'Medium bio',
+    note: '150 words',
     paragraphs: [
       "Based in Glasgow, Scotland, David Flanagan (better known as rawkode) has spent twenty years close to the metal, from embedded C to the GPU clusters powering today's AI. As a Senior Solutions Engineer at CoreWeave he helps teams tame that infrastructure, and as the founder of Rawkode Academy he gives the knowledge away, teaching Kubernetes, platform engineering, and cloud-native systems through free courses and building in the open.",
     ],
   },
   {
     id: 'long',
-    label: 'Long',
-    note: 'Full bio',
+    label: 'Long bio',
+    note: '300 words',
     paragraphs: [
       'Based in Glasgow, Scotland, David Flanagan, better known online as rawkode, has spent twenty years close to the metal. He began with embedded C in 2004 and worked his way up the stack as the industry moved from bare servers to containers to the GPU clusters now powering modern AI.',
       'Today he sits at that frontier as a Senior Solutions Engineer at CoreWeave, helping teams run demanding AI workloads where Kubernetes meets large-scale GPU compute. The same instinct to make hard infrastructure approachable runs through Rawkode Academy, the company he founded, where he gives that knowledge away, building in the open and publishing free courses on Kubernetes, platform engineering, and cloud-native systems so developers, platform engineers, and infrastructure operators can level up alongside him.',
@@ -41,61 +40,34 @@ const bios = [
 ];
 
 const facts = [
-  { label: 'Full name', value: 'David Flanagan' },
-  { label: 'Goes by', value: 'rawkode' },
-  { label: 'Pronunciation', value: 'FLAN-ah-gan' },
-  { label: 'Pronouns', value: 'He/Him' },
-  { label: 'Title', value: 'Senior Solutions Engineer at CoreWeave / Founder of Rawkode Academy' },
+  { label: 'Focus', value: 'Developer tooling, platform engineering, authz, and systems' },
+  { label: 'Current', value: 'Building in public, shipping tools, teaching at Rawkode Academy' },
   { label: 'Location', value: 'Glasgow, Scotland' },
-  { label: 'Website', value: 'rawkode.dev' },
+  { label: 'Availability', value: 'Available for speaking', status: true },
+  { label: 'Format', value: 'Keynotes, talks, panels, workshops' },
+  { label: 'Travel', value: 'Worldwide' },
 ];
 
 const topics = [
-  'AI Infrastructure',
-  'Cloud Native',
-  'Developer Experience',
-  'GPU & Accelerated Computing',
-  'Kubernetes',
-  'Nix',
-  'Open Source',
+  'Developer Tooling',
   'Platform Engineering',
+  'Kubernetes',
+  'Authorization & SpiceDB',
+  'CUE',
   'Rust',
-  'WebAssembly',
+  'Open Source',
+  'Build in Public',
+  'Infrastructure',
+  'Security',
 ];
 
-// Brand glyphs are CC0 paths from Simple Icons (24×24, filled with currentColor);
-// the Academy uses a graduation-cap mark.
 const socials = [
-  {
-    label: 'Bluesky',
-    handle: 'rawkode.dev',
-    href: 'https://bsky.app/profile/rawkode.dev',
-    icon: 'M12 10.8c-1.087-2.114-4.046-6.053-6.798-7.995C2.566.944 1.561 1.266.902 1.565.139 1.908 0 3.08 0 3.768c0 .69.378 5.65.624 6.479.815 2.736 3.713 3.66 6.383 3.364.136-.02.275-.039.415-.056-.138.022-.276.04-.415.056-3.912.58-7.387 2.005-2.83 7.078 5.013 5.19 6.87-1.113 7.823-4.308.953 3.195 2.05 9.271 7.733 4.308 4.267-4.308 1.172-6.498-2.74-7.078a8.741 8.741 0 0 1-.415-.056c.14.017.279.036.415.056 2.67.297 5.568-.628 6.383-3.364.246-.828.624-5.79.624-6.478 0-.688-.139-1.86-.902-2.203-.659-.299-1.664-.621-4.3 1.24C16.046 4.747 13.087 8.686 12 10.8Z',
-  },
-  {
-    label: 'Twitter / X',
-    handle: '@rawkode',
-    href: 'https://twitter.com/rawkode',
-    icon: 'M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z',
-  },
-  {
-    label: 'LinkedIn',
-    handle: '/in/rawkode',
-    href: 'https://linkedin.com/in/rawkode',
-    icon: 'M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z',
-  },
-  {
-    label: 'YouTube',
-    handle: 'rawkode.live',
-    href: 'https://www.youtube.com/@RawkodeAcademy',
-    icon: 'M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z',
-  },
-  {
-    label: 'Rawkode Academy',
-    handle: 'rawkode.academy',
-    href: 'https://rawkode.academy',
-    icon: 'M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3 1 9l11 6 9-4.91V17h2V9z',
-  },
+  { label: 'Email', handle: 'david@rawkode.dev', href: 'mailto:david@rawkode.dev' },
+  { label: 'Website', handle: 'rawkode.dev', href: 'https://rawkode.dev' },
+  { label: 'Academy', handle: 'rawkode.academy', href: 'https://rawkode.academy' },
+  { label: 'GitHub', handle: 'github.com/rawkode', href: 'https://github.com/rawkode' },
+  { label: 'Bluesky', handle: '@rawkode.dev', href: 'https://bsky.app/profile/rawkode.dev' },
+  { label: 'LinkedIn', handle: '/in/rawkode', href: 'https://linkedin.com/in/rawkode' },
 ];
 
 const personJsonLd = {
@@ -107,7 +79,7 @@ const personJsonLd = {
   worksFor: { '@type': 'Organization', name: 'CoreWeave' },
   founder: { '@type': 'Organization', name: 'Rawkode Academy', url: 'https://rawkode.academy' },
   address: { '@type': 'PostalAddress', addressLocality: 'Glasgow', addressCountry: 'GB' },
-  description: bios[0].text,
+  description: bios[0].paragraphs.join(' '),
   url: 'https://rawkode.dev/biography',
   sameAs: socials.map((s) => s.href),
 };
@@ -121,144 +93,124 @@ const personJsonLd = {
 >
   <Nav />
   <main id="main-content">
-
-    <!-- ─── Hero ──────────────────────────────────────────────────────────── -->
     <section class="bio-hero">
-      <div class="bio-hero__text">
-        <p class="eyebrow">Speaker kit</p>
-        <h1 class="bio-hero__name">David Flanagan</h1>
-        <p class="bio-hero__handle">aka <em>rawkode</em></p>
-        <p class="bio-hero__tagline">{tagline}</p>
-        <p class="bio-hero__location">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z"/><circle cx="12" cy="10" r="3"/>
-          </svg>
-          Glasgow, Scotland
-        </p>
+      <div class="container bio-hero__inner">
+        <div class="bio-hero__copy">
+          <h1>David Flanagan</h1>
+          <p class="bio-hero__handle">rawkode</p>
+          <p class="bio-hero__location">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z"/><circle cx="12" cy="10" r="3"/>
+            </svg>
+            Glasgow, Scotland
+          </p>
+          <p class="bio-hero__tagline">{tagline}</p>
+        </div>
+
+        <figure class="portrait-card">
+          <Image
+            src={rawkodePhoto}
+            alt="David Flanagan"
+            class="portrait-card__photo"
+            loading="eager"
+            widths={[360, 540, 720]}
+            sizes="(max-width: 899px) 48vw, 360px"
+          />
+          <figcaption>
+            <span><i aria-hidden="true"></i> Available for speaking</span>
+          </figcaption>
+        </figure>
       </div>
-      <figure class="bio-hero__photo-fig">
-        <Image
-          src={rawkodePhoto}
-          alt="David Flanagan"
-          class="bio-hero__photo"
-          loading="eager"
-          widths={[360, 540, 720]}
-          sizes="(max-width: 899px) 60vw, 360px"
-        />
-        <a href={rawkodePhoto.src} download="david-flanagan.jpg" class="bio-hero__download">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    </section>
+
+    <section class="bio-section">
+      <div class="container bio-grid">
+        <div class="bio-panel">
+          <header class="panel-head">
+            <p>Quick facts</p>
+          </header>
+          <dl class="facts">
+            {facts.map((fact) => (
+              <div class="facts__row">
+                <dt>{fact.label}</dt>
+                <dd>
+                  {fact.status && <span class="status-dot" aria-hidden="true"></span>}
+                  <span id={`fact-${fact.label.toLowerCase().replaceAll(' ', '-')}`}>{fact.value}</span>
+                  <button class="copy-btn copy-btn--icon" type="button" data-copy-target={`fact-${fact.label.toLowerCase().replaceAll(' ', '-')}`} aria-label={`Copy ${fact.label}`}>
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                      <rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h10"/>
+                    </svg>
+                  </button>
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+
+        <div class="bio-panel bio-panel--bios">
+          <header class="panel-head">
+            <p>Biography</p>
+          </header>
+          <div class="bio-cards">
+            {bios.map((bio) => (
+              <article class="bio-card">
+                <header>
+                  <h2>{bio.label}</h2>
+                  <span>{bio.note}</span>
+                  <button class="copy-btn" type="button" data-copy-target={`bio-${bio.id}`}>
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                      <rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h10"/>
+                    </svg>
+                    <span class="copy-btn__label">Copy</span>
+                  </button>
+                </header>
+                <div class="bio-card__text" id={`bio-${bio.id}`}>
+                  {bio.paragraphs.map((para) => <p>{para}</p>)}
+                </div>
+              </article>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="bio-section">
+      <div class="container bio-bottom">
+        <div class="bio-panel">
+          <header class="panel-head">
+            <p>Topics</p>
+          </header>
+          <ul class="topics" role="list">
+            {topics.map((topic) => <li>{topic}</li>)}
+          </ul>
+        </div>
+
+        <div class="bio-panel">
+          <header class="panel-head">
+            <p>Connect</p>
+          </header>
+          <ul class="socials" role="list">
+            {socials.map((social) => (
+              <li>
+                <a href={social.href} target={social.href.startsWith('mailto:') ? undefined : '_blank'} rel={social.href.startsWith('mailto:') ? undefined : 'noopener noreferrer'}>
+                  <span>{social.label}</span>
+                  <strong>{social.handle}</strong>
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M7 17 17 7M9 7h8v8"/>
+                  </svg>
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <a href={rawkodePhoto.src} download="david-flanagan.jpg" class="download-card">
+          <span>Download headshot</span>
+          <strong>High-resolution speaker photo</strong>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <path d="M12 3v12m0 0 4-4m-4 4-4-4M5 21h14"/>
           </svg>
-          Download photo
         </a>
-      </figure>
-    </section>
-
-    <!-- ─── Bios ──────────────────────────────────────────────────────────── -->
-    <section class="section" data-orchestrate>
-      <div class="container">
-        <div class="section-header">
-          <div class="section-header__text" data-enter="left">
-            <p class="eyebrow">Bios</p>
-            <h2>Pick the Length That Fits</h2>
-            <p class="lead">Three ready-to-use bios. Hit copy and paste straight into your programme.</p>
-          </div>
-        </div>
-        <div class="bio-cards">
-          {bios.map((bio, i) => (
-            <article class="bio-card" style={`--i: ${i}`} data-enter="up">
-              <header class="bio-card__head">
-                <h3 class="bio-card__label">{bio.label}</h3>
-                <span class="bio-card__note">{bio.note}</span>
-                <button class="copy-btn" type="button" data-copy-target={`bio-${bio.id}`}>
-                  <span class="copy-btn__icon" aria-hidden="true">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-                      <rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h10"/>
-                    </svg>
-                  </span>
-                  <span class="copy-btn__label">Copy</span>
-                </button>
-              </header>
-              <div class="bio-card__text" id={`bio-${bio.id}`}>
-                {bio.paragraphs.map((para) => <p>{para}</p>)}
-              </div>
-            </article>
-          ))}
-        </div>
-      </div>
-    </section>
-
-    <!-- ─── Quick facts ───────────────────────────────────────────────────── -->
-    <section class="section section--alt" data-orchestrate>
-      <div class="container">
-        <div class="section-header">
-          <div class="section-header__text" data-enter="left">
-            <p class="eyebrow">Quick facts</p>
-            <h2>The Details for Your Schedule</h2>
-          </div>
-        </div>
-        <dl class="facts">
-          {facts.map((fact, i) => (
-            <div class="facts__row" style={`--i: ${i}`} data-enter="up">
-              <dt class="facts__label">{fact.label}</dt>
-              <dd class="facts__value">
-                <span id={`fact-${i}`}>{fact.value}</span>
-                <button class="copy-btn copy-btn--icon" type="button" data-copy-target={`fact-${i}`} aria-label={`Copy ${fact.label}`}>
-                  <span class="copy-btn__icon" aria-hidden="true">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-                      <rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h10"/>
-                    </svg>
-                  </span>
-                </button>
-              </dd>
-            </div>
-          ))}
-        </dl>
-      </div>
-    </section>
-
-    <!-- ─── Topics ────────────────────────────────────────────────────────── -->
-    <section class="section" data-orchestrate>
-      <div class="container">
-        <div class="section-header">
-          <div class="section-header__text" data-enter="left">
-            <p class="eyebrow">Topics</p>
-            <h2>What I Speak About</h2>
-          </div>
-        </div>
-        <ul class="topics" role="list" data-enter="up">
-          {topics.map((topic) => (
-            <li class="topics__tag">{topic}</li>
-          ))}
-        </ul>
-      </div>
-    </section>
-
-    <!-- ─── Socials ───────────────────────────────────────────────────────── -->
-    <section class="section section--alt" data-orchestrate>
-      <div class="container">
-        <div class="section-header">
-          <div class="section-header__text" data-enter="left">
-            <p class="eyebrow">Find me online</p>
-            <h2>Tag Me in Your Promo</h2>
-          </div>
-        </div>
-        <ul class="socials" role="list">
-          {socials.map((social, i) => (
-            <li style={`--i: ${i}`} data-enter="up">
-              <a href={social.href} target="_blank" rel="noopener noreferrer" class="socials__link">
-                <svg class="socials__icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                  <path d={social.icon} />
-                </svg>
-                <span class="socials__label">{social.label}</span>
-                <span class="socials__handle">{social.handle}</span>
-                <svg class="socials__arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                  <line x1="7" y1="17" x2="17" y2="7"/><polyline points="8 7 17 7 17 16"/>
-                </svg>
-              </a>
-            </li>
-          ))}
-        </ul>
       </div>
     </section>
   </main>
@@ -266,7 +218,6 @@ const personJsonLd = {
 </Layout>
 
 <script>
-  // ── Copy-to-clipboard (progressive enhancement) ──────────────────────────
   const supportsCopy = !!(navigator.clipboard && navigator.clipboard.writeText);
 
   document.querySelectorAll<HTMLButtonElement>('.copy-btn').forEach((btn) => {
@@ -283,7 +234,6 @@ const personJsonLd = {
     btn.addEventListener('click', async () => {
       const target = targetId ? document.getElementById(targetId) : null;
       if (!target) return;
-      // Preserve paragraph breaks when copying multi-paragraph bios.
       const paragraphs = target.querySelectorAll('p');
       const text = paragraphs.length
         ? [...paragraphs].map((p) => p.textContent?.trim() ?? '').filter(Boolean).join('\n\n')
@@ -293,323 +243,397 @@ const personJsonLd = {
       try {
         await navigator.clipboard.writeText(text);
         btn.classList.add('is-copied');
-        if (labelEl) labelEl.textContent = 'Copied!';
+        if (labelEl) labelEl.textContent = 'Copied';
         window.clearTimeout(resetTimer);
         resetTimer = window.setTimeout(() => {
           btn.classList.remove('is-copied');
           if (labelEl) labelEl.textContent = defaultLabel;
         }, 1800);
       } catch {
-        /* clipboard write blocked — text remains selectable */
+        /* clipboard write blocked; visible text remains selectable */
       }
     });
   });
-
-  // ── IntersectionObserver — orchestrated entrances (mirrors index.astro) ───
-  const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-  if (!reducedMotion) {
-    const io = new IntersectionObserver((entries) => {
-      entries.forEach((entry) => {
-        if (!entry.isIntersecting) return;
-        const section = entry.target;
-        section.querySelectorAll<HTMLElement>('[data-enter]').forEach((el, i) => {
-          const baseDelay = el.style.getPropertyValue('--i')
-            ? parseInt(el.style.getPropertyValue('--i')) * 60
-            : i * 80;
-          setTimeout(() => el.classList.add('is-visible'), baseDelay);
-        });
-        io.unobserve(section);
-      });
-    }, { rootMargin: '0px 0px -60px 0px', threshold: 0.1 });
-
-    document.querySelectorAll('[data-orchestrate]').forEach((el) => io.observe(el));
-  } else {
-    document.querySelectorAll<HTMLElement>('[data-enter]').forEach((el) => el.classList.add('is-visible'));
-  }
 </script>
 
 <style>
-  /* ─── Hero ─────────────────────────────────────────────────────────────── */
   .bio-hero {
+    padding-block: var(--space-10) var(--space-6);
+  }
+
+  .bio-hero__inner {
     display: grid;
-    grid-template-columns: 1fr;
     gap: var(--space-8);
-    align-items: center;
-    max-width: 1200px;
-    margin-inline: auto;
-    padding-inline: var(--space-6);
-    padding-block: var(--space-16);
-    border-bottom: 1px solid var(--border-subtle);
   }
 
-  @media (min-width: 760px) {
-    .bio-hero {
-      grid-template-columns: minmax(0, 620px) minmax(300px, 360px);
-      justify-content: space-between;
-      column-gap: var(--space-16);
-      padding-inline: var(--space-8);
-    }
+  .bio-hero__copy {
+    display: grid;
+    gap: var(--space-3);
+    align-content: center;
   }
 
-  .bio-hero__name {
-    font-size: clamp(2.5rem, 5vw + 1rem, 4.5rem);
-    font-style: italic;
-    line-height: 0.95;
-    letter-spacing: -0.04em;
-    color: var(--text-primary);
-    margin-top: var(--space-2);
+  .bio-hero h1 {
+    margin: 0;
+    font-size: clamp(2.35rem, 10vw, 4.5rem);
   }
 
   .bio-hero__handle {
-    margin-top: var(--space-3);
-    font-size: 1rem;
-    color: var(--text-tertiary);
-  }
-  .bio-hero__handle em {
-    font-style: italic;
+    margin: calc(-1 * var(--space-2)) 0 0;
     color: var(--color-accent);
-    font-family: var(--fonts-serif);
-    font-size: 1.15em;
-  }
-
-  .bio-hero__tagline {
-    margin-top: var(--space-6);
-    max-width: 44ch;
-    font-family: var(--fonts-serif);
-    font-style: italic;
-    font-size: clamp(1.125rem, 1.4vw + 0.6rem, 1.5rem);
-    line-height: 1.4;
-    color: var(--text-secondary);
-    text-wrap: balance;
+    font-size: clamp(1.35rem, 6vw, 2rem);
+    font-weight: 650;
+    line-height: 1.1;
   }
 
   .bio-hero__location {
     display: inline-flex;
     align-items: center;
     gap: var(--space-2);
-    margin-top: var(--space-6);
-    font-size: 0.9rem;
-    color: var(--text-tertiary);
+    margin: var(--space-2) 0 0;
+    color: var(--text-secondary);
+    font-size: 0.92rem;
   }
-  .bio-hero__location svg { width: 1.05em; height: 1.05em; color: var(--color-accent); }
 
-  .bio-hero__photo-fig {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-3);
+  .bio-hero__location svg {
+    width: 16px;
+    height: 16px;
+    color: var(--color-accent-cyan);
+  }
+
+  .bio-hero__tagline {
+    max-width: 42rem;
+    margin: var(--space-2) 0 0;
+    color: var(--text-secondary);
+    font-size: 1rem;
+  }
+
+  .portrait-card {
+    overflow: hidden;
+    width: min(100%, 360px);
     margin: 0;
-    max-width: 360px;
-    justify-self: end;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-xl);
+    background: var(--surface-raised);
+    box-shadow: var(--shadow-lg);
   }
 
-  .bio-hero__photo {
+  .portrait-card__photo {
+    display: block;
     width: 100%;
-    aspect-ratio: 4 / 5;
+    aspect-ratio: 4 / 3.35;
     object-fit: cover;
     object-position: top center;
-    border-radius: var(--radius-lg, 16px);
-    border: 1px solid var(--border-subtle);
-    filter: saturate(0.92) contrast(1.03);
+    filter: saturate(0.84) contrast(1.05) brightness(0.86);
   }
 
-  .bio-hero__download {
+  .portrait-card figcaption {
+    padding: var(--space-4);
+    border-top: 1px solid var(--border-subtle);
+    color: var(--text-secondary);
+    font-size: 0.88rem;
+  }
+
+  .portrait-card span {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .portrait-card i,
+  .status-dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--color-accent-success);
+  }
+
+  .bio-section {
+    padding-block: var(--space-5);
+  }
+
+  .bio-grid,
+  .bio-bottom {
+    display: grid;
+    gap: var(--space-4);
+  }
+
+  .bio-panel,
+  .download-card {
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-xl);
+    background: var(--surface-glass);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .bio-panel {
+    overflow: hidden;
+  }
+
+  .panel-head {
+    padding: var(--space-4);
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .panel-head p {
+    margin: 0;
+    color: var(--text-tertiary);
+    font-family: var(--fonts-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .facts {
+    display: grid;
+    margin: 0;
+  }
+
+  .facts__row {
+    display: grid;
+    gap: var(--space-2);
+    padding: var(--space-4);
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .facts__row:last-child {
+    border-bottom: 0;
+  }
+
+  .facts dt {
+    color: var(--text-tertiary);
+    font-family: var(--fonts-mono);
+    font-size: 0.72rem;
+  }
+
+  .facts dd {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    margin: 0;
+    color: var(--text-primary);
+    font-size: 0.92rem;
+  }
+
+  .facts dd span:not(.status-dot) {
+    min-width: 0;
+  }
+
+  .copy-btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     gap: var(--space-2);
-    padding: var(--space-2) var(--space-4);
-    border: 1px solid var(--border-default);
-    border-radius: 999px;
-    font-size: 0.85rem;
-    font-weight: 600;
+    min-height: 34px;
+    padding: 0.35rem 0.7rem;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    background: var(--surface-glass);
     color: var(--text-secondary);
-    text-decoration: none;
-    transition: color var(--dur-fast) var(--ease-out-expo),
-                border-color var(--dur-fast) var(--ease-out-expo),
-                background var(--dur-fast) var(--ease-out-expo);
-  }
-  .bio-hero__download svg { width: 1.05em; height: 1.05em; }
-  .bio-hero__download:hover {
-    color: var(--text-primary);
-    border-color: var(--text-primary);
-    background: var(--surface-2);
-  }
-
-  /* ─── Shared section scaffolding (matches index.astro) ──────────────────── */
-  .section { padding-block: var(--space-16); }
-  .section--alt {
-    background: var(--surface-2);
-    border-top: 1px solid var(--border-subtle);
-    border-bottom: 1px solid var(--border-subtle);
-  }
-
-  .section-header { margin-bottom: var(--space-12); }
-
-  .eyebrow {
-    font-size: 0.75rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--color-accent);
-    margin-bottom: var(--space-2);
-  }
-  .lead { margin-top: var(--space-3); font-size: 1.0625rem; max-width: 55ch; color: var(--text-secondary); }
-
-  /* ─── Copy button ───────────────────────────────────────────────────────── */
-  .copy-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-2);
-    padding: var(--space-1) var(--space-3);
-    border: 1px solid var(--border-default);
-    border-radius: 999px;
-    background: transparent;
     font-family: var(--fonts-sans);
-    font-size: 0.78rem;
-    font-weight: 600;
-    color: var(--text-secondary);
+    font-size: 0.82rem;
+    font-weight: 650;
     cursor: pointer;
-    transition: color var(--dur-fast) var(--ease-out-expo),
-                border-color var(--dur-fast) var(--ease-out-expo),
-                background var(--dur-fast) var(--ease-out-expo);
+    transition:
+      color var(--dur-fast) var(--ease-out-expo),
+      border-color var(--dur-fast) var(--ease-out-expo),
+      background var(--dur-fast) var(--ease-out-expo);
   }
-  .copy-btn:hover {
-    color: var(--text-primary);
-    border-color: var(--text-primary);
-  }
-  .copy-btn.is-copied {
-    color: var(--color-accent);
-    border-color: var(--color-accent);
-  }
-  .copy-btn__icon svg { width: 0.95rem; height: 0.95rem; display: block; }
-  .copy-btn--icon { padding: var(--space-1); border-color: var(--border-subtle); }
 
-  /* ─── Bio cards ─────────────────────────────────────────────────────────── */
-  .bio-cards { display: grid; gap: var(--space-6); }
+  .copy-btn:hover,
+  .copy-btn.is-copied {
+    color: var(--text-primary);
+    border-color: var(--border-default);
+    background: var(--surface-raised);
+  }
+
+  .copy-btn svg {
+    width: 15px;
+    height: 15px;
+  }
+
+  .copy-btn--icon {
+    width: 32px;
+    min-height: 32px;
+    padding: 0;
+    margin-left: auto;
+  }
+
+  .bio-cards {
+    display: grid;
+  }
 
   .bio-card {
-    padding: var(--space-6);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg, 16px);
-    background: var(--surface-2);
-  }
-
-  .bio-card__head {
-    display: flex;
-    align-items: center;
-    gap: var(--space-3);
-    margin-bottom: var(--space-4);
-  }
-  .bio-card__label {
-    font-family: var(--fonts-serif);
-    font-style: italic;
-    font-size: 1.25rem;
-    color: var(--text-primary);
-  }
-  .bio-card__note {
-    font-size: 0.72rem;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--text-tertiary);
-    margin-right: auto;
-  }
-  .bio-card__text {
-    font-family: var(--fonts-serif);
-    font-size: 1.0625rem;
-    line-height: 1.7;
-    color: var(--text-secondary);
-    max-width: 70ch;
-  }
-  .bio-card__text p + p { margin-top: var(--space-4); }
-
-  /* ─── Quick facts ───────────────────────────────────────────────────────── */
-  .facts { display: grid; gap: 0; max-width: 760px; }
-  .facts__row {
     display: grid;
-    grid-template-columns: 1fr;
-    gap: var(--space-1);
-    padding-block: var(--space-4);
+    gap: var(--space-3);
+    padding: var(--space-4);
     border-bottom: 1px solid var(--border-subtle);
   }
-  .facts__row:first-child { border-top: 1px solid var(--border-subtle); }
 
-  @media (min-width: 600px) {
-    .facts__row { grid-template-columns: 200px 1fr; gap: var(--space-6); align-items: baseline; }
+  .bio-card:last-child {
+    border-bottom: 0;
   }
 
-  .facts__label {
-    font-size: 0.72rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--text-tertiary);
-  }
-  .facts__value {
-    display: flex;
+  .bio-card header {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto;
     align-items: center;
     gap: var(--space-3);
+  }
+
+  .bio-card h2 {
     margin: 0;
     font-size: 1rem;
-    color: var(--text-primary);
   }
-  .facts__value span { min-width: 0; }
 
-  /* ─── Topics ────────────────────────────────────────────────────────────── */
-  .topics { display: flex; flex-wrap: wrap; gap: var(--space-3); list-style: none; }
-  .topics__tag {
-    padding: var(--space-2) var(--space-4);
-    border: 1px solid var(--border-default);
-    border-radius: 999px;
-    font-size: 0.9rem;
-    font-weight: 500;
+  .bio-card header > span {
+    color: var(--text-tertiary);
+    font-family: var(--fonts-mono);
+    font-size: 0.72rem;
+  }
+
+  .bio-card__text {
+    display: grid;
+    gap: var(--space-3);
+  }
+
+  .bio-card__text p {
+    margin: 0;
     color: var(--text-secondary);
-    background: var(--surface-1);
+    font-size: 0.92rem;
+    line-height: 1.65;
   }
 
-  /* ─── Socials ───────────────────────────────────────────────────────────── */
-  .socials {
+  .topics {
     display: flex;
     flex-wrap: wrap;
-    gap: var(--space-4);
+    gap: var(--space-2);
+    margin: 0;
+    padding: var(--space-4);
     list-style: none;
   }
-  .socials__link {
-    display: flex;
-    align-items: center;
-    gap: var(--space-3);
-    padding: var(--space-4) var(--space-6);
+
+  .topics li {
+    padding: 0.38rem 0.58rem;
     border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-lg, 16px);
-    background: var(--surface-1);
-    text-decoration: none;
-    transition: border-color var(--dur-fast) var(--ease-out-expo),
-                transform var(--dur-fast) var(--ease-out-expo);
-  }
-  .socials__link:hover { border-color: var(--color-accent); transform: translateY(-2px); }
-  .socials__icon {
-    width: 1.15rem;
-    height: 1.15rem;
-    flex-shrink: 0;
+    border-radius: var(--radius-sm);
     color: var(--text-secondary);
-    transition: color var(--dur-fast) var(--ease-out-expo);
+    font-size: 0.82rem;
   }
-  .socials__link:hover .socials__icon { color: var(--color-accent); }
-  .socials__label { font-weight: 600; color: var(--text-primary); }
-  .socials__handle { color: var(--text-tertiary); font-size: 0.9rem; margin-right: auto; }
-  .socials__arrow { width: 1rem; height: 1rem; color: var(--text-tertiary); flex-shrink: 0; }
-  .socials__link:hover .socials__arrow { color: var(--color-accent); }
 
-  /* ─── Entrance animations (shared pattern) ──────────────────────────────── */
-  [data-enter] {
-    opacity: 0;
-    transition: opacity 0.6s var(--ease-out-expo) calc(var(--i, 0) * 60ms),
-                transform 0.6s var(--ease-out-expo) calc(var(--i, 0) * 60ms);
+  .socials {
+    display: grid;
+    margin: 0;
+    padding: 0;
+    list-style: none;
   }
-  [data-enter="left"] { transform: translateX(-24px); }
-  [data-enter="up"]   { transform: translateY(22px); }
-  [data-enter].is-visible { opacity: 1; transform: none; }
 
-  @media (prefers-reduced-motion: reduce) {
-    [data-enter] { opacity: 1 !important; transform: none !important; transition: none !important; }
+  .socials a {
+    display: grid;
+    grid-template-columns: 5rem minmax(0, 1fr) auto;
+    gap: var(--space-3);
+    align-items: center;
+    padding: var(--space-4);
+    border-bottom: 1px solid var(--border-subtle);
+    color: var(--text-primary);
+    text-decoration: none;
+  }
+
+  .socials li:last-child a {
+    border-bottom: 0;
+  }
+
+  .socials a:hover {
+    background: var(--surface-raised);
+    text-decoration: none;
+  }
+
+  .socials span {
+    color: var(--text-tertiary);
+    font-family: var(--fonts-mono);
+    font-size: 0.72rem;
+  }
+
+  .socials strong {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: var(--text-primary);
+    font-size: 0.9rem;
+    white-space: nowrap;
+  }
+
+  .socials svg {
+    width: 16px;
+    height: 16px;
+    color: var(--text-secondary);
+  }
+
+  .download-card {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: var(--space-2) var(--space-4);
+    align-items: center;
+    padding: var(--space-4);
+    color: var(--text-primary);
+    text-decoration: none;
+  }
+
+  .download-card:hover {
+    border-color: var(--border-default);
+    background: var(--surface-raised);
+    text-decoration: none;
+  }
+
+  .download-card span {
+    color: var(--text-tertiary);
+    font-family: var(--fonts-mono);
+    font-size: 0.72rem;
+    text-transform: uppercase;
+  }
+
+  .download-card strong {
+    grid-column: 1;
+    font-size: 0.95rem;
+  }
+
+  .download-card svg {
+    grid-row: 1 / span 2;
+    grid-column: 2;
+    width: 20px;
+    height: 20px;
+    color: var(--color-accent);
+  }
+
+  @media (min-width: 760px) {
+    .bio-hero {
+      padding-block: var(--space-12) var(--space-8);
+    }
+
+    .bio-hero__inner {
+      grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
+      align-items: center;
+      gap: var(--space-12);
+    }
+
+    .portrait-card {
+      justify-self: end;
+    }
+
+    .bio-grid {
+      grid-template-columns: minmax(280px, 0.8fr) minmax(0, 1.2fr);
+    }
+
+    .facts__row {
+      grid-template-columns: 9rem minmax(0, 1fr);
+      align-items: center;
+    }
+
+    .bio-bottom {
+      grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.2fr);
+    }
+
+    .download-card {
+      grid-column: 1 / -1;
+    }
   }
 </style>

--- a/websites/rawkode.dev/src/pages/biography.astro
+++ b/websites/rawkode.dev/src/pages/biography.astro
@@ -114,7 +114,7 @@ const personJsonLd = {
             class="portrait-card__photo"
             loading="eager"
             widths={[360, 540, 720]}
-            sizes="(max-width: 899px) 48vw, 360px"
+            sizes="(max-width: 759px) 100vw, (max-width: 899px) 40vw, 360px"
           />
           <figcaption>
             <span><i aria-hidden="true"></i> Available for speaking</span>
@@ -127,7 +127,7 @@ const personJsonLd = {
       <div class="container bio-grid">
         <div class="bio-panel">
           <header class="panel-head">
-            <p>Quick facts</p>
+            <h2>Quick facts</h2>
           </header>
           <dl class="facts">
             {facts.map((fact) => (
@@ -149,7 +149,7 @@ const personJsonLd = {
 
         <div class="bio-panel bio-panel--bios">
           <header class="panel-head">
-            <p>Biography</p>
+            <h2>Biography</h2>
           </header>
           <div class="bio-cards">
             {bios.map((bio) => (
@@ -178,7 +178,7 @@ const personJsonLd = {
       <div class="container bio-bottom">
         <div class="bio-panel">
           <header class="panel-head">
-            <p>Topics</p>
+            <h2>Topics</h2>
           </header>
           <ul class="topics" role="list">
             {topics.map((topic) => <li>{topic}</li>)}
@@ -187,7 +187,7 @@ const personJsonLd = {
 
         <div class="bio-panel">
           <header class="panel-head">
-            <p>Connect</p>
+            <h2>Connect</h2>
           </header>
           <ul class="socials" role="list">
             {socials.map((social) => (
@@ -375,7 +375,7 @@ const personJsonLd = {
     border-bottom: 1px solid var(--border-subtle);
   }
 
-  .panel-head p {
+  .panel-head h2 {
     margin: 0;
     color: var(--text-tertiary);
     font-family: var(--fonts-mono);

--- a/websites/rawkode.dev/src/pages/index.astro
+++ b/websites/rawkode.dev/src/pages/index.astro
@@ -1,738 +1,487 @@
 ---
 export const prerender = true;
 
-// Direction C — Kinetic Type + Orchestrated Entrances
-// Magnetic hero name (pointer-only), @property animated Academy CTA,
-// word-level entrance choreography, dramatic asymmetric Academy section.
 import { Image } from 'astro:assets';
 import rawkodePhoto from '../assets/rawkode.jpg';
 import Layout from '../layouts/Layout.astro';
 import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
 import AppCard from '../components/AppCard.astro';
-import BlueskyPostCard from '../components/BlueskyPostCard.astro';
-import { getBlueskyPosts } from '../lib/bluesky';
 import { getCollection } from 'astro:content';
 
-const bskyPosts = await getBlueskyPosts(4);
 const allPosts = await getCollection('blog', ({ data }) => !data.draft);
 const recentPosts = allPosts
   .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
   .slice(0, 3);
+const appOrder = ['rawkode-academy', 'cuenv', 'kubectl-ditto', 'kree', 'prescience', 'waddle'];
 const apps = (await getCollection('apps')).sort((a, b) => {
   if (a.data.featured !== b.data.featured) return a.data.featured ? -1 : 1;
+  const ai = appOrder.indexOf(a.id);
+  const bi = appOrder.indexOf(b.id);
+  if (ai !== -1 || bi !== -1) return (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi);
   return a.data.name.localeCompare(b.data.name);
 });
-function formatDate(date: Date) {
-  return date.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
+
+function formatShortDate(date: Date) {
+  return date.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' });
+}
+
+function readMinutes(body = '') {
+  const words = body.trim().split(/\s+/).filter(Boolean).length;
+  return Math.max(1, Math.round(words / 220));
 }
 ---
 
 <Layout>
   <Nav />
   <main id="main-content">
-
-    <!-- ─── Hero ──────────────────────────────────────────────────────────── -->
     <section class="hero">
-      <div class="hero__text-col">
-        <div class="hero__content">
-          <div class="hero__id">
-            <!-- data-magnetic: JS will split into letter spans -->
-            <h1 class="hero__name" data-magnetic>David<br />Flanagan</h1>
-            <p class="hero__handle">aka <em>rawkode</em></p>
-          </div>
-          <p class="hero__roles" data-split-words>Developer Tooling · Open Source · Education</p>
-          <p class="hero__lead" data-split-words>
-            I build developer tooling for cloud-native infrastructure, maintain open-source projects,
-            and teach engineers the practical systems work behind it through Rawkode Academy.
+      <div class="container hero__inner">
+        <div class="hero__copy">
+          <h1>David Flanagan</h1>
+          <p class="hero__handle">rawkode</p>
+          <p class="hero__lead">
+            Developer tooling for cloud-native infrastructure, open source, and Rawkode Academy.
           </p>
           <div class="hero__actions">
-            <a href="#apps" class="btn btn--solid">
-              <span class="btn__label">See my <em>work</em></span>
-              <svg class="btn__arrow btn__arrow--down" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                <line x1="12" y1="5" x2="12" y2="19"/>
-                <polyline points="19 12 12 19 5 12"/>
+            <a href="#apps" class="button button--primary">
+              See the work
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M5 12h14M13 5l7 7-7 7"/>
               </svg>
             </a>
-            <a href="/read" class="btn btn--outline">
-              <span class="btn__label">Read <em>writing</em></span>
-              <svg class="btn__arrow btn__arrow--right" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                <line x1="5" y1="12" x2="19" y2="12"/>
-                <polyline points="12 5 19 12 12 19"/>
-              </svg>
-            </a>
-            <a href="https://rawkode.academy" target="_blank" rel="noopener noreferrer" class="btn btn--text">
-              <span class="btn__label">Rawkode <em>Academy</em></span>
-              <svg class="btn__arrow btn__arrow--ne" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                <line x1="7" y1="17" x2="17" y2="7"/>
-                <polyline points="8 7 17 7 17 16"/>
+            <a href="/read" class="button button--secondary">
+              Read writing
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M5 12h14M13 5l7 7-7 7"/>
               </svg>
             </a>
           </div>
         </div>
-      </div>
 
-      <div class="hero__photo-col">
-        <Image
-          src={rawkodePhoto}
-          alt="David Flanagan"
-          class="hero__photo"
-          loading="eager"
-          widths={[480, 720, 1080]}
-          sizes="(max-width: 899px) 100vw, 50vw"
-        />
-        <div class="hero__photo-fade" aria-hidden="true"></div>
-      </div>
-    </section>
-
-    <!-- ─── Apps ──────────────────────────────────────────────────────────── -->
-    <section class="section" id="apps" data-orchestrate>
-      <div class="container">
-        <div class="section-header">
-          <div class="section-header__text" data-enter="left">
-            <p class="eyebrow">Apps</p>
-            <h2>Things I've built</h2>
-            <p class="lead">Open-source tools and experiments for infrastructure work I keep meeting in the real world.</p>
-          </div>
-        </div>
-        <ul class="apps-grid" role="list">
-          {apps.map((entry, i) => (
-            <li style={`--i: ${i}`} data-enter="up" class:list={[{ 'apps-grid__featured': entry.data.featured }]}>
-              <AppCard app={entry.data} />
-            </li>
-          ))}
-        </ul>
+        <figure class="hero-card">
+          <Image
+            src={rawkodePhoto}
+            alt="David Flanagan"
+            class="hero-card__photo"
+            loading="eager"
+            widths={[360, 540, 720]}
+            sizes="(max-width: 760px) 44vw, 320px"
+          />
+          <figcaption class="hero-card__meta">
+            <span><i aria-hidden="true"></i> Glasgow, Scotland</span>
+            <span>Principal Developer</span>
+          </figcaption>
+        </figure>
       </div>
     </section>
 
-    <!-- ─── Bluesky ────────────────────────────────────────────────────────── -->
-    {bskyPosts.length > 0 && (
-      <section class="section section--alt" data-orchestrate>
-        <div class="container">
-          <div class="section-header">
-            <div class="section-header__text" data-enter="left">
-              <p class="eyebrow">From Bluesky</p>
-              <h2>What I'm thinking about</h2>
-            </div>
-            <a href="https://bsky.app/profile/rawkode.dev" target="_blank" rel="noopener noreferrer" class="link-more" data-enter="right">
-              Follow on Bluesky →
-            </a>
+    <section class="section" id="apps">
+      <div class="container section__grid">
+        <header class="section__header">
+          <div>
+            <p class="section__kicker">Work</p>
+            <h2>Work</h2>
+            <p class="section__desc">Tools, systems, and teaching.</p>
           </div>
-          <ul class="bsky-grid" role="list">
-            {bskyPosts.map((post, i) => (
-              <li style={`--i: ${i}`} data-enter="up"><BlueskyPostCard post={post} /></li>
+          <a href="https://github.com/rawkode" target="_blank" rel="noopener noreferrer" class="section__link">View all apps</a>
+        </header>
+        <div class="panel">
+          <ul class="app-list" role="list">
+            {apps.map((entry) => (
+              <li><AppCard app={entry.data} /></li>
             ))}
           </ul>
+        </div>
+      </div>
+    </section>
+
+    {recentPosts.length > 0 && (
+      <section class="section">
+        <div class="container writing-layout">
+          <header class="section__header">
+            <div>
+              <p class="section__kicker">Current thinking</p>
+              <h2>Writing that survives the thread.</h2>
+            </div>
+            <a href="/read" class="section__link">Read all</a>
+          </header>
+          <ol class="writing-list" role="list">
+            {recentPosts.map((post) => (
+              <li>
+                <a href={`/read/${post.id}`} class="writing-row">
+                  <time datetime={post.data.pubDate.toISOString()}>{formatShortDate(post.data.pubDate)}</time>
+                  <span class="writing-row__dot" aria-hidden="true"></span>
+                  <span class="writing-row__content">
+                    <strong>{post.data.title}</strong>
+                    <span>{readMinutes(post.body)} min read</span>
+                  </span>
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M5 12h14M13 5l7 7-7 7"/>
+                  </svg>
+                </a>
+              </li>
+            ))}
+          </ol>
         </div>
       </section>
     )}
 
-    <!-- ─── Academy CTA — dramatic full-bleed ────────────────────────────── -->
-    <section class="academy-cta" data-orchestrate>
-      <div class="academy-cta__bg" aria-hidden="true"></div>
+    <section class="section">
       <div class="container">
-        <div class="academy-cta__inner">
-          <p class="eyebrow eyebrow--light" data-enter="left">Rawkode Academy</p>
-          <h2 class="academy-cta__heading" data-enter="left">
-            Go deeper.<br /><em>Learn in the open.</em>
-          </h2>
-          <p class="academy-cta__body" data-enter="left">
-            Free courses, real-world projects, and community material on Kubernetes,
-            platform engineering, and developer tooling, built around the tradeoffs
-            teams hit in production.
-          </p>
-          <a href="https://rawkode.academy" target="_blank" rel="noopener noreferrer" class="btn btn--light" data-enter="left">
-            Visit Rawkode Academy →
+        <div class="academy-panel">
+          <div class="academy-panel__mark" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round">
+              <path d="m12 3 9 5-9 5-9-5 9-5Z"/><path d="m5 10 7 4 7-4v5l-7 4-7-4v-5Z"/>
+            </svg>
+          </div>
+          <div>
+            <p class="section__kicker">Rawkode Academy</p>
+            <h2>Go deeper.</h2>
+            <p>
+              Practical courses, real-world projects, and a community for engineers building
+              infrastructure and developer platforms.
+            </p>
+          </div>
+          <a href="https://rawkode.academy" target="_blank" rel="noopener noreferrer" class="button button--secondary">
+            Explore Academy
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M5 12h14M13 5l7 7-7 7"/>
+            </svg>
           </a>
         </div>
       </div>
     </section>
-
-    <!-- ─── Blog ──────────────────────────────────────────────────────────── -->
-    {recentPosts.length > 0 && (
-      <section class="section" data-orchestrate>
-        <div class="container">
-          <div class="section-header">
-            <div class="section-header__text" data-enter="left">
-              <p class="eyebrow">Writing</p>
-              <h2>Longer thoughts</h2>
-              <p class="lead">Notes that need more room than a post or thread.</p>
-            </div>
-            <a href="/read" class="link-more" data-enter="right">All posts →</a>
-          </div>
-          <ul class="blog-list" role="list">
-            {recentPosts.map((post, i) => (
-              <li
-                style={`--i: ${i}`}
-                data-enter={i % 2 === 0 ? 'left' : 'right'}
-              >
-                <a href={`/read/${post.id}`} class="blog-list__link">
-                  <div class="blog-list__content">
-                    <h3 class="blog-list__title">{post.data.title}</h3>
-                    <p class="blog-list__desc">{post.data.description}</p>
-                  </div>
-                  <time datetime={post.data.pubDate.toISOString()} class="blog-list__date">
-                    {formatDate(post.data.pubDate)}
-                  </time>
-                </a>
-              </li>
-            ))}
-          </ul>
-        </div>
-      </section>
-    )}
   </main>
   <Footer />
 </Layout>
 
-<script>
-  const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-
-  // ── Magnetic letters on hero name ─────────────────────────────────────────
-  const nameEl = document.querySelector<HTMLElement>('[data-magnetic]');
-  if (nameEl && !reducedMotion) {
-    // Split text into spans per letter, preserving line breaks
-    const lines = nameEl.innerText.split('\n');
-    nameEl.innerHTML = '';
-    const letterSpans: HTMLElement[] = [];
-
-    lines.forEach((line, li) => {
-      if (li > 0) nameEl.appendChild(document.createElement('br'));
-      for (const ch of line) {
-        if (ch === ' ') { nameEl.appendChild(document.createTextNode('\u00a0')); continue; }
-        const span = document.createElement('span');
-        span.textContent = ch;
-        span.className = 'mag-letter';
-        span.style.display = 'inline-block';
-        span.style.transition = 'transform 0.35s cubic-bezier(0.16,1,0.3,1)';
-        nameEl.appendChild(span);
-        letterSpans.push(span);
-      }
-    });
-
-    // Magnetic force on mousemove
-    let ticking = false;
-    document.addEventListener('mousemove', (e) => {
-      if (ticking) return;
-      ticking = true;
-      requestAnimationFrame(() => {
-        letterSpans.forEach(span => {
-          const rect = span.getBoundingClientRect();
-          const cx = rect.left + rect.width / 2;
-          const cy = rect.top + rect.height / 2;
-          const dx = e.clientX - cx;
-          const dy = e.clientY - cy;
-          const dist = Math.hypot(dx, dy);
-          const radius = 160;
-
-          if (dist < radius) {
-            const force = (1 - dist / radius) ** 1.5 * 20;
-            const angle = Math.atan2(dy, dx);
-            span.style.transform = `translate(${Math.cos(angle) * force}px, ${Math.sin(angle) * force}px)`;
-          } else {
-            span.style.transform = '';
-          }
-        });
-        ticking = false;
-      });
-    }, { passive: true });
-
-    // Reset on pointer leave
-    document.addEventListener('mouseleave', () => {
-      letterSpans.forEach(span => { span.style.transform = ''; });
-    });
-  }
-
-  // ── Word splitting for role/lead ──────────────────────────────────────────
-  document.querySelectorAll<HTMLElement>('[data-split-words]').forEach(el => {
-    const text = el.innerText;
-    el.innerHTML = text.split(' ').map((word, i) =>
-      `<span class="word" style="--wi:${i}" data-word>${word}</span>`
-    ).join(' ');
-  });
-
-  // ── IntersectionObserver — orchestrated entrances ─────────────────────────
-  if (!reducedMotion) {
-    const io = new IntersectionObserver((entries) => {
-      entries.forEach(entry => {
-        if (!entry.isIntersecting) return;
-        const section = entry.target;
-
-        // Stagger [data-enter] elements within this section
-        const els = section.querySelectorAll<HTMLElement>('[data-enter]');
-        els.forEach((el, i) => {
-          const baseDelay = el.hasAttribute('style')
-            ? parseInt(el.style.getPropertyValue('--i') || '0') * 60
-            : i * 80;
-          setTimeout(() => el.classList.add('is-visible'), baseDelay);
-        });
-
-        // Also trigger word spans
-        section.querySelectorAll<HTMLElement>('[data-word]').forEach(word => {
-          const wi = parseInt(word.style.getPropertyValue('--wi') || '0');
-          setTimeout(() => word.classList.add('is-visible'), wi * 25);
-        });
-
-        io.unobserve(section);
-      });
-    }, { rootMargin: '0px 0px -60px 0px', threshold: 0.1 });
-
-    document.querySelectorAll('[data-orchestrate]').forEach(el => io.observe(el));
-  } else {
-    // No-motion: make everything visible immediately
-    document.querySelectorAll<HTMLElement>('[data-enter], [data-word]').forEach(el => {
-      el.classList.add('is-visible');
-    });
-  }
-</script>
-
 <style>
-  /* ─── Hero ─────────────────────────────────────────────────────────────── */
   .hero {
+    padding-block: var(--space-10) var(--space-8);
+  }
+
+  .hero__inner {
     display: grid;
-    grid-template-columns: 1fr;
-    min-height: 580px;
-    border-bottom: 1px solid var(--border-subtle);
-    overflow: hidden;
+    grid-template-columns: minmax(0, 1fr) minmax(128px, 38vw);
+    align-items: start;
+    gap: var(--space-4);
   }
 
-  @media (min-width: 900px) {
-    .hero { grid-template-columns: 1fr 1fr; }
+  .hero__copy {
+    display: grid;
+    gap: var(--space-4);
+    align-content: center;
   }
 
-  .hero__text-col {
-    display: flex;
-    align-items: center;
-    padding-block: var(--space-16);
-    padding-right: var(--space-8);
-    padding-left: max(var(--space-8), calc((100vw - 1200px) / 2 + var(--space-8)));
-  }
-
-  @media (max-width: 899px) {
-    .hero__text-col {
-      padding-inline: var(--space-6);
-      padding-block: var(--space-12);
-      order: 2;
-    }
-  }
-
-  .hero__content { max-width: 520px; width: 100%; }
-  .hero__id { margin-bottom: var(--space-5); }
-
-  .hero__name {
-    font-size: clamp(3rem, 5vw + 1rem, 6rem);
-    font-style: italic;
-    line-height: 0.92;
-    letter-spacing: -0.04em;
-    color: var(--text-primary);
-    cursor: default;
-    user-select: none;
+  .hero h1 {
+    margin: 0;
+    font-size: clamp(2.45rem, 12vw, 4.8rem);
+    font-weight: 680;
+    letter-spacing: 0;
   }
 
   .hero__handle {
-    margin-top: var(--space-3);
-    font-size: 1rem;
-    color: var(--text-tertiary);
-    line-height: 1;
-  }
-
-  .hero__handle em {
-    font-style: italic;
+    margin: calc(-1 * var(--space-3)) 0 0;
     color: var(--color-accent);
-    font-family: 'Newsreader Variable', 'Newsreader', Georgia, serif;
-    font-size: 1.1em;
-  }
-
-  .hero__roles {
-    font-size: 0.78rem;
-    font-weight: 700;
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-    color: var(--text-tertiary);
-    margin-bottom: var(--space-5);
-    overflow: hidden;
+    font-size: clamp(1.4rem, 6vw, 2rem);
+    font-weight: 650;
+    line-height: 1.1;
   }
 
   .hero__lead {
-    font-size: clamp(1rem, 1.1vw + 0.6rem, 1.125rem);
-    line-height: 1.75;
-    color: var(--text-secondary);
-    max-width: 48ch;
-    margin-bottom: var(--space-8);
-    overflow: hidden;
+    max-width: 34rem;
+    margin: 0;
+    color: var(--text-primary);
+    font-size: clamp(1rem, 2.5vw, 1.18rem);
+    line-height: 1.65;
   }
 
   .hero__actions {
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-column: 1 / -1;
     gap: var(--space-3);
+    margin-top: var(--space-2);
   }
 
-  .hero__photo-col {
-    position: relative;
-    overflow: hidden;
-    background: var(--surface-2);
-  }
-
-  @media (max-width: 899px) {
-    .hero__photo-col { min-height: 280px; order: 1; }
-  }
-
-  .hero__photo {
-    position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    object-position: top center;
-    display: block;
-    filter: saturate(0.88) contrast(1.04);
-  }
-
-  .hero__photo-fade {
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(
-      to right,
-      var(--surface-1) 0%,
-      color-mix(in oklch, var(--surface-1) 40%, transparent) 18%,
-      transparent 40%
-    );
-    pointer-events: none;
-  }
-
-  /* ─── Magnetic letters ──────────────────────────────────────────────────── */
-  /* .mag-letter transition is set via JS to avoid layout cost at parse time */
-
-  /* ─── Word splitting + entrance ─────────────────────────────────────────── */
-  [data-word] {
-    display: inline-block;
-    opacity: 0;
-    transform: translateY(10px);
-    transition:
-      opacity 0.4s var(--ease-out-expo) calc(var(--wi, 0) * 20ms),
-      transform 0.4s var(--ease-out-expo) calc(var(--wi, 0) * 20ms);
-  }
-  [data-word].is-visible {
-    opacity: 1;
-    transform: translateY(0);
-  }
-
-  /* ─── Orchestrated enter animations ─────────────────────────────────────── */
-  [data-enter] {
-    opacity: 0;
-    transition: opacity 0.65s var(--ease-out-expo) calc(var(--i, 0) * 60ms),
-                transform 0.65s var(--ease-out-expo) calc(var(--i, 0) * 60ms);
-  }
-  [data-enter="left"]  { transform: translateX(-24px); }
-  [data-enter="right"] { transform: translateX(24px); }
-  [data-enter="up"]    { transform: translateY(22px); }
-
-  [data-enter].is-visible {
-    opacity: 1;
-    transform: none;
-  }
-
-  /* ─── Shared section styles ─────────────────────────────────────────────── */
-  .section { padding-block: var(--space-24); }
-  .section--alt {
-    background: var(--surface-2);
-    border-top: 1px solid var(--border-subtle);
-    border-bottom: 1px solid var(--border-subtle);
-  }
-
-  .section-header {
-    display: flex;
-    align-items: flex-end;
-    justify-content: space-between;
-    gap: var(--space-6);
-    margin-bottom: var(--space-12);
-    flex-wrap: wrap;
-  }
-
-  .eyebrow {
-    font-size: 0.75rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--color-accent);
-    margin-bottom: var(--space-2);
-  }
-
-  .eyebrow--light { color: oklch(75% 0.16 250); }
-
-  .lead { margin-top: var(--space-3); font-size: 1.0625rem; max-width: 55ch; }
-
-  .link-more {
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--text-secondary);
-    text-decoration: none;
-    white-space: nowrap;
-    transition: color var(--dur-fast) var(--ease-out-expo);
-    flex-shrink: 0;
-    margin-bottom: var(--space-1);
-  }
-  .link-more:hover { color: var(--color-accent); }
-
-  /* ─── Buttons ───────────────────────────────────────────────────────────── */
-  .btn {
-    --btn-arrow-shift: 4px;
-    position: relative;
+  .button {
     display: inline-flex;
     align-items: center;
-    gap: 0.625rem;
-    padding: 0.78rem 1.4rem;
-    border: 1px solid transparent;
-    border-radius: 999px;
-    font-family: var(--fonts-sans);
-    font-size: 0.9375rem;
-    font-weight: 600;
-    letter-spacing: -0.005em;
+    justify-content: center;
+    gap: var(--space-3);
+    min-height: 48px;
+    padding: 0.78rem 1rem;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    color: var(--text-primary);
+    font-weight: 650;
     text-decoration: none;
-    white-space: nowrap;
-    cursor: pointer;
-    isolation: isolate;
     transition:
-      background-color 0.35s var(--ease-out-expo),
-      color 0.35s var(--ease-out-expo),
-      border-color 0.35s var(--ease-out-expo),
-      transform 0.35s var(--ease-out-expo),
-      box-shadow 0.35s var(--ease-out-expo);
+      transform var(--dur-fast) var(--ease-out-expo),
+      border-color var(--dur-fast) var(--ease-out-expo),
+      background var(--dur-fast) var(--ease-out-expo);
   }
 
-  .btn__label { display: inline-flex; align-items: baseline; gap: 0.25em; }
-  .btn__label em {
-    font-family: var(--fonts-serif);
-    font-style: italic;
-    font-weight: 500;
-    letter-spacing: -0.012em;
+  .button svg {
+    width: 17px;
+    height: 17px;
   }
 
-  .btn__arrow {
-    width: 1em;
-    height: 1em;
-    flex-shrink: 0;
-    transition: transform 0.45s var(--ease-out-expo);
-    will-change: transform;
-  }
-
-  /* Solid — filled primary (desaturated against the accent) */
-  .btn--solid {
-    background: color-mix(in oklch, var(--color-accent) 75%, oklch(22% 0.03 250));
-    color: oklch(98% 0.01 250);
-    box-shadow:
-      inset 0 1px 0 oklch(100% 0 0 / 0.10),
-      inset 0 -1px 0 oklch(0% 0 0 / 0.18),
-      0 1px 2px oklch(0% 0 0 / 0.10);
-  }
-  .btn--solid:hover {
-    background: color-mix(in oklch, var(--color-accent) 88%, oklch(28% 0.03 250));
+  .button:hover {
     transform: translateY(-1px);
-    box-shadow:
-      inset 0 1px 0 oklch(100% 0 0 / 0.15),
-      0 10px 28px color-mix(in oklch, var(--color-accent) 22%, transparent);
-  }
-  .btn--solid:active { transform: translateY(0); }
-  .btn--solid:hover .btn__arrow--down { transform: translateY(var(--btn-arrow-shift)); }
-
-  /* Outline — bordered, inverts on hover */
-  .btn--outline {
-    background: transparent;
-    color: var(--text-primary);
-    border-color: var(--border-default);
-  }
-  .btn--outline:hover {
-    background: var(--text-primary);
-    color: var(--surface-1);
-    border-color: var(--text-primary);
-    transform: translateY(-1px);
-  }
-  .btn--outline:hover .btn__arrow--right { transform: translateX(var(--btn-arrow-shift)); }
-  .btn--outline:hover .btn__arrow--ne {
-    transform: translate(var(--btn-arrow-shift), calc(-1 * var(--btn-arrow-shift)));
+    text-decoration: none;
   }
 
-  /* Text — minimal, persistent half-line that fills on hover */
-  .btn--text {
-    padding-inline: 0.25rem;
-    border-radius: 0;
-    background: transparent;
-    color: var(--text-primary);
-  }
-  .btn--text::after {
-    content: '';
-    position: absolute;
-    left: 0.25rem;
-    right: 0.25rem;
-    bottom: 0.42rem;
-    height: 1px;
-    background: currentColor;
-    transform: scaleX(0.5);
-    transform-origin: left center;
-    opacity: 0.35;
-    transition:
-      transform 0.5s var(--ease-out-expo),
-      opacity 0.5s var(--ease-out-expo);
-  }
-  .btn--text:hover::after {
-    transform: scaleX(1);
-    opacity: 0.9;
-  }
-  .btn--text:hover .btn__arrow--ne {
-    transform: translate(var(--btn-arrow-shift), calc(-1 * var(--btn-arrow-shift)));
-  }
-  .btn--text:hover .btn__arrow--right { transform: translateX(var(--btn-arrow-shift)); }
-
-  /* Light — kept for Academy CTA section */
-  .btn--light {
-    background: oklch(98% 0.01 250);
-    color: oklch(16% 0.02 250);
+  .button--primary {
     border-color: transparent;
-  }
-  .btn--light:hover {
-    background: #fff;
-    transform: translateY(-1px);
-    box-shadow: 0 8px 28px oklch(0% 0 0 / 0.22);
+    background: linear-gradient(135deg, var(--color-accent), color-mix(in oklch, var(--color-accent-cyan) 74%, var(--color-accent)));
+    color: oklch(16% 0.03 292);
+    box-shadow: 0 14px 36px color-mix(in oklch, var(--color-accent) 24%, transparent);
   }
 
-  /* ─── Apps grid ─────────────────────────────────────────────────────────── */
-  .apps-grid {
+  .button--secondary {
+    background: var(--surface-glass);
+  }
+
+  .button--secondary:hover {
+    border-color: var(--border-strong);
+    background: var(--surface-raised);
+  }
+
+  .hero-card {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
-    gap: var(--space-6);
-    list-style: none;
-  }
-  .apps-grid__featured { grid-column: 1 / -1; }
-
-  /* ─── Bluesky grid ──────────────────────────────────────────────────────── */
-  .bsky-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-    gap: var(--space-4);
-    list-style: none;
-  }
-
-  /* ─── Academy CTA — dramatic full-bleed ─────────────────────────────────── */
-  @property --cta-hue {
-    syntax: '<angle>';
-    initial-value: 0deg;
-    inherits: false;
-  }
-
-  .academy-cta {
-    position: relative;
-    padding-block: clamp(var(--space-24), 12vw, 10rem);
     overflow: hidden;
-    isolation: isolate;
-  }
-
-  .academy-cta__bg {
-    position: absolute;
-    inset: 0;
-    z-index: -1;
-    --cta-hue: 0deg;
-    background:
-      radial-gradient(ellipse 70% 80% at 20% 50%,
-        oklch(20% 0.12 250 / 0.9),
-        transparent 65%),
-      conic-gradient(
-        from var(--cta-hue) at 80% 50%,
-        oklch(11% 0.012 250),
-        oklch(17% 0.09 250),
-        oklch(13% 0.05 250),
-        oklch(11% 0.012 250)
-      );
-    animation: cta-spin 18s linear infinite;
-  }
-
-  @keyframes cta-spin {
-    to { --cta-hue: 360deg; }
-  }
-
-  .academy-cta__inner {
-    max-width: 680px;
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-6);
-  }
-
-  .academy-cta__heading {
-    font-size: clamp(2.5rem, 6vw, 5rem);
-    font-style: italic;
-    color: oklch(97% 0.01 250);
-    line-height: 1.05;
-  }
-
-  .academy-cta__heading em {
-    color: oklch(75% 0.20 250);
-    font-style: italic;
-  }
-
-  .academy-cta__body {
-    max-width: 52ch;
-    font-size: 1.0625rem;
-    color: oklch(80% 0.04 250);
-    line-height: 1.75;
-  }
-
-  /* ─── Blog list — editorial / folio treatment ─────────────────────────── */
-  .blog-list { list-style: none; display: flex; flex-direction: column; }
-
-  .blog-list li:first-child .blog-list__link { border-top: 1px solid var(--border-subtle); }
-  .blog-list__link {
-    display: grid;
-    grid-template-columns: 1fr auto;
-    align-items: baseline;
-    column-gap: var(--space-8);
-    padding-block: var(--space-6);
-    text-decoration: none;
-    border-bottom: 1px solid var(--border-subtle);
-    transition: background var(--dur-fast) var(--ease-out-expo);
-  }
-  .blog-list__link:hover { background: var(--surface-2); }
-  .blog-list__link:hover .blog-list__title { color: var(--color-accent); }
-
-  .blog-list__content { min-width: 0; }
-  .blog-list__title {
-    font-family: var(--fonts-serif);
-    font-style: italic;
-    font-weight: 500;
-    font-size: clamp(1.25rem, 1.8vw, 1.6rem);
-    line-height: 1.15;
-    letter-spacing: -0.015em;
-    color: var(--text-primary);
-    transition: color var(--dur-fast) var(--ease-out-expo);
-    margin-bottom: var(--space-2);
-    text-wrap: balance;
-  }
-  .blog-list__desc {
-    font-family: var(--fonts-serif);
-    font-size: 1rem;
-    line-height: 1.5;
-    color: var(--text-secondary);
+    width: 100%;
     margin: 0;
-    max-width: 60ch;
-  }
-  .blog-list__date {
-    font-family: var(--fonts-sans);
-    font-size: 0.7rem;
-    letter-spacing: 0.22em;
-    text-transform: uppercase;
-    color: var(--text-secondary);
-    white-space: nowrap;
-    flex-shrink: 0;
-    font-variant-numeric: tabular-nums;
-    padding-top: 0.4em;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-xl);
+    background: var(--surface-raised);
+    box-shadow: var(--shadow-lg);
   }
 
-  /* ─── Reduced motion ────────────────────────────────────────────────────── */
-  @media (prefers-reduced-motion: reduce) {
-    .academy-cta__bg { animation: none; }
-    [data-enter], [data-word] {
-      opacity: 1 !important;
-      transform: none !important;
-      transition: none !important;
+  .hero-card__photo {
+    display: block;
+    width: 100%;
+    aspect-ratio: 4 / 3.35;
+    object-fit: cover;
+    object-position: top center;
+    filter: saturate(0.72) contrast(1.08) brightness(0.7);
+  }
+
+  .hero-card__meta {
+    display: grid;
+    gap: var(--space-2);
+    padding: var(--space-4);
+    border-top: 1px solid var(--border-subtle);
+    color: var(--text-secondary);
+    font-size: 0.86rem;
+  }
+
+  .hero-card__meta span {
+    min-width: 0;
+  }
+
+  .hero-card__meta span {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .hero-card__meta i {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--color-accent-success);
+  }
+
+  .section {
+    padding-block: var(--space-8);
+  }
+
+  .section__grid,
+  .writing-layout {
+    display: grid;
+    gap: var(--space-5);
+  }
+
+  .section__header {
+    display: flex;
+    align-items: end;
+    justify-content: space-between;
+    gap: var(--space-4);
+  }
+
+  .section__header h2,
+  .academy-panel h2 {
+    margin: var(--space-1) 0 0;
+    font-size: clamp(1.5rem, 6vw, 2.25rem);
+  }
+
+  .section__desc {
+    margin: var(--space-2) 0 0;
+    color: var(--text-secondary);
+    font-size: 0.92rem;
+  }
+
+  .section__kicker {
+    margin: 0;
+    color: var(--color-accent-gold);
+    font-family: var(--fonts-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .section__link {
+    color: var(--text-secondary);
+    font-size: 0.86rem;
+    font-weight: 650;
+    text-decoration: none;
+    white-space: nowrap;
+  }
+
+  .section__link::after {
+    content: " →";
+    color: var(--color-accent);
+  }
+
+  .panel {
+    padding: var(--space-2);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-xl);
+    background: color-mix(in oklch, var(--surface-glass) 88%, transparent);
+    box-shadow: var(--shadow-md);
+  }
+
+  .app-list,
+  .writing-list {
+    display: grid;
+    gap: var(--space-2);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .writing-row {
+    display: grid;
+    grid-template-columns: auto auto minmax(0, 1fr) auto;
+    gap: var(--space-3);
+    align-items: center;
+    min-height: 74px;
+    padding: var(--space-4);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    background: var(--surface-glass);
+    color: var(--text-primary);
+    text-decoration: none;
+  }
+
+  .writing-row:hover {
+    border-color: var(--border-default);
+    background: var(--surface-raised);
+    text-decoration: none;
+  }
+
+  .writing-row time,
+  .writing-row__content span {
+    color: var(--text-tertiary);
+    font-family: var(--fonts-mono);
+    font-size: 0.72rem;
+  }
+
+  .writing-row__dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--color-accent);
+  }
+
+  .writing-row__content {
+    display: grid;
+    gap: var(--space-1);
+    min-width: 0;
+  }
+
+  .writing-row__content strong {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: var(--text-primary);
+    font-size: 0.95rem;
+    line-height: 1.35;
+  }
+
+  .writing-row svg {
+    width: 18px;
+    height: 18px;
+    color: var(--text-secondary);
+  }
+
+  .academy-panel {
+    display: grid;
+    gap: var(--space-5);
+    padding: var(--space-5);
+    border: 1px solid color-mix(in oklch, var(--color-accent) 32%, var(--border-default));
+    border-radius: var(--radius-xl);
+    background:
+      radial-gradient(circle at 12% 20%, color-mix(in oklch, var(--color-accent) 18%, transparent), transparent 18rem),
+      linear-gradient(135deg, color-mix(in oklch, var(--surface-3) 88%, transparent), var(--surface-glass));
+    box-shadow: var(--shadow-md);
+  }
+
+  .academy-panel__mark {
+    display: grid;
+    place-items: center;
+    width: 60px;
+    aspect-ratio: 1;
+    border-radius: var(--radius-full);
+    background: color-mix(in oklch, var(--color-accent) 18%, var(--surface-3));
+    color: var(--color-accent);
+  }
+
+  .academy-panel__mark svg {
+    width: 28px;
+    height: 28px;
+  }
+
+  .academy-panel p:not(.section__kicker) {
+    max-width: 46rem;
+    margin: var(--space-3) 0 0;
+  }
+
+  @media (min-width: 560px) {
+    .hero__actions {
+      grid-column: auto;
+      grid-template-columns: repeat(2, minmax(0, 180px));
+    }
+  }
+
+  @media (min-width: 860px) {
+    .hero {
+      padding-block: var(--space-16) var(--space-10);
+    }
+
+    .hero__inner {
+      grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
+      align-items: center;
+      gap: var(--space-12);
+    }
+
+    .hero__actions {
+      grid-column: auto;
+    }
+
+    .hero-card {
+      justify-self: end;
+    }
+
+    .writing-layout {
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    .academy-panel {
+      grid-template-columns: auto minmax(0, 1fr) auto;
+      align-items: center;
+      padding: var(--space-8);
     }
   }
 </style>

--- a/websites/rawkode.dev/src/pages/index.astro
+++ b/websites/rawkode.dev/src/pages/index.astro
@@ -7,6 +7,7 @@ import Layout from '../layouts/Layout.astro';
 import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
 import AppCard from '../components/AppCard.astro';
+import { calculateReadingMinutes } from '../utils/readingTime';
 import { getCollection } from 'astro:content';
 
 const allPosts = await getCollection('blog', ({ data }) => !data.draft);
@@ -26,10 +27,6 @@ function formatShortDate(date: Date) {
   return date.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' });
 }
 
-function readMinutes(body = '') {
-  const words = body.trim().split(/\s+/).filter(Boolean).length;
-  return Math.max(1, Math.round(words / 220));
-}
 ---
 
 <Layout>
@@ -114,7 +111,7 @@ function readMinutes(body = '') {
                   <span class="writing-row__dot" aria-hidden="true"></span>
                   <span class="writing-row__content">
                     <strong>{post.data.title}</strong>
-                    <span>{readMinutes(post.body)} min read</span>
+                    <span>{calculateReadingMinutes(post.body)} min read</span>
                   </span>
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                     <path d="M5 12h14M13 5l7 7-7 7"/>

--- a/websites/rawkode.dev/src/pages/read/[slug].astro
+++ b/websites/rawkode.dev/src/pages/read/[slug].astro
@@ -20,15 +20,14 @@ const { Content } = await render(post);
 const allPosts = await getCollection('blog', ({ data }) => !data.draft);
 const chronological = allPosts.sort((a, b) => a.data.pubDate.valueOf() - b.data.pubDate.valueOf());
 const total = chronological.length;
-const index = chronological.findIndex((p) => p.id === post.id) + 1;
+const index = chronological.findIndex((p) => p.id === post.id);
+const previous = index > 0 ? chronological[index - 1] : null;
+const next = index < total - 1 ? chronological[index + 1] : null;
 
 function formatDate(date: Date) {
-  return date.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
+  return date.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' });
 }
 
-const pad = (n: number) => String(n).padStart(2, '0');
-
-// Best-effort reading time from raw body length (markdown loader exposes body)
 const wordCount = (post.body ?? '').trim().split(/\s+/).filter(Boolean).length;
 const readMinutes = Math.max(1, Math.round(wordCount / 220));
 const siteUrl = new URL('/', Astro.site ?? 'https://rawkode.dev');
@@ -72,54 +71,74 @@ const articleJsonLd = {
   <Nav />
 
   <main id="main-content">
-    <article class="post">
-      <div class="post__container">
-        <p class="post__folio">№ {pad(index)} <span class="post__folio-of">of</span> {pad(total)}</p>
+    <article class="article">
+      <div class="container article__layout">
+        <div class="article__main">
+          <a href="/read" class="back-link" aria-label="Back to all essays">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M19 12H5M11 5l-7 7 7 7"/>
+            </svg>
+            All essays
+          </a>
 
-        <header class="post__header">
-          <a href="/read" class="post__back">← All writing</a>
-          <h1 class="post__title">{post.data.title}</h1>
-          <p class="post__deck">{post.data.description}</p>
-          <p class="post__byline">
-            <strong>David Flanagan</strong>
-            <span class="post__byline-sep">·</span>
-            <time datetime={post.data.pubDate.toISOString()}>{formatDate(post.data.pubDate)}</time>
-            {post.data.tags.length > 0 && (
-              <>
-                <span class="post__byline-sep">·</span>
-                <span class="post__byline-filed">Filed under {post.data.tags.join(' · ')}</span>
-              </>
+          <header class="article__header">
+            <h1>{post.data.title}</h1>
+            <p class="article__deck">{post.data.description}</p>
+            <div class="article__byline">
+              <span class="article__avatar" aria-hidden="true">DF</span>
+              <span>David Flanagan</span>
+              <time datetime={post.data.pubDate.toISOString()}>{formatDate(post.data.pubDate)}</time>
+              <span>{readMinutes} min read</span>
+            </div>
+          </header>
+
+          <div class="article__meta-strip">
+            <span>Essay</span>
+            <span><strong>{wordCount.toLocaleString('en-GB')}</strong> words</span>
+            <span>Updated <time datetime={modifiedTime}>{formatDate(new Date(modifiedTime))}</time></span>
+          </div>
+
+          {post.data.tags.length > 0 && (
+            <ul class="article__tags" role="list" aria-label="Tags">
+              {post.data.tags.map((tag: string) => <li>{tag}</li>)}
+            </ul>
+          )}
+
+          <div class="prose">
+            <Content />
+          </div>
+
+          <footer class="article__footer">
+            {previous && (
+              <a href={`/read/${previous.id}`} class="article__pager">
+                <span>Previous</span>
+                <strong>{previous.data.title}</strong>
+              </a>
             )}
-          </p>
-        </header>
-
-        <div class="post__meta-strip">
-          <span>Essay · <strong>{readMinutes} min read</strong></span>
-          <span><strong>{wordCount.toLocaleString('en-GB')}</strong> words</span>
-          <time datetime={post.data.pubDate.toISOString()}>{formatDate(post.data.pubDate)}</time>
+            {next && (
+              <a href={`/read/${next.id}`} class="article__pager article__pager--next">
+                <span>Next</span>
+                <strong>{next.data.title}</strong>
+              </a>
+            )}
+          </footer>
         </div>
 
-        <div class="post__body prose">
-          <Content />
-        </div>
-
-        <footer class="post__footer">
-          <p class="post__tags-line">
-            {post.data.tags.length > 0 && (
-              <>
-                <span class="post__tags-label">Filed under</span>
-                {post.data.tags.map((tag: string, i: number) => (
-                  <>
-                    {i > 0 && <span class="post__tags-sep">·</span>}
-                    <span class="post__tag">{tag}</span>
-                  </>
-                ))}
-              </>
-            )}
-          </p>
-          <p class="post__signoff" aria-hidden="true">❦</p>
-          <a href="/read" class="post__more">More writing →</a>
-        </footer>
+        <aside class="article__aside" aria-label="Article context">
+          <div class="aside-card">
+            <p class="aside-card__label">Article</p>
+            <p>{readMinutes} min read</p>
+            <p>{wordCount.toLocaleString('en-GB')} words</p>
+          </div>
+          {post.data.tags.length > 0 && (
+            <div class="aside-card">
+              <p class="aside-card__label">Tags</p>
+              <ul role="list">
+                {post.data.tags.map((tag: string) => <li>{tag}</li>)}
+              </ul>
+            </div>
+          )}
+        </aside>
       </div>
     </article>
   </main>
@@ -128,489 +147,354 @@ const articleJsonLd = {
 </Layout>
 
 <style>
-  /* ─── Article container ────────────────────────────────────────────── */
-  .post {
-    padding-block: var(--space-12) var(--space-24);
+  .article {
+    padding-block: var(--space-8) var(--space-16);
   }
 
-  .post__container {
-    width: 100%;
-    max-width: 1180px;
-    margin-inline: auto;
-    padding-inline: var(--space-6);
+  .article__layout {
+    display: grid;
+    gap: var(--space-8);
   }
 
-  @media (min-width: 768px) {
-    .post__container { padding-inline: var(--space-8); }
-  }
-
-  /* ─── Folio eyebrow (issue/date band above title) ──────────────────── */
-  .post__folio {
-    text-align: center;
-    margin-bottom: var(--space-12);
-    font-family: var(--fonts-sans);
-    font-size: 0.72rem;
-    letter-spacing: 0.28em;
-    text-transform: uppercase;
-    color: var(--text-secondary);
-    font-variant-numeric: tabular-nums lining-nums;
-  }
-  .post__folio-of {
-    color: var(--text-tertiary);
-    margin: 0 0.25em;
-  }
-  .post__folio::before,
-  .post__folio::after {
-    content: "";
-    display: inline-block;
-    width: 2rem;
-    height: 1px;
-    background: var(--border-subtle);
-    vertical-align: middle;
-    margin: 0 var(--space-4);
-  }
-
-  /* ─── Article header — centered, editorial ─────────────────────────── */
-  .post__header {
-    text-align: center;
-    max-width: 56rem;
-    margin: 0 auto var(--space-12);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+  .article__main {
+    min-width: 0;
+    display: grid;
     gap: var(--space-6);
   }
 
-  .post__back {
-    font-family: var(--fonts-sans);
-    font-size: 0.72rem;
-    letter-spacing: 0.18em;
-    text-transform: uppercase;
+  .back-link {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    width: fit-content;
     color: var(--text-tertiary);
+    font-size: 0.88rem;
+    font-weight: 650;
     text-decoration: none;
-    transition: color var(--dur-fast) var(--ease-out-expo);
   }
-  .post__back:hover { color: var(--color-accent); }
 
-  .post__title {
-    font-family: var(--fonts-serif);
-    font-style: italic;
-    font-weight: 500;
-    font-size: clamp(2.4rem, 6vw, 4.8rem);
-    line-height: 1;
-    letter-spacing: -0.025em;
+  .back-link:hover {
     color: var(--text-primary);
-    margin: 0;
-    text-wrap: balance;
+    text-decoration: none;
   }
 
-  .post__deck {
-    font-family: var(--fonts-serif);
-    font-style: normal;
-    font-weight: 400;
-    font-size: clamp(1.125rem, 1.6vw, 1.375rem);
-    line-height: 1.45;
-    color: var(--text-secondary);
-    max-width: 52ch;
-    text-wrap: balance;
-    margin: 0;
+  .back-link svg {
+    width: 16px;
+    height: 16px;
   }
 
-  .post__byline {
-    font-family: var(--fonts-sans);
-    font-size: 0.72rem;
-    letter-spacing: 0.22em;
-    text-transform: uppercase;
-    color: var(--text-tertiary);
-    margin: 0;
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: var(--space-3);
-  }
-  .post__byline strong {
-    color: var(--text-primary);
-    font-weight: 600;
-  }
-  .post__byline-sep { color: var(--color-accent); }
-  .post__byline time { font-variant-numeric: tabular-nums; }
-
-  /* ─── Meta strip (reading time band) ────────────────────────────────── */
-  .post__meta-strip {
-    max-width: 64ch;
-    margin: 0 auto var(--space-12);
-    padding: var(--space-3) 0;
-    border-top: 1px solid var(--border-subtle);
-    border-bottom: 1px solid var(--border-subtle);
-    display: flex;
-    justify-content: space-between;
-    flex-wrap: wrap;
+  .article__header {
+    display: grid;
     gap: var(--space-4);
-    font-family: var(--fonts-sans);
-    font-size: 0.7rem;
-    letter-spacing: 0.18em;
-    text-transform: uppercase;
+    max-width: 780px;
+  }
+
+  .article__header h1 {
+    margin: 0;
+    font-size: clamp(2rem, 8vw, 4rem);
+  }
+
+  .article__deck {
+    max-width: 58ch;
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: clamp(1rem, 3vw, 1.18rem);
+  }
+
+  .article__byline {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-2) var(--space-3);
     color: var(--text-tertiary);
-  }
-  .post__meta-strip strong {
-    color: var(--text-primary);
-    font-weight: 600;
+    font-size: 0.86rem;
   }
 
-  /* ─── Prose body — Newsreader serif, with marginalia column ─────────── */
-  .prose {
-    max-width: 64ch;
-    margin: 0 auto;
-    font-family: var(--fonts-serif);
-    font-size: 1.15rem;
-    line-height: 1.78;
-    color: var(--text-primary);
-    font-feature-settings: 'kern' 1, 'liga' 1, 'onum' 1;
-
-    /* Rough hand-drawn underline (baked accent per scheme) */
-    --rough-underline: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 6' preserveAspectRatio='none'><path d='M0 3 Q 12 0 25 3 T 50 3 T 75 3 T 100 3' stroke='%23b4637a' stroke-width='1.5' fill='none' stroke-linecap='round'/></svg>");
+  .article__byline > :not(:first-child)::before {
+    content: "·";
+    margin-right: var(--space-3);
+    color: var(--border-strong);
   }
 
-  @media (prefers-color-scheme: dark) {
-    :root:not([data-theme=light]) .prose {
-      --rough-underline: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 6' preserveAspectRatio='none'><path d='M0 3 Q 12 0 25 3 T 50 3 T 75 3 T 100 3' stroke='%23e78284' stroke-width='1.5' fill='none' stroke-linecap='round'/></svg>");
-    }
-  }
-  [data-theme=dark] .prose {
-    --rough-underline: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 6' preserveAspectRatio='none'><path d='M0 3 Q 12 0 25 3 T 50 3 T 75 3 T 100 3' stroke='%23e78284' stroke-width='1.5' fill='none' stroke-linecap='round'/></svg>");
-  }
-
-  /* Paragraphs */
-  .prose :global(p) {
-    margin-top: var(--space-6);
-    color: var(--text-primary);
-    line-height: 1.78;
-  }
-  .prose :global(p:first-of-type) { margin-top: 0; }
-
-  /* Drop cap — first paragraph only */
-  .prose :global(> p:first-of-type::first-letter) {
-    font-family: var(--fonts-serif);
-    font-style: italic;
-    font-weight: 500;
+  .article__avatar {
+    display: inline-grid;
+    place-items: center;
+    width: 30px;
+    height: 30px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 50%;
+    background: var(--surface-raised);
     color: var(--color-accent);
-    float: left;
-    font-size: 5.2em;
-    line-height: 0.82;
-    padding: 0.08em 0.08em 0 0;
-    margin-right: 0.05em;
+    font-family: var(--fonts-mono);
+    font-size: 0.72rem;
+    font-weight: 700;
   }
 
-  /* Headings */
-  .prose :global(h2) {
-    font-family: var(--fonts-serif);
-    font-style: italic;
-    font-weight: 500;
-    font-size: clamp(1.5rem, 2.2vw, 1.95rem);
-    line-height: 1.15;
-    letter-spacing: -0.015em;
-    color: var(--text-primary);
-    margin-top: var(--space-16);
-    margin-bottom: var(--space-3);
+  .article__meta-strip {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-3);
+    width: fit-content;
+    max-width: 100%;
+    padding: var(--space-2);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    background: var(--surface-glass);
+    color: var(--text-tertiary);
+    font-family: var(--fonts-mono);
+    font-size: 0.72rem;
   }
-  .prose :global(h2::before) {
-    content: "";
-    display: block;
-    width: 2.5rem;
-    height: 1px;
-    background: var(--color-accent);
-    margin-bottom: var(--space-3);
-    opacity: 0.7;
+
+  .article__meta-strip span {
+    padding: 0.35rem 0.55rem;
+    border-radius: var(--radius-md);
+  }
+
+  .article__meta-strip span:first-child {
+    background: var(--color-accent-soft);
+    color: var(--text-primary);
+  }
+
+  .article__tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .article__tags li,
+  .aside-card li {
+    padding: 0.24rem 0.5rem;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
+    color: var(--text-tertiary);
+    font-family: var(--fonts-mono);
+    font-size: 0.7rem;
+  }
+
+  .prose {
+    max-width: 70ch;
+    color: var(--text-primary);
+    font-size: clamp(1rem, 2.5vw, 1.08rem);
+    line-height: 1.76;
+  }
+
+  .prose :global(*) {
+    max-width: 100%;
+  }
+
+  .prose :global(p) {
+    margin: var(--space-5) 0 0;
+    color: var(--text-primary);
+    line-height: 1.76;
+  }
+
+  .prose :global(p:first-child) {
+    margin-top: 0;
+  }
+
+  .prose :global(h2) {
+    margin: var(--space-12) 0 var(--space-3);
+    font-size: clamp(1.45rem, 4vw, 2rem);
   }
 
   .prose :global(h3) {
-    font-family: var(--fonts-serif);
-    font-style: italic;
-    font-weight: 500;
-    font-size: 1.35rem;
-    line-height: 1.2;
-    color: var(--text-primary);
-    margin-top: var(--space-12);
-    margin-bottom: var(--space-2);
+    margin: var(--space-8) 0 var(--space-2);
+    font-size: 1.2rem;
   }
 
-  /* Lists — em-dash markers in accent for ul, italic decimals for ol */
-  .prose :global(ul) {
-    list-style: none;
-    padding-left: 0;
-    margin-top: var(--space-4);
-  }
-  .prose :global(ul > li) {
-    position: relative;
-    padding-left: var(--space-6);
-    margin-top: var(--space-2);
-    line-height: 1.55;
-    color: var(--text-primary);
-  }
-  .prose :global(ul > li::before) {
-    content: "—";
-    position: absolute;
-    left: 0;
-    top: 0;
-    color: var(--color-accent);
-    font-weight: 500;
-  }
-
+  .prose :global(ul),
   .prose :global(ol) {
-    list-style: decimal;
+    margin: var(--space-4) 0 0;
     padding-left: var(--space-6);
-    margin-top: var(--space-4);
     color: var(--text-primary);
   }
-  .prose :global(ol > li) {
+
+  .prose :global(li) {
     margin-top: var(--space-2);
-    line-height: 1.55;
-    padding-left: var(--space-2);
+    line-height: 1.62;
   }
-  .prose :global(ol > li::marker) {
+
+  .prose :global(li::marker) {
     color: var(--color-accent);
-    font-family: var(--fonts-serif);
-    font-style: italic;
-    font-weight: 500;
   }
 
-  /* Nested lists tighten further */
-  .prose :global(li > ul),
-  .prose :global(li > ol) {
-    margin-top: var(--space-2);
-  }
-
-  /* Links — rough hand-drawn underline */
   .prose :global(a) {
-    color: var(--text-primary);
-    text-decoration: none;
-    background-image: var(--rough-underline);
-    background-repeat: repeat-x;
-    background-position: 0 100%;
-    background-size: 80px 4px;
-    padding-bottom: 3px;
-    transition: color var(--dur-fast) var(--ease-out-expo), background-size var(--dur-fast) var(--ease-out-expo);
-  }
-  .prose :global(a:hover) {
-    color: var(--color-accent);
-    background-size: 60px 5px;
+    color: var(--color-accent-hover);
+    text-decoration-color: color-mix(in oklch, currentColor 38%, transparent);
   }
 
-  /* Emphasis */
-  .prose :global(strong) { font-weight: 600; color: var(--text-primary); }
-  .prose :global(em) { font-style: italic; }
-
-  /* Inline code — small, restrained, mono */
-  .prose :global(code) {
-    font-family: var(--fonts-mono);
-    font-size: 0.84em;
-    background: var(--surface-2);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    padding: 0.08em 0.4em;
-    color: var(--color-accent);
-    font-feature-settings: normal;
-  }
-
-  /* Blockquote → pull quote (column-breaking, italic, accent guillemets) */
   .prose :global(blockquote) {
-    margin: var(--space-12) auto;
-    max-width: 32ch;
-    padding: var(--space-4) 0;
-    text-align: center;
-    font-family: var(--fonts-serif);
-    font-style: italic;
-    font-weight: 400;
-    font-size: clamp(1.5rem, 2.6vw, 2.1rem);
-    line-height: 1.25;
+    margin: var(--space-8) 0;
+    padding: var(--space-4);
+    border: 1px solid var(--border-subtle);
+    border-left: 3px solid var(--color-accent);
+    border-radius: var(--radius-lg);
+    background: var(--surface-glass);
     color: var(--text-primary);
-    position: relative;
-    border: 0;
   }
-  .prose :global(blockquote::before),
-  .prose :global(blockquote::after) {
-    color: var(--color-accent);
-    font-style: normal;
-    font-size: 2.4rem;
-    line-height: 1;
-    position: absolute;
-  }
-  .prose :global(blockquote::before) {
-    content: "«";
-    left: -1.4rem;
-    top: -0.2rem;
-  }
-  .prose :global(blockquote::after) {
-    content: "»";
-    right: -1.4rem;
-    bottom: -0.6rem;
-  }
+
   .prose :global(blockquote p) {
     margin: 0;
-    line-height: inherit;
     color: inherit;
   }
 
-  /* Horizontal rule → fleuron */
   .prose :global(hr) {
+    height: 1px;
+    margin: var(--space-10) 0;
     border: 0;
-    text-align: center;
-    height: var(--space-12);
-    position: relative;
-    margin: var(--space-12) 0;
-  }
-  .prose :global(hr::after) {
-    content: "❦";
-    color: var(--color-accent);
-    font-size: 1.4rem;
-    letter-spacing: 1rem;
-    padding-left: 1rem;
-    line-height: var(--space-12);
+    background: var(--border-subtle);
   }
 
-  /* Code blocks — keep expressive-code intact, just spacing/border */
   .prose :global(.expressive-code) {
     margin-block: var(--space-8);
   }
 
-  /* Plain <pre> fallback (rare; expressive-code handles most) */
+  .prose :global(.expressive-code .frame) {
+    border-color: var(--border-subtle);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-md);
+  }
+
   .prose :global(> pre) {
-    background: var(--surface-2);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-md);
-    padding: var(--space-6);
     overflow-x: auto;
     margin-block: var(--space-8);
-    font-family: var(--fonts-mono);
-    font-size: 0.875rem;
-    line-height: 1.65;
-  }
-  .prose :global(> pre code) {
-    background: none;
-    border: none;
-    padding: 0;
-    font-size: inherit;
+    padding: var(--space-5);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    background: color-mix(in oklch, var(--surface-2) 86%, black);
     color: var(--text-primary);
+    font-family: var(--fonts-mono);
+    font-size: 0.88rem;
+    line-height: 1.7;
+    box-shadow: var(--shadow-md);
   }
 
-  /* ─── Sidenote — short annotation, inline, accent rule ─────────────── */
-  .prose :global(aside.sidenote) {
-    font-family: var(--fonts-sans);
-    font-size: 0.9rem;
-    line-height: 1.55;
-    color: var(--text-secondary);
-    margin: var(--space-6) 0;
-    padding-left: var(--space-4);
-    border-left: 2px solid var(--color-accent);
+  .prose :global(> pre code) {
+    padding: 0;
+    border: 0;
+    background: none;
+    color: inherit;
+    font-size: inherit;
   }
 
-  /* ─── Marginalia — inline term definition or aside ─────────────────── */
+  .prose :global(aside.sidenote),
   .prose :global(aside.marginalia) {
-    font-family: var(--fonts-sans);
-    font-size: 0.9rem;
-    line-height: 1.55;
-    color: var(--text-secondary);
     margin: var(--space-6) 0;
-    padding: var(--space-3) var(--space-4);
-    background: var(--surface-2);
-    border-left: 2px solid var(--color-accent);
-    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
-  }
-  .prose :global(aside.marginalia::before) {
-    content: "✎ ";
-    color: var(--color-accent);
-    font-family: var(--fonts-serif);
-    font-style: italic;
-  }
-  .prose :global(aside.marginalia strong) { color: var(--text-primary); }
-
-  /* Inline reference mark (e.g. <sup>*</sup>) */
-  .prose :global(sup) {
-    font-family: var(--fonts-serif);
-    font-style: italic;
-    color: var(--color-accent);
-    font-size: 0.65em;
-    vertical-align: super;
-    margin-left: 1px;
+    padding: var(--space-4);
+    border: 1px solid var(--border-subtle);
+    border-left: 3px solid var(--color-accent);
+    border-radius: var(--radius-lg);
+    background: var(--surface-glass);
+    color: var(--text-secondary);
+    font-size: 0.92rem;
+    line-height: 1.58;
   }
 
-  /* ─── Markdown footnotes (remark-gfm) ──────────────────────────────── */
   .prose :global(.footnotes) {
-    margin-top: var(--space-16);
+    margin-top: var(--space-12);
     padding-top: var(--space-6);
     border-top: 1px solid var(--border-subtle);
-    font-size: 0.95rem;
-  }
-  .prose :global(.footnotes h2),
-  .prose :global(.footnotes .sr-only) {
-    font-family: var(--fonts-sans);
-    font-style: normal;
-    font-size: 0.7rem;
-    letter-spacing: 0.22em;
-    text-transform: uppercase;
-    color: var(--text-tertiary);
-    margin: 0 0 var(--space-3);
-  }
-  .prose :global(.footnotes h2::before) { display: none; }
-  .prose :global(.footnotes ol) {
-    padding-left: var(--space-5);
     color: var(--text-secondary);
-    font-family: var(--fonts-serif);
-    font-size: 0.95rem;
-    line-height: 1.65;
-  }
-  .prose :global(.footnotes ol li::marker) { color: var(--color-accent); }
-  .prose :global(.data-footnote-backref) {
-    background: none;
-    padding: 0;
-    margin-left: 0.3em;
-    color: var(--color-accent);
+    font-size: 0.92rem;
   }
 
-  /* ─── Article footer ───────────────────────────────────────────────── */
-  .post__footer {
-    max-width: 64ch;
-    margin: var(--space-16) auto 0;
-    text-align: center;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: var(--space-6);
+  .article__footer {
+    display: grid;
+    gap: var(--space-3);
+    max-width: 70ch;
+    margin-top: var(--space-4);
   }
 
-  .post__tags-line {
-    font-family: var(--fonts-sans);
-    font-size: 0.72rem;
-    letter-spacing: 0.22em;
-    text-transform: uppercase;
+  .article__pager {
+    display: grid;
+    gap: var(--space-2);
+    padding: var(--space-4);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    background: var(--surface-glass);
+    color: var(--text-primary);
+    text-decoration: none;
+  }
+
+  .article__pager:hover {
+    border-color: var(--border-default);
+    background: var(--surface-raised);
+    text-decoration: none;
+  }
+
+  .article__pager span {
     color: var(--text-tertiary);
+    font-family: var(--fonts-mono);
+    font-size: 0.72rem;
+    text-transform: uppercase;
+  }
+
+  .article__pager strong {
+    font-size: 0.95rem;
+    line-height: 1.35;
+  }
+
+  .article__aside {
+    display: none;
+  }
+
+  .aside-card {
+    display: grid;
+    gap: var(--space-3);
+    padding: var(--space-4);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    background: var(--surface-glass);
+  }
+
+  .aside-card p {
     margin: 0;
+    color: var(--text-tertiary);
+    font-family: var(--fonts-mono);
+    font-size: 0.75rem;
+  }
+
+  .aside-card__label {
+    color: var(--text-primary) !important;
+    text-transform: uppercase;
+  }
+
+  .aside-card ul {
     display: flex;
     flex-wrap: wrap;
-    justify-content: center;
     gap: var(--space-2);
-  }
-  .post__tags-label { color: var(--text-tertiary); }
-  .post__tag { color: var(--text-primary); }
-  .post__tags-sep { color: var(--color-accent); }
-
-  .post__signoff {
     margin: 0;
-    color: var(--color-accent);
-    font-size: 1.5rem;
-    letter-spacing: 1rem;
-    padding-left: 1rem;
-    line-height: 1;
+    padding: 0;
+    list-style: none;
   }
 
-  .post__more {
-    font-family: var(--fonts-sans);
-    font-size: 0.78rem;
-    letter-spacing: 0.18em;
-    text-transform: uppercase;
-    color: var(--text-secondary);
-    text-decoration: none;
-    transition: color var(--dur-fast) var(--ease-out-expo);
+  @media (min-width: 900px) {
+    .article {
+      padding-block: var(--space-12) var(--space-20);
+    }
+
+    .article__layout {
+      grid-template-columns: minmax(0, 1fr) 240px;
+      align-items: start;
+      gap: var(--space-10);
+    }
+
+    .article__aside {
+      position: sticky;
+      top: 92px;
+      display: grid;
+      gap: var(--space-4);
+    }
+
+    .article__footer {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .article__pager--next {
+      text-align: right;
+    }
   }
-  .post__more:hover { color: var(--color-accent); }
 </style>

--- a/websites/rawkode.dev/src/pages/read/[slug].astro
+++ b/websites/rawkode.dev/src/pages/read/[slug].astro
@@ -4,6 +4,7 @@ export const prerender = true;
 import Layout from '../../layouts/Layout.astro';
 import Nav from '../../components/Nav.astro';
 import Footer from '../../components/Footer.astro';
+import { calculateReadingMinutes, calculateWordCount } from '../../utils/readingTime';
 import { getCollection, render } from 'astro:content';
 
 export async function getStaticPaths() {
@@ -28,8 +29,8 @@ function formatDate(date: Date) {
   return date.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' });
 }
 
-const wordCount = (post.body ?? '').trim().split(/\s+/).filter(Boolean).length;
-const readMinutes = Math.max(1, Math.round(wordCount / 220));
+const wordCount = calculateWordCount(post.body ?? '');
+const readMinutes = calculateReadingMinutes(post.body ?? '');
 const siteUrl = new URL('/', Astro.site ?? 'https://rawkode.dev');
 const personId = new URL('/#person', siteUrl).toString();
 const postUrl = new URL(`/read/${post.id}`, siteUrl).toString();
@@ -323,7 +324,7 @@ const articleJsonLd = {
 
   .prose :global(a) {
     color: var(--color-accent-hover);
-    text-decoration-color: color-mix(in oklch, currentColor 38%, transparent);
+    text-decoration-color: color-mix(in oklch, currentcolor 38%, transparent);
   }
 
   .prose :global(blockquote) {
@@ -484,7 +485,7 @@ const articleJsonLd = {
 
     .article__aside {
       position: sticky;
-      top: 92px;
+      top: var(--nav-height-offset);
       display: grid;
       gap: var(--space-4);
     }

--- a/websites/rawkode.dev/src/pages/read/index.astro
+++ b/websites/rawkode.dev/src/pages/read/index.astro
@@ -2,6 +2,7 @@
 import Layout from '../../layouts/Layout.astro';
 import Nav from '../../components/Nav.astro';
 import Footer from '../../components/Footer.astro';
+import { calculateReadingMinutes } from '../../utils/readingTime';
 import { getCollection } from 'astro:content';
 
 const allPosts = await getCollection('blog', ({ data }) => !data.draft);
@@ -37,10 +38,6 @@ function formatDate(date: Date) {
   return date.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' });
 }
 
-function readMinutes(body = '') {
-  const words = body.trim().split(/\s+/).filter(Boolean).length;
-  return Math.max(1, Math.round(words / 220));
-}
 ---
 
 <Layout
@@ -61,9 +58,8 @@ function readMinutes(body = '') {
             Technical essays on infrastructure, developer tooling, and building in public.
           </p>
         </div>
-        <div class="writing-hero__tabs" role="list" aria-label="Writing filters">
+        <div class="writing-hero__tabs" aria-label="Writing filters">
           <span class="writing-hero__tab writing-hero__tab--active">Essays</span>
-          <span class="writing-hero__tab">Notes</span>
         </div>
       </div>
     </section>
@@ -74,10 +70,10 @@ function readMinutes(body = '') {
           <p class="empty">Nothing here yet. Check back soon.</p>
         ) : (
           <ol class="post-list" role="list">
-            {posts.map((post, i) => (
+            {posts.map((post) => (
               <li>
                 <a href={`/read/${post.id}`} class="post-row">
-                  <span class="post-row__marker" style={`--marker-index: ${i}`} aria-hidden="true"></span>
+                  <span class="post-row__marker" aria-hidden="true"></span>
                   <div class="post-row__content">
                     <h2>{post.data.title}</h2>
                     <p>{post.data.description}</p>
@@ -89,7 +85,7 @@ function readMinutes(body = '') {
                   </div>
                   <div class="post-row__meta">
                     <time datetime={post.data.pubDate.toISOString()}>{formatDate(post.data.pubDate)}</time>
-                    <span>{readMinutes(post.body)} min read</span>
+                    <span>{calculateReadingMinutes(post.body)} min read</span>
                   </div>
                   <svg class="post-row__arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                     <path d="M5 12h14M13 5l7 7-7 7"/>
@@ -139,7 +135,7 @@ function readMinutes(body = '') {
 
   .writing-hero__tabs {
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: minmax(0, 1fr);
     gap: var(--space-2);
     padding: var(--space-1);
     border: 1px solid var(--border-subtle);

--- a/websites/rawkode.dev/src/pages/read/index.astro
+++ b/websites/rawkode.dev/src/pages/read/index.astro
@@ -7,7 +7,7 @@ import { getCollection } from 'astro:content';
 const allPosts = await getCollection('blog', ({ data }) => !data.draft);
 const posts = allPosts.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 const blogDescription =
-  'Essays from David Flanagan on cloud-native infrastructure, developer tooling, open source, and the practical edge of software work.';
+  'Technical essays from David Flanagan on cloud-native infrastructure, developer tooling, open source, and building in public.';
 const siteUrl = new URL('/', Astro.site ?? 'https://rawkode.dev');
 const blogUrl = new URL('/read', siteUrl).toString();
 const personId = new URL('/#person', siteUrl).toString();
@@ -34,11 +34,12 @@ const blogJsonLd = {
 };
 
 function formatDate(date: Date) {
-  return date.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
+  return date.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' });
 }
 
-function formatYear(date: Date) {
-  return date.getFullYear().toString();
+function readMinutes(body = '') {
+  const words = body.trim().split(/\s+/).filter(Boolean).length;
+  return Math.max(1, Math.round(words / 220));
 }
 ---
 
@@ -51,47 +52,48 @@ function formatYear(date: Date) {
   <Nav />
 
   <main id="main-content">
-    <section class="blog-hero">
-      <div class="container">
-        <p class="blog-hero__folio">Writing · A Folio</p>
-        <h1 class="blog-hero__title">Longer thoughts.</h1>
-        <p class="blog-hero__deck">
-          Essays on cloud-native infrastructure, developer tooling, open source, and the
-          practical edge of software work — written when a post or thread will not carry the idea.
-        </p>
+    <section class="writing-hero">
+      <div class="container writing-hero__inner">
+        <div>
+          <p class="page-label">Writing</p>
+          <h1>Writing</h1>
+          <p>
+            Technical essays on infrastructure, developer tooling, and building in public.
+          </p>
+        </div>
+        <div class="writing-hero__tabs" role="list" aria-label="Writing filters">
+          <span class="writing-hero__tab writing-hero__tab--active">Essays</span>
+          <span class="writing-hero__tab">Notes</span>
+        </div>
       </div>
     </section>
 
-    <section class="blog-content">
+    <section class="writing-content">
       <div class="container">
         {posts.length === 0 ? (
           <p class="empty">Nothing here yet. Check back soon.</p>
         ) : (
           <ol class="post-list" role="list">
             {posts.map((post, i) => (
-              <li class="post-list__item">
-                <a href={`/read/${post.id}`} class="post-list__link">
-                  <span class="post-list__no">{String(i + 1).padStart(2, '0')}</span>
-                  <div class="post-list__content">
-                    <h2 class="post-list__title">{post.data.title}</h2>
-                    <p class="post-list__desc">{post.data.description}</p>
+              <li>
+                <a href={`/read/${post.id}`} class="post-row">
+                  <span class="post-row__marker" style={`--marker-index: ${i}`} aria-hidden="true"></span>
+                  <div class="post-row__content">
+                    <h2>{post.data.title}</h2>
+                    <p>{post.data.description}</p>
                     {post.data.tags.length > 0 && (
-                      <p class="post-list__tags">
-                        {post.data.tags.map((tag: string, ti: number) => (
-                          <>
-                            {ti > 0 && <span class="post-list__tag-sep">·</span>}
-                            <span class="post-list__tag">{tag}</span>
-                          </>
-                        ))}
-                      </p>
+                      <ul class="post-row__tags" role="list" aria-label="Tags">
+                        {post.data.tags.map((tag: string) => <li>{tag}</li>)}
+                      </ul>
                     )}
                   </div>
-                  <div class="post-list__meta">
-                    <time class="post-list__date" datetime={post.data.pubDate.toISOString()}>
-                      {formatDate(post.data.pubDate)}
-                    </time>
-                    <span class="post-list__year">{formatYear(post.data.pubDate)}</span>
+                  <div class="post-row__meta">
+                    <time datetime={post.data.pubDate.toISOString()}>{formatDate(post.data.pubDate)}</time>
+                    <span>{readMinutes(post.body)} min read</span>
                   </div>
+                  <svg class="post-row__arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M5 12h14M13 5l7 7-7 7"/>
+                  </svg>
                 </a>
               </li>
             ))}
@@ -105,191 +107,197 @@ function formatYear(date: Date) {
 </Layout>
 
 <style>
-  /* ─── Hero — editorial, centered ────────────────────────────────────── */
-  .blog-hero {
-    padding-block: var(--space-16) var(--space-12);
-    text-align: center;
-    border-bottom: 1px solid var(--border-subtle);
+  .writing-hero {
+    padding-block: var(--space-10) var(--space-6);
   }
 
-  .blog-hero__folio {
-    font-family: var(--fonts-sans);
-    font-size: 0.7rem;
-    letter-spacing: 0.28em;
+  .writing-hero__inner {
+    display: grid;
+    gap: var(--space-6);
+  }
+
+  .page-label {
+    margin: 0 0 var(--space-3);
+    color: var(--color-accent);
+    font-family: var(--fonts-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
-    color: var(--text-tertiary);
-    margin-bottom: var(--space-6);
-  }
-  .blog-hero__folio::before,
-  .blog-hero__folio::after {
-    content: "";
-    display: inline-block;
-    width: 2rem;
-    height: 1px;
-    background: var(--border-subtle);
-    vertical-align: middle;
-    margin: 0 var(--space-4);
   }
 
-  .blog-hero__title {
-    font-family: var(--fonts-serif);
-    font-style: italic;
-    font-weight: 500;
-    font-size: clamp(2.4rem, 6vw, 4.8rem);
-    line-height: 1;
-    letter-spacing: -0.025em;
-    margin-bottom: var(--space-4);
-    text-wrap: balance;
+  .writing-hero h1 {
+    margin: 0;
+    font-size: clamp(2.4rem, 10vw, 4.2rem);
   }
 
-  .blog-hero__deck {
-    font-family: var(--fonts-serif);
-    font-weight: 400;
-    font-size: clamp(1.0625rem, 1.4vw, 1.25rem);
-    line-height: 1.5;
+  .writing-hero p:not(.page-label) {
+    max-width: 34rem;
+    margin: var(--space-3) 0 0;
     color: var(--text-secondary);
-    max-width: 56ch;
-    margin: 0 auto;
-    text-wrap: balance;
+    font-size: 1rem;
   }
 
-  /* ─── Post list — TOC-like ──────────────────────────────────────────── */
-  .blog-content {
-    padding-block: var(--space-12) var(--space-24);
+  .writing-hero__tabs {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-2);
+    padding: var(--space-1);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    background: var(--surface-glass);
+  }
+
+  .writing-hero__tab {
+    padding: var(--space-3);
+    border-radius: var(--radius-md);
+    color: var(--text-tertiary);
+    font-size: 0.88rem;
+    text-align: center;
+  }
+
+  .writing-hero__tab--active {
+    color: var(--text-primary);
+    background: var(--surface-raised);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .writing-content {
+    padding-block: var(--space-4) var(--space-16);
   }
 
   .empty {
     color: var(--text-tertiary);
-    font-family: var(--fonts-serif);
-    font-style: italic;
-    font-size: 1.125rem;
-    text-align: center;
-    padding-block: var(--space-16);
+    padding-block: var(--space-12);
   }
 
   .post-list {
-    list-style: none;
-    counter-reset: post;
-    max-width: 920px;
-    margin: 0 auto;
-  }
-
-  .post-list__item {
-    border-top: 1px solid var(--border-subtle);
-  }
-  .post-list__item:last-child {
-    border-bottom: 1px solid var(--border-subtle);
-  }
-
-  .post-list__link {
     display: grid;
-    grid-template-columns: auto 1fr auto;
-    align-items: baseline;
-    gap: var(--space-6);
-    padding-block: var(--space-8);
-    text-decoration: none;
-    transition: background var(--dur-fast) var(--ease-out-expo);
-  }
-
-  @media (max-width: 720px) {
-    .post-list__link {
-      grid-template-columns: auto 1fr;
-      gap: var(--space-3) var(--space-4);
-    }
-  }
-
-  .post-list__link:hover {
-    background: var(--surface-2);
-  }
-  .post-list__link:hover .post-list__title {
-    color: var(--color-accent);
-  }
-
-  .post-list__no {
-    font-family: var(--fonts-sans);
-    font-size: 0.72rem;
-    letter-spacing: 0.18em;
-    color: var(--text-tertiary);
-    font-variant-numeric: tabular-nums;
-    padding-top: 0.6em;
-    align-self: start;
-    min-width: 2ch;
-  }
-
-  .post-list__content { min-width: 0; }
-
-  .post-list__title {
-    font-family: var(--fonts-serif);
-    font-style: italic;
-    font-weight: 500;
-    font-size: clamp(1.5rem, 2.4vw, 2rem);
-    line-height: 1.1;
-    letter-spacing: -0.015em;
-    color: var(--text-primary);
-    margin: 0 0 var(--space-2);
-    transition: color var(--dur-fast) var(--ease-out-expo);
-    text-wrap: balance;
-  }
-
-  .post-list__desc {
-    font-family: var(--fonts-serif);
-    font-size: 1.05rem;
-    line-height: 1.55;
-    color: var(--text-secondary);
+    gap: var(--space-3);
+    max-width: 920px;
     margin: 0;
-    max-width: 60ch;
+    padding: 0;
+    list-style: none;
   }
 
-  .post-list__tags {
-    font-family: var(--fonts-sans);
-    font-size: 0.7rem;
-    letter-spacing: 0.22em;
-    text-transform: uppercase;
-    color: var(--text-tertiary);
-    margin: var(--space-3) 0 0;
-    display: flex;
-    flex-wrap: wrap;
+  .post-row {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    gap: var(--space-3);
+    align-items: center;
+    padding: var(--space-4);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    background: var(--surface-glass);
+    color: var(--text-primary);
+    text-decoration: none;
+    box-shadow: var(--shadow-sm);
+    transition:
+      border-color var(--dur-fast) var(--ease-out-expo),
+      background var(--dur-fast) var(--ease-out-expo),
+      transform var(--dur-fast) var(--ease-out-expo);
+  }
+
+  .post-row:hover {
+    border-color: var(--border-default);
+    background: var(--surface-raised);
+    transform: translateY(-1px);
+    text-decoration: none;
+  }
+
+  .post-row__marker {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--color-accent);
+    box-shadow: 0 0 0 4px var(--color-accent-soft);
+  }
+
+  .post-row:nth-child(3n + 2) .post-row__marker {
+    background: var(--color-accent-cyan);
+  }
+
+  .post-row:nth-child(3n) .post-row__marker {
+    background: var(--color-accent-rose);
+  }
+
+  .post-row__content {
+    min-width: 0;
+    display: grid;
     gap: var(--space-2);
   }
-  .post-list__tag { color: var(--text-tertiary); }
-  .post-list__tag-sep { color: var(--color-accent); }
 
-  .post-list__meta {
-    text-align: right;
-    align-self: start;
-    padding-top: 0.4em;
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-1);
+  .post-row h2 {
+    margin: 0;
+    color: var(--text-primary);
+    font-size: clamp(1rem, 4vw, 1.35rem);
+    line-height: 1.24;
   }
 
-  @media (max-width: 720px) {
-    .post-list__meta {
-      grid-column: 1 / -1;
-      text-align: left;
-      flex-direction: row;
-      gap: var(--space-3);
-      padding-top: var(--space-2);
-    }
-    .post-list__year { display: none; }
-  }
-
-  .post-list__date {
-    font-family: var(--fonts-sans);
-    font-size: 0.72rem;
-    letter-spacing: 0.18em;
-    text-transform: uppercase;
+  .post-row p {
+    display: none;
+    margin: 0;
     color: var(--text-secondary);
-    white-space: nowrap;
-    font-variant-numeric: tabular-nums;
+    font-size: 0.92rem;
+    line-height: 1.55;
   }
 
-  .post-list__year {
-    font-family: var(--fonts-serif);
-    font-style: italic;
-    font-size: 1.5rem;
-    line-height: 1;
-    color: var(--color-accent);
-    font-variant-numeric: lining-nums;
+  .post-row__tags {
+    display: none;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .post-row__tags li {
+    padding: 0.2rem 0.45rem;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
+    color: var(--text-tertiary);
+    font-family: var(--fonts-mono);
+    font-size: 0.68rem;
+  }
+
+  .post-row__meta {
+    display: grid;
+    gap: var(--space-1);
+    justify-items: end;
+    color: var(--text-tertiary);
+    font-family: var(--fonts-mono);
+    font-size: 0.7rem;
+    white-space: nowrap;
+  }
+
+  .post-row__arrow {
+    display: none;
+    width: 18px;
+    height: 18px;
+    color: var(--text-secondary);
+  }
+
+  @media (min-width: 720px) {
+    .writing-hero {
+      padding-block: var(--space-16) var(--space-8);
+    }
+
+    .writing-hero__inner {
+      grid-template-columns: minmax(0, 1fr) 320px;
+      align-items: end;
+    }
+
+    .post-row {
+      grid-template-columns: auto minmax(0, 1fr) auto auto;
+      padding: var(--space-5);
+    }
+
+    .post-row p,
+    .post-row__tags {
+      display: flex;
+    }
+
+    .post-row__arrow {
+      display: block;
+    }
   }
 </style>

--- a/websites/rawkode.dev/src/styles/global.css
+++ b/websites/rawkode.dev/src/styles/global.css
@@ -11,6 +11,7 @@
     scroll-behavior: smooth;
     -webkit-text-size-adjust: 100%;
     text-size-adjust: 100%;
+    --nav-height-offset: 92px;
   }
 }
 
@@ -29,7 +30,7 @@
       linear-gradient(180deg, var(--colors-surface-1) 0%, color-mix(in oklch, var(--colors-surface-1) 84%, black) 100%);
     background-attachment: fixed;
     font-feature-settings: 'kern' 1, 'liga' 1, 'calt' 1;
-    text-rendering: optimizeLegibility;
+    text-rendering: optimizelegibility;
     transition:
       background-color var(--durations-normal) var(--easings-in-out),
       color var(--durations-normal) var(--easings-in-out);
@@ -89,7 +90,7 @@
 
   a:hover {
     color: var(--colors-accent);
-    text-decoration-color: currentColor;
+    text-decoration-color: currentcolor;
   }
 
   strong {

--- a/websites/rawkode.dev/src/styles/global.css
+++ b/websites/rawkode.dev/src/styles/global.css
@@ -1,6 +1,4 @@
 /* ─── Fonts ─────────────────────────────────────────────────────────────── */
-@import '@fontsource-variable/newsreader/wght.css';
-@import '@fontsource-variable/newsreader/wght-italic.css';
 @import '@fontsource-variable/figtree/index.css';
 
 /* ─── Panda CSS layers ──────────────────────────────────────────────────── */
@@ -19,17 +17,36 @@
 /* ─── Base typography & elements ────────────────────────────────────────── */
 @layer base {
   body {
+    min-height: 100dvh;
+    margin: 0;
     font-family: var(--fonts-sans);
     font-size: 1rem;
     font-weight: 400;
     line-height: 1.6;
     color: var(--colors-text-primary);
-    background-color: var(--colors-surface-1);
+    background:
+      var(--page-glow),
+      linear-gradient(180deg, var(--colors-surface-1) 0%, color-mix(in oklch, var(--colors-surface-1) 84%, black) 100%);
+    background-attachment: fixed;
     font-feature-settings: 'kern' 1, 'liga' 1, 'calt' 1;
+    text-rendering: optimizeLegibility;
     transition:
       background-color var(--durations-normal) var(--easings-in-out),
       color var(--durations-normal) var(--easings-in-out);
-    min-height: 100dvh;
+  }
+
+  body::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    background-image:
+      linear-gradient(to right, color-mix(in oklch, var(--colors-border-subtle) 52%, transparent) 1px, transparent 1px),
+      linear-gradient(to bottom, color-mix(in oklch, var(--colors-border-subtle) 42%, transparent) 1px, transparent 1px);
+    background-size: 40px 40px;
+    mask-image: linear-gradient(to bottom, oklch(0% 0 0 / 0.22), transparent 64%);
+    opacity: 0.32;
   }
 
   ::selection {
@@ -40,42 +57,58 @@
   time { font-variant-numeric: tabular-nums; }
 
   h1, h2, h3, h4, h5, h6 {
-    font-family: var(--fonts-serif);
-    font-weight: 600;
-    line-height: 1.15;
-    letter-spacing: -0.02em;
+    font-family: var(--fonts-sans);
+    font-weight: 650;
+    line-height: 1.05;
+    letter-spacing: 0;
     color: var(--colors-text-primary);
+    text-wrap: balance;
   }
 
-  h1 { font-size: clamp(2.4rem, 5vw + 1rem, 4.5rem); }
-  h2 { font-size: clamp(1.75rem, 3vw + 0.5rem, 2.75rem); }
-  h3 { font-size: clamp(1.25rem, 2vw + 0.25rem, 1.75rem); }
-  h4 { font-size: 1.25rem; }
+  h1 { font-size: clamp(2.35rem, 8vw, 4.6rem); }
+  h2 { font-size: clamp(1.65rem, 5vw, 2.75rem); }
+  h3 { font-size: clamp(1.12rem, 3vw, 1.5rem); }
+  h4 { font-size: 1rem; }
 
-  p { line-height: 1.7; color: var(--colors-text-secondary); }
+  p {
+    line-height: 1.72;
+    color: var(--colors-text-secondary);
+  }
+
   p + p { margin-top: var(--spacing-4); }
 
   a {
-    color: var(--colors-accent);
+    color: var(--colors-accent-hover);
     text-decoration: underline;
     text-decoration-color: transparent;
     text-underline-offset: 3px;
-    transition: text-decoration-color var(--durations-fast) var(--easings-out-expo);
+    transition:
+      color var(--durations-fast) var(--easings-out-expo),
+      text-decoration-color var(--durations-fast) var(--easings-out-expo);
   }
-  a:hover { text-decoration-color: currentColor; }
 
-  strong { font-weight: 600; color: var(--colors-text-primary); }
+  a:hover {
+    color: var(--colors-accent);
+    text-decoration-color: currentColor;
+  }
+
+  strong {
+    font-weight: 650;
+    color: var(--colors-text-primary);
+  }
 
   code {
     font-family: var(--fonts-mono);
     font-size: 0.875em;
-    background: var(--colors-surface-2);
+    background: var(--colors-surface-raised);
     border: 1px solid var(--colors-border-subtle);
     border-radius: var(--radii-sm);
-    padding: 0.1em 0.35em;
+    padding: 0.12em 0.42em;
+    color: var(--colors-accent-hover);
   }
 
   :focus { outline: none; }
+
   :focus-visible {
     outline: 2px solid var(--colors-accent);
     outline-offset: 3px;
@@ -89,7 +122,7 @@
     width: 100%;
     max-width: 1200px;
     margin-inline: auto;
-    padding-inline: var(--spacing-6);
+    padding-inline: var(--spacing-4);
   }
 
   @media (min-width: 768px) {

--- a/websites/rawkode.dev/src/utils/readingTime.ts
+++ b/websites/rawkode.dev/src/utils/readingTime.ts
@@ -1,0 +1,9 @@
+const WORDS_PER_MINUTE = 220;
+
+export function calculateWordCount(body = ''): number {
+  return body.trim().split(/\s+/).filter(Boolean).length;
+}
+
+export function calculateReadingMinutes(body = ''): number {
+  return Math.max(1, Math.round(calculateWordCount(body) / WORDS_PER_MINUTE));
+}


### PR DESCRIPTION
## Summary

- Reworks rawkode.dev around the approved softer-premium dark Rose Pine direction.
- Updates Panda/global tokens, shared chrome, homepage, writing index, article pages, biography, app rows, and code block theming.
- Preserves existing routes, content collections, app/blog data, the real headshot asset, and the existing theme storage contract.

## Validation

- `deno task codegen`
- `deno task build`
- In-app Browser QA at `390x844`, `768x1024`, and `1280x800` across `/`, `/read`, `/read/introducing-alteran-atproto-pds-cloudflare-astro`, and `/biography`

Browser QA checked dark default rendering, no horizontal overflow, no console errors, real app ordering, biography copy controls, and Expressive Code blocks on the long article.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile navigation menu
  * Reading time estimates for blog posts
  * Copy-to-clipboard functionality on biography page

* **Design Updates**
  * Complete design system overhaul with Rosé Pine color palette (dark-first approach)
  * Grid-based redesign of cards, layouts, and components
  * Updated typography, spacing, and color tokens
  * Restructured footer and navigation
  * Refreshed biography and blog pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->