### PR TITLE
feat(enchiridion): build graph-native data model

### DIFF
--- a/apps/enchiridion/Documentation/GraphDataModel.md
+++ b/apps/enchiridion/Documentation/GraphDataModel.md
@@ -65,8 +65,10 @@ queries are vault metadata with generation-safe CloudKit acknowledgements and to
 Base Tags and system relationship definitions ship with the application and are not uploaded.
 
 The vault catalog remains local device configuration: selected/default-capture vault choices and
-local database locations are not graph knowledge. Global search opens each local vault and returns
-vault-scoped identities; it does not create cross-vault edges.
+local database locations are not graph knowledge. The built-in Personal vault has a fixed identity,
+so fresh devices using the same iCloud account address the same graph zone; custom vault identities
+remain catalogued locally until explicitly transferred or synchronized. Global search opens each
+local vault and returns vault-scoped identities; it does not create cross-vault edges.
 
 ## Evolution rules
 

--- a/apps/enchiridion/Documentation/GraphDataModel.md
+++ b/apps/enchiridion/Documentation/GraphDataModel.md
@@ -1,0 +1,78 @@
+# Knowledge graph data model
+
+Enchiridion treats every page as a node in a vault-local knowledge graph. Supertags provide
+types and inherited predicates; canonical directed edges provide relationships; inverse names
+provide backlinks without storing a second edge. SQLite is the local query engine. CloudKit is
+transport, not an alternate graph authority.
+
+## Semantic contract
+
+- A node has one durable `NodeID` inside one `VaultID`. External identities always serialize as
+  `VaultScopedNodeID`; relationships never cross vaults implicitly.
+- A node may have multiple Supertags. A custom tag may inherit from multiple parents. The closure
+  is a directed acyclic graph and includes the fixed Base Tags supplied by Enchiridion: Person,
+  Organization, Company, Event, Place, Area, Project, and Task.
+- A fact is a typed `(node, predicate, value)` assertion projected from the node's Automerge
+  document. Predicate identity is stable even when a field is renamed.
+- A relationship is one source-owned canonical edge with a forward and inverse name. One-to-one,
+  one-to-many, many-to-one, and many-to-many are expressed as endpoint maximums on its definition.
+- A backlink is the inverse projection of an incoming canonical edge. It is never a second mutable
+  record.
+- Concurrent maximum-one edges are preserved and surfaced as graph issues. Resolution is explicit;
+  merge order must not silently choose a winner.
+- Provider and inline-reference edges are graph projections. User-created edges are stored in the
+  source node's Automerge document and therefore merge with the rest of that node.
+
+## SQL versus Cypher
+
+Enchiridion uses read-only SQLite SQL rather than embedding a Cypher engine.
+
+| Concern | SQLite SQL | Cypher |
+| --- | --- | --- |
+| Local Apple-platform runtime | Already embedded, supported by GRDB, and shares transactions with page projection | Requires a second embedded engine or a server runtime |
+| Graph traversal | Recursive CTEs are more verbose but compile cleanly from the visual builder | Pattern syntax is clearer for hand-written variable-length traversals |
+| Facts, calendar data, FTS, and ordering | Natural joins, indexes, FTS5, aggregates, and date sorting in one engine | Often requires duplicated non-graph projections or engine-specific extensions |
+| Cardinality and inheritance checks | Explicit projection and validation code; easy to test transactionally | Relationships are native, but application cardinality and tag-DAG rules still need validation |
+| Query isolation | SQLite authorizer permits one read-only statement over stable public views | Would require an equivalent allowlist and resource-limiting layer |
+| Mobile footprint and offline recovery | One database, backup, migration path, and CloudKit projection boundary | Two authorities increase packaging, migration, reconciliation, and recovery cost |
+| User ergonomics | Visual query builder hides recursive SQL; advanced users may inspect or write SQL | Better direct graph syntax for advanced graph users |
+
+Cypher wins on handwritten graph-pattern readability. SQL wins for this product because the graph
+is one aspect of the same local-first data authority as prose, tasks, calendars, full-text search,
+and sync state. Adding a graph database now would create a second transactional authority without
+removing the need for SQLite.
+
+This is not a commitment to expose SQLite internals. The supported query surface is the visual
+query model and these read-only relations:
+
+- `graph_nodes`
+- `graph_tags`, `graph_tag_parents`, and `graph_tag_closure`
+- `graph_node_tags` and `graph_facts`
+- `graph_relation_definitions` and `graph_edges`
+- `graph_issues`
+- `graph_text_search`
+
+Physical tables are denied by the SQLite authorizer. Queries are limited by row count, result size,
+execution time, and a single-statement read-only policy. If a future Cypher engine becomes valuable,
+it must implement the same semantic contract and query model; UI and persisted saved queries should
+not depend on private SQL table names.
+
+## Persistence and synchronization
+
+Each vault has its own SQLite database and CloudKit record zone. Pages own their Automerge
+documents and canonical edges. Supertag schemas, custom relationship definitions, and saved graph
+queries are vault metadata with generation-safe CloudKit acknowledgements and tombstones. Fixed
+Base Tags and system relationship definitions ship with the application and are not uploaded.
+
+The vault catalog remains local device configuration: selected/default-capture vault choices and
+local database locations are not graph knowledge. Global search opens each local vault and returns
+vault-scoped identities; it does not create cross-vault edges.
+
+## Evolution rules
+
+1. Add graph behavior to the semantic model first, then project it into stable query views.
+2. Keep one canonical mutation owner for every edge or fact.
+3. Never materialize backlinks as independently editable data.
+4. Preserve conflicting graph assertions through merge and expose deterministic issues.
+5. Keep query execution read-only and bounded.
+6. Version public query semantics deliberately; private tables may change freely.

--- a/apps/enchiridion/Enchiridion.xcodeproj/project.pbxproj
+++ b/apps/enchiridion/Enchiridion.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		989C08D0B1317BB4D5D7E339 /* AppIntents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1922885EA354367E18999189 /* AppIntents.framework */; };
 		9BDA6E300E9631938293318F /* LiveViewScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F822D8E1C45AAD940DB28D1 /* LiveViewScreen.swift */; };
 		A1AF4B4993FF6A66FF07F7F8 /* EnchiridioniOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BBC3293A34793EC285B34BB /* EnchiridioniOSApp.swift */; };
+		A32C6AC40180C3A3228172C3 /* GraphQueryWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0938AF7A6668F0079D01E68F /* GraphQueryWorkspace.swift */; };
 		A40D92F77ECEF3BD9F93F222 /* TaskMutationWarningModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5CBBC0AA631127161681E80 /* TaskMutationWarningModifier.swift */; };
 		A45CFBCF225823A2564383EF /* SupertagSchemaEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF2344F7F29266FD14A246D /* SupertagSchemaEditor.swift */; };
 		A560FD670108778F88258DF9 /* TaskCompletionUndoModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96FD1482EC943483B8E9F710 /* TaskCompletionUndoModifier.swift */; };
@@ -84,6 +85,7 @@
 		A79AD5EDE80E4592564CB9C7 /* TaskReminderAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13780FE9A222B8284EF0FF3 /* TaskReminderAppDelegate.swift */; };
 		A9732128EA8883D8BA6BF9EE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5B20EC98721AA71FBB0962DB /* Assets.xcassets */; };
 		A997BF51D7CC828F0707BA81 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D9C3C3EB64DA4FB0979160BE /* WidgetKit.framework */; };
+		A9D193A79C860FAC08DD7078 /* GraphRelationshipViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31DFF3CD751EC0680E7E70C1 /* GraphRelationshipViews.swift */; };
 		AB7B3A3A930722901E924B9D /* ContactsUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F19D2EBDC5F87EE5147087E6 /* ContactsUI.framework */; };
 		AD52CB10D1EFFCA2869BB1B5 /* EnchiridionCore in Frameworks */ = {isa = PBXBuildFile; productRef = 3E539EB8451EC283BFE5CA0D /* EnchiridionCore */; };
 		ADFEEFED47744B5DDC927214 /* TaskMutationWarningModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5CBBC0AA631127161681E80 /* TaskMutationWarningModifier.swift */; };
@@ -98,19 +100,23 @@
 		C2639A7EB7E845EA0F16E377 /* CarPlayScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64E087EF8C854F882AF3E55 /* CarPlayScene.swift */; };
 		C2E6F4E0C28B6135A015984F /* WhiteboardElementOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FC9C67965AEB108C7118E14 /* WhiteboardElementOverlay.swift */; };
 		C43646907D2E902FFAC0240B /* EntryRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F58D1AB494B3CACDFDAA6873 /* EntryRowView.swift */; };
+		C649B9970BF398CE15EC1EEF /* GraphRelationshipViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31DFF3CD751EC0680E7E70C1 /* GraphRelationshipViews.swift */; };
 		C8C6F37DE6DE094440175D44 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8E348F8C323D6A9956945CF /* AVFoundation.framework */; };
 		C9CC857D1F28219726E04AAA /* LibrarySection+Presentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D402E534CF31302196BB5DAB /* LibrarySection+Presentation.swift */; };
 		CCA4C3B4D33E63877C0D862D /* VaultManagementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECEEBCB6F45BBED097C77B4 /* VaultManagementView.swift */; };
 		CEAB5177991E19C711C72DF2 /* VaultManagementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECEEBCB6F45BBED097C77B4 /* VaultManagementView.swift */; };
+		D0584F43527169484B81DB96 /* GraphRelationDefinitionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15C78A2A912D114CC56B0E63 /* GraphRelationDefinitionsView.swift */; };
 		D1149A491B23B3D229E28CFB /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8E348F8C323D6A9956945CF /* AVFoundation.framework */; };
 		D23352015992D41FF8882FF2 /* WhiteboardDrawingLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86A76A1059320AF5A463BCB /* WhiteboardDrawingLayer.swift */; };
 		D2A35D7137F26A24D0D4AB92 /* DailyTaskContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB44DD178640603EEBE0FC0 /* DailyTaskContext.swift */; };
+		D3351B5BCA365630C5E35D18 /* GraphQueryWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0938AF7A6668F0079D01E68F /* GraphQueryWorkspace.swift */; };
 		D6A4FDDB59D000F76FEF0787 /* WhiteboardChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E74F1D6BD05A71A70720A8 /* WhiteboardChrome.swift */; };
 		D8E60E651B6339FEC1E4A06B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5B20EC98721AA71FBB0962DB /* Assets.xcassets */; };
 		DA9B78C2B47B01C1496F6DE6 /* CalendarAgendaModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96595A2BB06A38AC6E917736 /* CalendarAgendaModels.swift */; };
 		DAAA51321537920D9734ED1A /* LibrarySection+Presentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D402E534CF31302196BB5DAB /* LibrarySection+Presentation.swift */; };
 		DB148207B85C8D5D24C5BC91 /* EmptyLibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9A9C5EAB3A0E418591E48D /* EmptyLibraryView.swift */; };
 		DC85120843B68760FF8E15B5 /* WhiteboardChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E74F1D6BD05A71A70720A8 /* WhiteboardChrome.swift */; };
+		DEA5685EE7AD3986FB231BA2 /* GraphRelationDefinitionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15C78A2A912D114CC56B0E63 /* GraphRelationDefinitionsView.swift */; };
 		E0A72D4016BA7AA4378D7796 /* WhiteboardCanvasGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CD10EE53C2822339A541B7B /* WhiteboardCanvasGeometry.swift */; };
 		E1933CD85E9587F250228CFE /* TaskManagementViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D4CB8A66447640BDA42FD86 /* TaskManagementViews.swift */; };
 		E2D2F33CA0885506A77E459C /* SupertagPropertiesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF130800D16354D0460E0A38 /* SupertagPropertiesView.swift */; };
@@ -163,7 +169,9 @@
 
 /* Begin PBXFileReference section */
 		040BA6B652D9E8EA278D5E67 /* WhiteboardTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteboardTool.swift; sourceTree = "<group>"; };
+		0938AF7A6668F0079D01E68F /* GraphQueryWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQueryWorkspace.swift; sourceTree = "<group>"; };
 		147AA2076A7386AF15C27C8A /* TaskWorkbench.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskWorkbench.swift; sourceTree = "<group>"; };
+		15C78A2A912D114CC56B0E63 /* GraphRelationDefinitionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphRelationDefinitionsView.swift; sourceTree = "<group>"; };
 		1922885EA354367E18999189 /* AppIntents.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppIntents.framework; path = System/Library/Frameworks/AppIntents.framework; sourceTree = SDKROOT; };
 		1A92D6D7C62EFE1A235AB1F2 /* DeviceContactPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceContactPicker.swift; sourceTree = "<group>"; };
 		1CB44DD178640603EEBE0FC0 /* DailyTaskContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyTaskContext.swift; sourceTree = "<group>"; };
@@ -172,6 +180,7 @@
 		28402AC196EC51B0A3E782CF /* TaskPlanningViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskPlanningViews.swift; sourceTree = "<group>"; };
 		2D7EE81CB0F9C21786FEA84D /* MobileRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileRootView.swift; sourceTree = "<group>"; };
 		2FB9B6918B67571BAC776C36 /* CalendarAgendaRows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarAgendaRows.swift; sourceTree = "<group>"; };
+		31DFF3CD751EC0680E7E70C1 /* GraphRelationshipViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphRelationshipViews.swift; sourceTree = "<group>"; };
 		41B1758C51CCC9F6FDAD3169 /* CalendarChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarChrome.swift; sourceTree = "<group>"; };
 		43B5F7FE8066B45C8D015097 /* MacRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacRootView.swift; sourceTree = "<group>"; };
 		4992038E65A7C111FF05ABD2 /* TaskReminderNotificationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskReminderNotificationCoordinator.swift; sourceTree = "<group>"; };
@@ -358,6 +367,9 @@
 				AF9A9C5EAB3A0E418591E48D /* EmptyLibraryView.swift */,
 				A34DEE0C4C94BFA4F642C799 /* EntryEditorView.swift */,
 				F58D1AB494B3CACDFDAA6873 /* EntryRowView.swift */,
+				0938AF7A6668F0079D01E68F /* GraphQueryWorkspace.swift */,
+				15C78A2A912D114CC56B0E63 /* GraphRelationDefinitionsView.swift */,
+				31DFF3CD751EC0680E7E70C1 /* GraphRelationshipViews.swift */,
 				D402E534CF31302196BB5DAB /* LibrarySection+Presentation.swift */,
 				8F822D8E1C45AAD940DB28D1 /* LiveViewScreen.swift */,
 				D76762F81B512A918E1CBD2B /* OnDeviceSpeechTranscriber.swift */,
@@ -631,6 +643,9 @@
 				3067F6FDF94E2BEBEB78825D /* EnchiridionMacApp.swift in Sources */,
 				5461DBCFEEE1F0AD9F53FF76 /* EntryEditorView.swift in Sources */,
 				105F420A5CB29170F60761A2 /* EntryRowView.swift in Sources */,
+				D3351B5BCA365630C5E35D18 /* GraphQueryWorkspace.swift in Sources */,
+				D0584F43527169484B81DB96 /* GraphRelationDefinitionsView.swift in Sources */,
+				C649B9970BF398CE15EC1EEF /* GraphRelationshipViews.swift in Sources */,
 				C9CC857D1F28219726E04AAA /* LibrarySection+Presentation.swift in Sources */,
 				B2AB811BC8E3C184F52AA920 /* LiveViewScreen.swift in Sources */,
 				3677B1C36F6FBBCB3FECB27C /* MacDailyTaskContext.swift in Sources */,
@@ -689,6 +704,9 @@
 				32FFA9788E39F5A2F0E99262 /* EntryEditorView.swift in Sources */,
 				47928D7124ABA0AD79FE4662 /* EntryListScreen.swift in Sources */,
 				C43646907D2E902FFAC0240B /* EntryRowView.swift in Sources */,
+				A32C6AC40180C3A3228172C3 /* GraphQueryWorkspace.swift in Sources */,
+				DEA5685EE7AD3986FB231BA2 /* GraphRelationDefinitionsView.swift in Sources */,
+				A9D193A79C860FAC08DD7078 /* GraphRelationshipViews.swift in Sources */,
 				DAAA51321537920D9734ED1A /* LibrarySection+Presentation.swift in Sources */,
 				9BDA6E300E9631938293318F /* LiveViewScreen.swift in Sources */,
 				929E1941060850FB6F278874 /* MobileLibraryScreen.swift in Sources */,

--- a/apps/enchiridion/Enchiridion.xcodeproj/project.pbxproj
+++ b/apps/enchiridion/Enchiridion.xcodeproj/project.pbxproj
@@ -100,6 +100,8 @@
 		C43646907D2E902FFAC0240B /* EntryRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F58D1AB494B3CACDFDAA6873 /* EntryRowView.swift */; };
 		C8C6F37DE6DE094440175D44 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8E348F8C323D6A9956945CF /* AVFoundation.framework */; };
 		C9CC857D1F28219726E04AAA /* LibrarySection+Presentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D402E534CF31302196BB5DAB /* LibrarySection+Presentation.swift */; };
+		CCA4C3B4D33E63877C0D862D /* VaultManagementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECEEBCB6F45BBED097C77B4 /* VaultManagementView.swift */; };
+		CEAB5177991E19C711C72DF2 /* VaultManagementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECEEBCB6F45BBED097C77B4 /* VaultManagementView.swift */; };
 		D1149A491B23B3D229E28CFB /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8E348F8C323D6A9956945CF /* AVFoundation.framework */; };
 		D23352015992D41FF8882FF2 /* WhiteboardDrawingLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86A76A1059320AF5A463BCB /* WhiteboardDrawingLayer.swift */; };
 		D2A35D7137F26A24D0D4AB92 /* DailyTaskContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB44DD178640603EEBE0FC0 /* DailyTaskContext.swift */; };
@@ -210,6 +212,7 @@
 		BE80ADD38DF8DAD479B64FC4 /* AssistantConversationRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssistantConversationRuntime.swift; sourceTree = "<group>"; };
 		C13780FE9A222B8284EF0FF3 /* TaskReminderAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskReminderAppDelegate.swift; sourceTree = "<group>"; };
 		CBA7E703EC81C57573102899 /* CalendarDayStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarDayStrip.swift; sourceTree = "<group>"; };
+		CECEEBCB6F45BBED097C77B4 /* VaultManagementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultManagementView.swift; sourceTree = "<group>"; };
 		D01C78BB8752D4959D32D9E9 /* Enchiridion.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Enchiridion.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D402E534CF31302196BB5DAB /* LibrarySection+Presentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LibrarySection+Presentation.swift"; sourceTree = "<group>"; };
 		D4347F52242BFA54AB59CF1D /* AssistantConversationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssistantConversationView.swift; sourceTree = "<group>"; };
@@ -369,6 +372,7 @@
 				28402AC196EC51B0A3E782CF /* TaskPlanningViews.swift */,
 				4992038E65A7C111FF05ABD2 /* TaskReminderNotificationCoordinator.swift */,
 				147AA2076A7386AF15C27C8A /* TaskWorkbench.swift */,
+				CECEEBCB6F45BBED097C77B4 /* VaultManagementView.swift */,
 				7CD10EE53C2822339A541B7B /* WhiteboardCanvasGeometry.swift */,
 				D83C5CD6502254CF1A8FD2CE /* WhiteboardCanvasView.swift */,
 				89E74F1D6BD05A71A70720A8 /* WhiteboardChrome.swift */,
@@ -646,6 +650,7 @@
 				A79AD5EDE80E4592564CB9C7 /* TaskReminderAppDelegate.swift in Sources */,
 				B54F13D5E2C5129FE49DCFBF /* TaskReminderNotificationCoordinator.swift in Sources */,
 				FFC8ABA3D669D308FAD1714C /* TaskWorkbench.swift in Sources */,
+				CEAB5177991E19C711C72DF2 /* VaultManagementView.swift in Sources */,
 				E0A72D4016BA7AA4378D7796 /* WhiteboardCanvasGeometry.swift in Sources */,
 				1B2A6A3232EB1383DBF2F958 /* WhiteboardCanvasView.swift in Sources */,
 				DC85120843B68760FF8E15B5 /* WhiteboardChrome.swift in Sources */,
@@ -702,6 +707,7 @@
 				BB55209018648535F8C68363 /* TaskReminderNotificationCoordinator.swift in Sources */,
 				5E764416E1D9F740E73E8C09 /* TaskWorkbench.swift in Sources */,
 				EF3E3120300B86E63FD15C85 /* TodayWorkspaceView.swift in Sources */,
+				CCA4C3B4D33E63877C0D862D /* VaultManagementView.swift in Sources */,
 				B68CA822E35720463AB56093 /* WhiteboardCanvasGeometry.swift in Sources */,
 				5291BA3C3C7401D9E73A0E79 /* WhiteboardCanvasView.swift in Sources */,
 				D6A4FDDB59D000F76FEF0787 /* WhiteboardChrome.swift in Sources */,

--- a/apps/enchiridion/README.md
+++ b/apps/enchiridion/README.md
@@ -11,6 +11,16 @@ A local-first, native SwiftUI knowledge journal for macOS and iOS.
 
 Edits are journaled in the editor before Swift receives them, committed atomically to SQLite, and only then acknowledged. CloudKit is a transport; the local database remains authoritative offline.
 
+## Knowledge graph
+
+Pages are vault-local graph nodes. Supertags provide multiple-inheritance types and typed facts;
+canonical relationships provide one-to-one, one-to-many, many-to-one, and many-to-many edges with
+inverse backlinks. The visual query builder compiles to bounded, read-only SQLite over stable
+`graph_*` views, and advanced users can run SQL against the same allowlisted surface.
+
+See [Knowledge graph data model](Documentation/GraphDataModel.md) for the semantic contract, vault
+and sync boundaries, and the SQL-versus-Cypher decision.
+
 ## Supertags
 
 Supertags turn ordinary pages into typed objects while keeping the page editable and linkable:

--- a/apps/enchiridion/Sources/EnchiridionCore/CloudSyncCoordinator.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/CloudSyncCoordinator.swift
@@ -58,7 +58,7 @@ struct CloudAssetRegistry {
 
 public actor CloudSyncCoordinator: CKSyncEngineDelegate {
   public static let containerIdentifier = "iCloud.dev.rawkode.enchiridion"
-  public static let zoneName = "EnchiridionVault"
+  public static let zoneName = VaultID.personalCloudZoneName
   static let codeSignEntitlementsInfoKey = "EnchiridionCodeSignEntitlements"
   static let codeSigningAllowedInfoKey = "EnchiridionCodeSigningAllowed"
 

--- a/apps/enchiridion/Sources/EnchiridionCore/CloudSyncCoordinator.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/CloudSyncCoordinator.swift
@@ -275,6 +275,16 @@ public actor CloudSyncCoordinator: CKSyncEngineDelegate {
     }
   }
 
+  public func stop() {
+    revalidationTask?.cancel()
+    revalidationTask = nil
+    engine = nil
+    isStarting = false
+    isAccountAuthorized = false
+    manualSyncInProgress = false
+    manualSyncRequested = false
+  }
+
   public func pageDidChange(_ pageID: PageID) async {
     guard isAccountAuthorized else { return }
     queueRecord(recordID(for: pageID), trigger: .localMutation)

--- a/apps/enchiridion/Sources/EnchiridionCore/CloudSyncCoordinator.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/CloudSyncCoordinator.swift
@@ -184,6 +184,7 @@ public actor CloudSyncCoordinator: CKSyncEngineDelegate {
 
   public init(
     repository: LibraryRepository,
+    zoneName: String = CloudSyncCoordinator.zoneName,
     statusHandler: @escaping @Sendable (SyncStatus) -> Void,
     changeHandler: @escaping @Sendable () -> Void = {}
   ) {
@@ -191,7 +192,7 @@ public actor CloudSyncCoordinator: CKSyncEngineDelegate {
     self.statusHandler = statusHandler
     self.changeHandler = changeHandler
     container = CKContainer(identifier: Self.containerIdentifier)
-    zoneID = CKRecordZone.ID(zoneName: Self.zoneName, ownerName: CKCurrentUserDefaultName)
+    zoneID = CKRecordZone.ID(zoneName: zoneName, ownerName: CKCurrentUserDefaultName)
   }
 
   public func start() async {

--- a/apps/enchiridion/Sources/EnchiridionCore/CloudSyncCoordinator.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/CloudSyncCoordinator.swift
@@ -152,9 +152,15 @@ public actor CloudSyncCoordinator: CKSyncEngineDelegate {
       recordName.hasPrefix(viewRecordPrefix)
     case RecordType.supertag:
       recordName.hasPrefix(supertagRecordPrefix)
+    case RecordType.graphRelation:
+      recordName.hasPrefix(graphRelationRecordPrefix)
+    case RecordType.graphQuery:
+      recordName.hasPrefix(graphQueryRecordPrefix)
     case RecordType.page:
       !recordName.hasPrefix(viewRecordPrefix)
         && !recordName.hasPrefix(supertagRecordPrefix)
+        && !recordName.hasPrefix(graphRelationRecordPrefix)
+        && !recordName.hasPrefix(graphQueryRecordPrefix)
     default:
       false
     }
@@ -289,6 +295,16 @@ public actor CloudSyncCoordinator: CKSyncEngineDelegate {
     queueRecord(recordID(for: supertagID), trigger: .localMutation)
   }
 
+  public func relationDefinitionDidChange(_ relationID: RelationID) async {
+    guard isAccountAuthorized else { return }
+    queueRecord(recordID(for: relationID), trigger: .localMutation)
+  }
+
+  public func graphQueryDidChange(_ queryID: GraphQueryID) async {
+    guard isAccountAuthorized else { return }
+    queueRecord(recordID(for: queryID), trigger: .localMutation)
+  }
+
   public func enqueueDirtyChanges() async {
     guard isAccountAuthorized, let engine else { return }
     do {
@@ -374,6 +390,8 @@ public actor CloudSyncCoordinator: CKSyncEngineDelegate {
     let purges = try await repository.dirtyPurgeMarkers()
     let views = try await repository.dirtyViews()
     let supertags = try await repository.dirtySupertags()
+    let relations = try await repository.dirtyRelationDefinitions()
+    let graphQueries = try await repository.dirtyGraphQueries()
     let pageChanges = pages.map {
       CKSyncEngine.PendingRecordZoneChange.saveRecord(recordID(for: $0.id))
     }
@@ -386,11 +404,18 @@ public actor CloudSyncCoordinator: CKSyncEngineDelegate {
     let supertagChanges = supertags.map {
       CKSyncEngine.PendingRecordZoneChange.saveRecord(recordID(for: $0.id))
     }
+    let relationChanges = relations.map {
+      CKSyncEngine.PendingRecordZoneChange.saveRecord(recordID(for: $0.definition.id))
+    }
+    let graphQueryChanges = graphQueries.map {
+      CKSyncEngine.PendingRecordZoneChange.saveRecord(recordID(for: $0.query.id))
+    }
     engine.state.add(
       pendingRecordZoneChanges: pageChanges + purgeChanges + viewChanges + supertagChanges
+        + relationChanges + graphQueryChanges
     )
     Self.logger.info(
-      "Queued local changes; pages=\(pages.count, privacy: .public), purges=\(purges.count, privacy: .public), views=\(views.count, privacy: .public), supertags=\(supertags.count, privacy: .public)"
+      "Queued local changes; pages=\(pages.count, privacy: .public), purges=\(purges.count, privacy: .public), views=\(views.count, privacy: .public), supertags=\(supertags.count, privacy: .public), relations=\(relations.count, privacy: .public), graphQueries=\(graphQueries.count, privacy: .public)"
     )
   }
 
@@ -502,6 +527,24 @@ public actor CloudSyncCoordinator: CKSyncEngineDelegate {
                   pendingRecordZoneChanges: [.saveRecord(deletion.recordID)]
                 )
               }
+            } else if deletion.recordID.recordName.hasPrefix(Self.graphRelationRecordPrefix) {
+              let shouldRetry = try await repository.applyCloudRelationDefinitionRecordDeletion(
+                id: relationID(for: deletion.recordID)
+              )
+              if shouldRetry {
+                syncEngine.state.add(
+                  pendingRecordZoneChanges: [.saveRecord(deletion.recordID)]
+                )
+              }
+            } else if deletion.recordID.recordName.hasPrefix(Self.graphQueryRecordPrefix) {
+              let shouldRetry = try await repository.applyCloudGraphQueryRecordDeletion(
+                id: graphQueryID(for: deletion.recordID)
+              )
+              if shouldRetry {
+                syncEngine.state.add(
+                  pendingRecordZoneChanges: [.saveRecord(deletion.recordID)]
+                )
+              }
             } else {
               let pageID = PageID(rawValue: deletion.recordID.recordName)
               let shouldRetry = try await repository.applyCloudPageRecordDeletion(pageID: pageID)
@@ -591,6 +634,20 @@ public actor CloudSyncCoordinator: CKSyncEngineDelegate {
               let generation = (record[Field.dirtyGeneration] as? NSNumber)?.int64Value ?? 0
               stillDirty = try await repository.markSupertagCloudSaved(
                 id: supertagID(for: record.recordID),
+                sentGeneration: generation,
+                systemFields: fields
+              )
+            } else if record.recordType == RecordType.graphRelation {
+              let generation = (record[Field.dirtyGeneration] as? NSNumber)?.int64Value ?? 0
+              stillDirty = try await repository.markRelationDefinitionCloudSaved(
+                id: relationID(for: record.recordID),
+                sentGeneration: generation,
+                systemFields: fields
+              )
+            } else if record.recordType == RecordType.graphQuery {
+              let generation = (record[Field.dirtyGeneration] as? NSNumber)?.int64Value ?? 0
+              stillDirty = try await repository.markGraphQueryCloudSaved(
+                id: graphQueryID(for: record.recordID),
                 sentGeneration: generation,
                 systemFields: fields
               )
@@ -797,6 +854,14 @@ public actor CloudSyncCoordinator: CKSyncEngineDelegate {
       shouldRetry = try await repository.applyCloudSupertagRecordDeletion(
         id: supertagID(for: recordID)
       )
+    } else if recordID.recordName.hasPrefix(Self.graphRelationRecordPrefix) {
+      shouldRetry = try await repository.applyCloudRelationDefinitionRecordDeletion(
+        id: relationID(for: recordID)
+      )
+    } else if recordID.recordName.hasPrefix(Self.graphQueryRecordPrefix) {
+      shouldRetry = try await repository.applyCloudGraphQueryRecordDeletion(
+        id: graphQueryID(for: recordID)
+      )
     } else {
       shouldRetry = try await repository.applyCloudPageRecordDeletion(
         pageID: PageID(rawValue: recordID.recordName)
@@ -917,6 +982,40 @@ public actor CloudSyncCoordinator: CKSyncEngineDelegate {
         record[Field.dirtyGeneration] = NSNumber(value: supertag.dirtyGeneration)
         return record
       }
+      if recordID.recordName.hasPrefix(Self.graphRelationRecordPrefix) {
+        let relationID = relationID(for: recordID)
+        guard let relation = try await repository.relationDefinitionCloudRecord(id: relationID)
+        else { return nil }
+        let record = try Self.record(
+          from: relation.cloudRecord,
+          recordType: RecordType.graphRelation,
+          recordID: recordID
+        )
+        record[Field.schemaVersion] = NSNumber(value: 1)
+        record[Field.definition] =
+          try JSONEncoder.enchiridion.encode(relation.definition) as NSData
+        record[Field.deleted] = NSNumber(value: relation.definition.isDeleted)
+        record[Field.modifiedAt] = relation.modifiedAt as NSDate
+        record[Field.dirtyGeneration] = NSNumber(value: relation.dirtyGeneration)
+        return record
+      }
+      if recordID.recordName.hasPrefix(Self.graphQueryRecordPrefix) {
+        let queryID = graphQueryID(for: recordID)
+        guard let query = try await repository.savedGraphQueryCloudRecord(id: queryID)
+        else { return nil }
+        let record = try Self.record(
+          from: query.cloudRecord,
+          recordType: RecordType.graphQuery,
+          recordID: recordID
+        )
+        record[Field.schemaVersion] = NSNumber(value: 1)
+        record[Field.definition] = try JSONEncoder.enchiridion.encode(query.query) as NSData
+        record[Field.deleted] = NSNumber(value: query.isDeleted)
+        record[Field.sortOrder] = NSNumber(value: query.sortOrder)
+        record[Field.modifiedAt] = query.modifiedAt as NSDate
+        record[Field.dirtyGeneration] = NSNumber(value: query.dirtyGeneration)
+        return record
+      }
       let pageID = PageID(rawValue: recordID.recordName)
       if let marker = try await repository.purgeMarker(pageID: pageID) {
         let record = try Self.record(from: marker.cloudRecord, recordType: RecordType.page, recordID: recordID)
@@ -1022,6 +1121,46 @@ public actor CloudSyncCoordinator: CKSyncEngineDelegate {
       }
       return
     }
+    if record.recordType == RecordType.graphRelation {
+      guard let definitionData = record[Field.definition] as? Data else {
+        throw LibraryRepositoryError.invalidRecord
+      }
+      let definition = try JSONDecoder.enchiridion.decode(
+        RelationDefinition.self,
+        from: definitionData
+      )
+      let needsUpload = try await repository.mergeCloudRelationDefinition(
+        id: relationID(for: record.recordID),
+        definition: definition,
+        isDeleted: (record[Field.deleted] as? NSNumber)?.boolValue ?? false,
+        modifiedAt: record[Field.modifiedAt] as? Date ?? record.modificationDate ?? Date(),
+        dirtyGeneration: (record[Field.dirtyGeneration] as? NSNumber)?.int64Value ?? 0,
+        systemFields: try Self.systemFields(for: record)
+      )
+      if needsUpload {
+        engine?.state.add(pendingRecordZoneChanges: [.saveRecord(record.recordID)])
+      }
+      return
+    }
+    if record.recordType == RecordType.graphQuery {
+      guard let definitionData = record[Field.definition] as? Data else {
+        throw LibraryRepositoryError.invalidRecord
+      }
+      let query = try JSONDecoder.enchiridion.decode(SavedGraphQuery.self, from: definitionData)
+      let needsUpload = try await repository.mergeCloudGraphQuery(
+        id: graphQueryID(for: record.recordID),
+        query: query,
+        isDeleted: (record[Field.deleted] as? NSNumber)?.boolValue ?? false,
+        sortOrder: (record[Field.sortOrder] as? NSNumber)?.intValue ?? 999,
+        modifiedAt: record[Field.modifiedAt] as? Date ?? record.modificationDate ?? Date(),
+        dirtyGeneration: (record[Field.dirtyGeneration] as? NSNumber)?.int64Value ?? 0,
+        systemFields: try Self.systemFields(for: record)
+      )
+      if needsUpload {
+        engine?.state.add(pendingRecordZoneChanges: [.saveRecord(record.recordID)])
+      }
+      return
+    }
     guard record.recordType == RecordType.page else { return }
     let pageID = PageID(rawValue: record.recordID.recordName)
     let systemFields = try Self.systemFields(for: record)
@@ -1073,6 +1212,17 @@ public actor CloudSyncCoordinator: CKSyncEngineDelegate {
     CKRecord.ID(recordName: Self.supertagRecordPrefix + supertagID.rawValue, zoneID: zoneID)
   }
 
+  private func recordID(for relationID: RelationID) -> CKRecord.ID {
+    CKRecord.ID(
+      recordName: Self.graphRelationRecordPrefix + relationID.rawValue,
+      zoneID: zoneID
+    )
+  }
+
+  private func recordID(for queryID: GraphQueryID) -> CKRecord.ID {
+    CKRecord.ID(recordName: Self.graphQueryRecordPrefix + queryID.rawValue, zoneID: zoneID)
+  }
+
   private func viewID(for recordID: CKRecord.ID) -> LiveQueryID {
     .init(rawValue: String(recordID.recordName.dropFirst(Self.viewRecordPrefix.count)))
   }
@@ -1081,8 +1231,18 @@ public actor CloudSyncCoordinator: CKSyncEngineDelegate {
     .init(rawValue: String(recordID.recordName.dropFirst(Self.supertagRecordPrefix.count)))
   }
 
+  private func relationID(for recordID: CKRecord.ID) -> RelationID {
+    .init(rawValue: String(recordID.recordName.dropFirst(Self.graphRelationRecordPrefix.count)))
+  }
+
+  private func graphQueryID(for recordID: CKRecord.ID) -> GraphQueryID {
+    .init(rawValue: String(recordID.recordName.dropFirst(Self.graphQueryRecordPrefix.count)))
+  }
+
   private static let viewRecordPrefix = "saved-view:"
   private static let supertagRecordPrefix = "supertag:"
+  private static let graphRelationRecordPrefix = "graph-relation:"
+  private static let graphQueryRecordPrefix = "graph-query:"
 
   private func cleanupAsset(for record: CKRecord) {
     let recordID = record.recordID
@@ -1107,6 +1267,16 @@ public actor CloudSyncCoordinator: CKSyncEngineDelegate {
     }
     if record.recordType == RecordType.supertag {
       try await repository.clearSupertagCloudRecordMetadata(id: supertagID(for: record.recordID))
+      return
+    }
+    if record.recordType == RecordType.graphRelation {
+      try await repository.clearRelationDefinitionCloudRecordMetadata(
+        id: relationID(for: record.recordID)
+      )
+      return
+    }
+    if record.recordType == RecordType.graphQuery {
+      try await repository.clearGraphQueryCloudRecordMetadata(id: graphQueryID(for: record.recordID))
       return
     }
     guard record.recordType == RecordType.page else { return }
@@ -1141,11 +1311,15 @@ public actor CloudSyncCoordinator: CKSyncEngineDelegate {
       let dirtyPurges = try await repository.dirtyPurgeMarkers()
       let dirtyViews = try await repository.dirtyViews()
       let dirtySupertags = try await repository.dirtySupertags()
+      let dirtyRelations = try await repository.dirtyRelationDefinitions()
+      let dirtyGraphQueries = try await repository.dirtyGraphQueries()
       let hasRepositoryChanges =
         !dirtyPages.isEmpty
         || !dirtyPurges.isEmpty
         || !dirtyViews.isEmpty
         || !dirtySupertags.isEmpty
+        || !dirtyRelations.isEmpty
+        || !dirtyGraphQueries.isEmpty
       if hasRepositoryChanges {
         statusHandler(
           .attentionRequired(
@@ -1283,4 +1457,6 @@ private enum RecordType {
   static let page = "Page"
   static let savedView = "SavedView"
   static let supertag = "Supertag"
+  static let graphRelation = "GraphRelation"
+  static let graphQuery = "GraphQuery"
 }

--- a/apps/enchiridion/Sources/EnchiridionCore/GraphDatabase.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/GraphDatabase.swift
@@ -14,6 +14,10 @@ enum GraphDatabaseSchema {
       table.column("is_deleted", .boolean).notNull().defaults(to: false)
       table.column("definition_json", .blob).notNull()
       table.column("modified_at", .double).notNull()
+      table.column("dirty_generation", .integer).notNull().defaults(to: 1)
+      table.column("cloud_dirty", .boolean).notNull().defaults(to: true).indexed()
+      table.column("cloud_synced_generation", .integer).notNull().defaults(to: 0)
+      table.column("cloud_record", .blob)
     }
     try db.create(table: "_graph_relation_source_tags") { table in
       table.column("relation_id", .text).notNull()
@@ -238,8 +242,8 @@ enum GraphDatabaseSchema {
       sql: """
         INSERT INTO _graph_relation_definitions
           (id,forward_name,inverse_name,targets_per_source,sources_per_target,
-           is_system,is_deleted,definition_json,modified_at)
-        VALUES (?,?,?,?,?,?,?,?,?)
+           is_system,is_deleted,definition_json,modified_at,dirty_generation,cloud_dirty)
+        VALUES (?,?,?,?,?,?,?,?,?,1,?)
         ON CONFLICT(id) DO UPDATE SET
           forward_name=excluded.forward_name,
           inverse_name=excluded.inverse_name,
@@ -248,7 +252,9 @@ enum GraphDatabaseSchema {
           is_system=excluded.is_system,
           is_deleted=excluded.is_deleted,
           definition_json=excluded.definition_json,
-          modified_at=excluded.modified_at
+          modified_at=excluded.modified_at,
+          dirty_generation=_graph_relation_definitions.dirty_generation + 1,
+          cloud_dirty=excluded.cloud_dirty
         """,
       arguments: [
         relation.id.rawValue,
@@ -260,6 +266,7 @@ enum GraphDatabaseSchema {
         relation.isDeleted,
         encoded,
         modifiedAt.timeIntervalSince1970,
+        !relation.isSystem,
       ]
     )
     try db.execute(

--- a/apps/enchiridion/Sources/EnchiridionCore/GraphDatabase.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/GraphDatabase.swift
@@ -480,20 +480,37 @@ enum GraphProjectionStore {
           }
         }
       }
-      guard !relation.targetTagIDs.isEmpty else { continue }
-      for edge in relationEdges where existingNodes.contains(edge.targetNodeID.rawValue) {
-        let targetTags = Set(try String.fetchAll(
-          db,
-          sql: "SELECT tag_id FROM graph_node_tags WHERE node_id = ?",
-          arguments: [edge.targetNodeID.rawValue]
-        ).map(TagID.init(rawValue:)))
-        guard targetTags.isDisjoint(with: relation.targetTagIDs) else { continue }
-        try insertIssue(
-          kind: .invalidTargetType,
-          edge: edge,
-          message: "The target does not have a type allowed by \(relation.forwardName).",
-          in: db
-        )
+      if !relation.sourceTagIDs.isEmpty {
+        for edge in relationEdges where existingNodes.contains(edge.sourceNodeID.rawValue) {
+          let sourceTags = Set(try String.fetchAll(
+            db,
+            sql: "SELECT tag_id FROM graph_node_tags WHERE node_id = ?",
+            arguments: [edge.sourceNodeID.rawValue]
+          ).map(TagID.init(rawValue:)))
+          guard sourceTags.isDisjoint(with: relation.sourceTagIDs) else { continue }
+          try insertIssue(
+            kind: .invalidSourceType,
+            edge: edge,
+            message: "The source does not have a type allowed by \(relation.forwardName).",
+            in: db
+          )
+        }
+      }
+      if !relation.targetTagIDs.isEmpty {
+        for edge in relationEdges where existingNodes.contains(edge.targetNodeID.rawValue) {
+          let targetTags = Set(try String.fetchAll(
+            db,
+            sql: "SELECT tag_id FROM graph_node_tags WHERE node_id = ?",
+            arguments: [edge.targetNodeID.rawValue]
+          ).map(TagID.init(rawValue:)))
+          guard targetTags.isDisjoint(with: relation.targetTagIDs) else { continue }
+          try insertIssue(
+            kind: .invalidTargetType,
+            edge: edge,
+            message: "The target does not have a type allowed by \(relation.forwardName).",
+            in: db
+          )
+        }
       }
     }
   }

--- a/apps/enchiridion/Sources/EnchiridionCore/GraphDatabase.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/GraphDatabase.swift
@@ -1,0 +1,667 @@
+import CryptoKit
+import Foundation
+import GRDB
+
+enum GraphDatabaseSchema {
+  static func install(in db: Database) throws {
+    try db.create(table: "_graph_relation_definitions") { table in
+      table.column("id", .text).primaryKey()
+      table.column("forward_name", .text).notNull()
+      table.column("inverse_name", .text).notNull()
+      table.column("targets_per_source", .text).notNull()
+      table.column("sources_per_target", .text).notNull()
+      table.column("is_system", .boolean).notNull().defaults(to: false)
+      table.column("is_deleted", .boolean).notNull().defaults(to: false)
+      table.column("definition_json", .blob).notNull()
+      table.column("modified_at", .double).notNull()
+    }
+    try db.create(table: "_graph_relation_source_tags") { table in
+      table.column("relation_id", .text).notNull()
+        .references("_graph_relation_definitions", onDelete: .cascade)
+      table.column("tag_id", .text).notNull()
+      table.primaryKey(["relation_id", "tag_id"])
+    }
+    try db.create(table: "_graph_relation_target_tags") { table in
+      table.column("relation_id", .text).notNull()
+        .references("_graph_relation_definitions", onDelete: .cascade)
+      table.column("tag_id", .text).notNull()
+      table.primaryKey(["relation_id", "tag_id"])
+    }
+    try db.create(table: "_graph_tag_parents") { table in
+      table.column("tag_id", .text).notNull()
+      table.column("parent_tag_id", .text).notNull()
+      table.primaryKey(["tag_id", "parent_tag_id"])
+    }
+    try db.create(table: "_graph_tag_closure") { table in
+      table.column("descendant_tag_id", .text).notNull()
+      table.column("ancestor_tag_id", .text).notNull()
+      table.column("depth", .integer).notNull()
+      table.primaryKey(["descendant_tag_id", "ancestor_tag_id"])
+    }
+    try db.create(
+      index: "_graph_tag_closure_on_ancestor",
+      on: "_graph_tag_closure",
+      columns: ["ancestor_tag_id", "descendant_tag_id"]
+    )
+    try db.create(table: "_graph_facts") { table in
+      table.column("fact_id", .text).primaryKey()
+      table.column("node_id", .text).notNull().indexed()
+        .references("pages", onDelete: .cascade)
+      table.column("predicate_id", .text).notNull().indexed()
+      table.column("tag_id", .text).notNull().indexed()
+      table.column("field_id", .text).notNull().indexed()
+      table.column("value_index", .integer).notNull()
+      table.column("value_type", .text).notNull()
+      table.column("text_value", .text)
+      table.column("number_value", .double)
+      table.column("boolean_value", .boolean)
+      table.column("local_date_value", .text)
+      table.column("date_time_value", .double)
+      table.column("origin", .text).notNull()
+      table.column("created_at", .double).notNull()
+    }
+    try db.create(table: "_graph_edges") { table in
+      table.column("edge_id", .text).primaryKey()
+      table.column("relation_id", .text).notNull().indexed()
+      table.column("source_node_id", .text).notNull().indexed()
+        .references("pages", onDelete: .cascade)
+      // Deliberately no target foreign key. A source-owned CRDT edge survives target purge and is
+      // surfaced as an unresolved issue until the user removes or repairs it.
+      table.column("target_node_id", .text).notNull().indexed()
+      table.column("origin", .text).notNull()
+      table.column("created_at", .double).notNull()
+    }
+    try db.create(
+      index: "_graph_edges_on_relation_source",
+      on: "_graph_edges",
+      columns: ["relation_id", "source_node_id"]
+    )
+    try db.create(
+      index: "_graph_edges_on_relation_target",
+      on: "_graph_edges",
+      columns: ["relation_id", "target_node_id"]
+    )
+    try db.create(table: "_graph_issues") { table in
+      table.column("issue_id", .text).primaryKey()
+      table.column("kind", .text).notNull().indexed()
+      table.column("node_id", .text).notNull().indexed()
+      table.column("edge_id", .text).indexed()
+      table.column("relation_id", .text).indexed()
+      table.column("message", .text).notNull()
+      table.column("created_at", .double).notNull()
+    }
+    try db.create(table: "_saved_graph_queries") { table in
+      table.column("id", .text).primaryKey()
+      table.column("name", .text).notNull()
+      table.column("source_kind", .text).notNull()
+      table.column("builder_json", .blob)
+      table.column("sql_text", .text)
+      table.column("presentation_json", .blob).notNull()
+      table.column("modified_at", .double).notNull()
+      table.column("sort_order", .integer).notNull().defaults(to: 999)
+      table.column("deleted", .boolean).notNull().defaults(to: false)
+      table.column("dirty_generation", .integer).notNull().defaults(to: 1)
+      table.column("cloud_dirty", .boolean).notNull().defaults(to: true)
+      table.column("cloud_synced_generation", .integer).notNull().defaults(to: 0)
+      table.column("cloud_record", .blob)
+    }
+    try db.execute(
+      sql: "CREATE VIRTUAL TABLE graph_text_search USING fts5(node_id UNINDEXED, title, body)"
+    )
+    try db.execute(sql: """
+      CREATE TRIGGER _graph_pages_after_delete
+      AFTER DELETE ON pages
+      BEGIN
+        DELETE FROM graph_text_search WHERE node_id = OLD.id;
+      END
+      """)
+
+    try createPublicViews(in: db)
+    for relation in BuiltInRelations.all {
+      try saveRelation(relation, in: db, modifiedAt: Date(timeIntervalSince1970: 0))
+    }
+    try rebuildTagClosure(in: db)
+
+    for row in try Row.fetchAll(db, sql: "SELECT * FROM pages") {
+      let page = try LibraryRepository.decodePage(row)
+      try GraphProjectionStore.replacePage(page, references: nil, in: db)
+    }
+    try GraphProjectionStore.refreshIssues(in: db)
+  }
+
+  static func createPublicViews(in db: Database) throws {
+    try db.execute(sql: """
+      CREATE VIEW graph_nodes AS
+      SELECT id AS node_id,
+             title,
+             plain_text,
+             kind_tag AS kind,
+             created_at,
+             modified_at,
+             deleted_at,
+             is_pinned
+      FROM pages
+      WHERE id IS NOT NULL
+      """)
+    try db.execute(sql: """
+      CREATE VIEW graph_tags AS
+      SELECT id AS tag_id,
+             name,
+             sort_order,
+             deleted,
+             CASE WHEN id IN ('person','organization','company','event','place','area','project','task')
+               THEN 1 ELSE 0 END AS is_base
+      FROM supertag_schemas
+      WHERE id IS NOT NULL
+      """)
+    try db.execute(sql: """
+      CREATE VIEW graph_tag_parents AS
+      SELECT tag_id, parent_tag_id FROM _graph_tag_parents WHERE tag_id IS NOT NULL
+      """)
+    try db.execute(sql: """
+      CREATE VIEW graph_tag_closure AS
+      SELECT descendant_tag_id, ancestor_tag_id, depth
+      FROM _graph_tag_closure
+      WHERE descendant_tag_id IS NOT NULL
+      """)
+    try db.execute(sql: """
+      CREATE VIEW graph_node_tags AS
+      SELECT direct.page_id AS node_id,
+             closure.ancestor_tag_id AS tag_id,
+             MIN(closure.depth) AS depth,
+             MAX(CASE WHEN closure.depth = 0 THEN 1 ELSE 0 END) AS direct
+      FROM page_supertags direct
+      JOIN _graph_tag_closure closure
+        ON closure.descendant_tag_id = direct.supertag_id
+      GROUP BY direct.page_id, closure.ancestor_tag_id
+      """)
+    try db.execute(sql: """
+      CREATE VIEW graph_facts AS
+      SELECT fact_id, node_id, predicate_id, tag_id, field_id, value_index,
+             value_type, text_value, number_value, boolean_value,
+             local_date_value, date_time_value, origin, created_at
+      FROM _graph_facts
+      WHERE fact_id IS NOT NULL
+      """)
+    try db.execute(sql: """
+      CREATE VIEW graph_relation_definitions AS
+      SELECT id AS relation_id, forward_name, inverse_name,
+             targets_per_source, sources_per_target, is_system
+      FROM _graph_relation_definitions
+      WHERE is_deleted = 0
+      """)
+    try db.execute(sql: """
+      CREATE VIEW graph_edges AS
+      SELECT edge.edge_id,
+             edge.source_node_id AS from_node_id,
+             edge.target_node_id AS to_node_id,
+             edge.relation_id,
+             relation.forward_name AS relationship_name,
+             'forward' AS direction,
+             edge.source_node_id AS canonical_source_node_id,
+             edge.target_node_id AS canonical_target_node_id,
+             edge.origin,
+             edge.created_at
+      FROM _graph_edges edge
+      JOIN _graph_relation_definitions relation ON relation.id = edge.relation_id
+      WHERE relation.is_deleted = 0
+      UNION ALL
+      SELECT edge.edge_id,
+             edge.target_node_id AS from_node_id,
+             edge.source_node_id AS to_node_id,
+             edge.relation_id,
+             relation.inverse_name AS relationship_name,
+             'inverse' AS direction,
+             edge.source_node_id AS canonical_source_node_id,
+             edge.target_node_id AS canonical_target_node_id,
+             edge.origin,
+             edge.created_at
+      FROM _graph_edges edge
+      JOIN _graph_relation_definitions relation ON relation.id = edge.relation_id
+      WHERE relation.is_deleted = 0
+      """)
+    try db.execute(sql: """
+      CREATE VIEW graph_issues AS
+      SELECT issue_id, kind, node_id, edge_id, relation_id, message, created_at
+      FROM _graph_issues
+      WHERE issue_id IS NOT NULL
+      """)
+  }
+
+  static func saveRelation(
+    _ relation: RelationDefinition,
+    in db: Database,
+    modifiedAt: Date = Date()
+  ) throws {
+    let encoded = try JSONEncoder.enchiridion.encode(relation)
+    try db.execute(
+      sql: """
+        INSERT INTO _graph_relation_definitions
+          (id,forward_name,inverse_name,targets_per_source,sources_per_target,
+           is_system,is_deleted,definition_json,modified_at)
+        VALUES (?,?,?,?,?,?,?,?,?)
+        ON CONFLICT(id) DO UPDATE SET
+          forward_name=excluded.forward_name,
+          inverse_name=excluded.inverse_name,
+          targets_per_source=excluded.targets_per_source,
+          sources_per_target=excluded.sources_per_target,
+          is_system=excluded.is_system,
+          is_deleted=excluded.is_deleted,
+          definition_json=excluded.definition_json,
+          modified_at=excluded.modified_at
+        """,
+      arguments: [
+        relation.id.rawValue,
+        relation.forwardName,
+        relation.inverseName,
+        relation.cardinality.targetsPerSource.rawValue,
+        relation.cardinality.sourcesPerTarget.rawValue,
+        relation.isSystem,
+        relation.isDeleted,
+        encoded,
+        modifiedAt.timeIntervalSince1970,
+      ]
+    )
+    try db.execute(
+      sql: "DELETE FROM _graph_relation_source_tags WHERE relation_id = ?",
+      arguments: [relation.id.rawValue]
+    )
+    try db.execute(
+      sql: "DELETE FROM _graph_relation_target_tags WHERE relation_id = ?",
+      arguments: [relation.id.rawValue]
+    )
+    for tagID in relation.sourceTagIDs {
+      try db.execute(
+        sql: "INSERT INTO _graph_relation_source_tags (relation_id,tag_id) VALUES (?,?)",
+        arguments: [relation.id.rawValue, tagID.rawValue]
+      )
+    }
+    for tagID in relation.targetTagIDs {
+      try db.execute(
+        sql: "INSERT INTO _graph_relation_target_tags (relation_id,tag_id) VALUES (?,?)",
+        arguments: [relation.id.rawValue, tagID.rawValue]
+      )
+    }
+  }
+
+  static func rebuildTagClosure(in db: Database) throws {
+    let definitions: [SupertagDefinition] = try Row.fetchAll(
+      db,
+      sql: "SELECT definition_json FROM supertag_schemas WHERE deleted = 0"
+    ).compactMap { row in
+      guard let data: Data = row["definition_json"] else { return nil }
+      return try? JSONDecoder.enchiridion.decode(SupertagDefinition.self, from: data)
+    }
+    let byID = Dictionary(uniqueKeysWithValues: definitions.map { ($0.id, $0) })
+    var closure: [TagID: [TagID: Int]] = [:]
+
+    func ancestors(of id: TagID, path: [TagID]) throws -> [TagID: Int] {
+      if let cached = closure[id] { return cached }
+      guard let definition = byID[id] else { throw GraphModelError.unknownTag(id) }
+      guard !path.contains(id) else { throw GraphModelError.inheritanceCycle(path + [id]) }
+      var result: [TagID: Int] = [id: 0]
+      for parentID in definition.parentIDs {
+        for (ancestorID, parentDepth) in try ancestors(of: parentID, path: path + [id]) {
+          result[ancestorID] = min(result[ancestorID] ?? .max, parentDepth + 1)
+        }
+      }
+      closure[id] = result
+      return result
+    }
+
+    for id in byID.keys { _ = try ancestors(of: id, path: []) }
+    try db.execute(sql: "DELETE FROM _graph_tag_parents")
+    try db.execute(sql: "DELETE FROM _graph_tag_closure")
+    for definition in definitions {
+      for parentID in definition.parentIDs {
+        try db.execute(
+          sql: "INSERT INTO _graph_tag_parents (tag_id,parent_tag_id) VALUES (?,?)",
+          arguments: [definition.id.rawValue, parentID.rawValue]
+        )
+      }
+      for (ancestorID, depth) in closure[definition.id] ?? [:] {
+        try db.execute(
+          sql: "INSERT INTO _graph_tag_closure (descendant_tag_id,ancestor_tag_id,depth) VALUES (?,?,?)",
+          arguments: [definition.id.rawValue, ancestorID.rawValue, depth]
+        )
+      }
+    }
+  }
+}
+
+enum GraphProjectionStore {
+  static func replacePage(
+    _ page: PageSnapshot,
+    references: [PageReference]?,
+    in db: Database
+  ) throws {
+    let projection = try? PageDocument.inspect(page.document, pageID: page.id)
+    try db.execute(sql: "DELETE FROM _graph_facts WHERE node_id = ?", arguments: [page.id.rawValue])
+    try db.execute(
+      sql: "DELETE FROM _graph_edges WHERE source_node_id = ? AND origin <> ?",
+      arguments: [page.id.rawValue, GraphEdgeOrigin.inlineReference.rawValue]
+    )
+    var explicitTuples: Set<String> = []
+    for edge in projection?.graphEdges ?? [] {
+      try insert(edge: edge, in: db)
+      explicitTuples.insert(tuple(edge.relationID, edge.targetNodeID))
+    }
+    for (key, values) in page.objectMetadata.properties {
+      for (index, value) in values.enumerated() {
+        switch value {
+        case .page(let targetID):
+          let relationID = BuiltInRelations.relationID(for: key)
+          guard !explicitTuples.contains(tuple(relationID, targetID)) else { continue }
+          let edge = KnowledgeEdge(
+            id: deterministicEdgeID(
+              source: page.id,
+              relation: relationID,
+              target: targetID,
+              ordinal: index
+            ),
+            relationID: relationID,
+            sourceNodeID: page.id,
+            targetNodeID: targetID,
+            createdAt: page.createdAt
+          )
+          try insert(edge: edge, in: db)
+        default:
+          try insert(
+            fact: fact(
+              nodeID: page.id,
+              key: key,
+              value: value,
+              index: index,
+              createdAt: page.createdAt
+            ),
+            key: key,
+            index: index,
+            in: db
+          )
+        }
+      }
+    }
+    if let references { try replaceMentions(from: page.id, references: references, in: db) }
+    try db.execute(sql: "DELETE FROM graph_text_search WHERE node_id = ?", arguments: [page.id.rawValue])
+    if page.deletedAt == nil {
+      try db.execute(
+        sql: "INSERT INTO graph_text_search (node_id,title,body) VALUES (?,?,?)",
+        arguments: [page.id.rawValue, page.title, page.plainText]
+      )
+    }
+  }
+
+  static func replaceMentions(
+    from sourceID: NodeID,
+    references: [PageReference],
+    in db: Database
+  ) throws {
+    try db.execute(
+      sql: "DELETE FROM _graph_edges WHERE source_node_id = ? AND origin = ?",
+      arguments: [sourceID.rawValue, GraphEdgeOrigin.inlineReference.rawValue]
+    )
+    for (index, reference) in references.enumerated() {
+      try insert(
+        edge: .init(
+          id: deterministicEdgeID(
+            source: sourceID,
+            relation: BuiltInRelations.mentions,
+            target: reference.targetPageID,
+            ordinal: index
+          ),
+          relationID: BuiltInRelations.mentions,
+          sourceNodeID: sourceID,
+          targetNodeID: reference.targetPageID,
+          origin: .inlineReference
+        ),
+        in: db
+      )
+    }
+  }
+
+  static func refreshIssues(in db: Database) throws {
+    try db.execute(sql: "DELETE FROM _graph_issues")
+    let edges: [KnowledgeEdge] = try Row.fetchAll(db, sql: "SELECT * FROM _graph_edges")
+      .compactMap(decodeEdge)
+    let relations: [RelationID: RelationDefinition] = Dictionary(uniqueKeysWithValues:
+      try Row.fetchAll(
+        db,
+        sql: "SELECT definition_json FROM _graph_relation_definitions WHERE is_deleted = 0"
+      ).compactMap { row -> (RelationID, RelationDefinition)? in
+        guard let data: Data = row["definition_json"],
+          let definition = try? JSONDecoder.enchiridion.decode(RelationDefinition.self, from: data)
+        else { return nil }
+        return (definition.id, definition)
+      }
+    )
+    let existingNodes = Set(try String.fetchAll(db, sql: "SELECT id FROM pages WHERE deleted_at IS NULL"))
+
+    for edge in edges where !existingNodes.contains(edge.targetNodeID.rawValue) {
+      try insertIssue(
+        kind: .unresolvedTarget,
+        edge: edge,
+        message: "The relationship target is unavailable.",
+        in: db
+      )
+    }
+
+    for (relationID, relation) in relations {
+      let relationEdges = edges.filter { $0.relationID == relationID }
+      if relation.cardinality.targetsPerSource == .one {
+        for (_, conflicts) in Dictionary(grouping: relationEdges, by: \KnowledgeEdge.sourceNodeID)
+        where Set(conflicts.map(\.targetNodeID)).count > 1 {
+          for edge in conflicts {
+            try insertIssue(
+              kind: .cardinalityViolation,
+              edge: edge,
+              message: "\(relation.forwardName.capitalized) allows one target; choose which relationship to keep.",
+              in: db
+            )
+          }
+        }
+      }
+      if relation.cardinality.sourcesPerTarget == .one {
+        for (_, conflicts) in Dictionary(grouping: relationEdges, by: \KnowledgeEdge.targetNodeID)
+        where Set(conflicts.map(\.sourceNodeID)).count > 1 {
+          for edge in conflicts {
+            try insertIssue(
+              kind: .cardinalityViolation,
+              edge: edge,
+              message: "\(relation.inverseName.capitalized) allows one source; choose which relationship to keep.",
+              in: db
+            )
+          }
+        }
+      }
+      guard !relation.targetTagIDs.isEmpty else { continue }
+      for edge in relationEdges where existingNodes.contains(edge.targetNodeID.rawValue) {
+        let targetTags = Set(try String.fetchAll(
+          db,
+          sql: "SELECT tag_id FROM graph_node_tags WHERE node_id = ?",
+          arguments: [edge.targetNodeID.rawValue]
+        ).map(TagID.init(rawValue:)))
+        guard targetTags.isDisjoint(with: relation.targetTagIDs) else { continue }
+        try insertIssue(
+          kind: .invalidTargetType,
+          edge: edge,
+          message: "The target does not have a type allowed by \(relation.forwardName).",
+          in: db
+        )
+      }
+    }
+  }
+
+  private static func fact(
+    nodeID: NodeID,
+    key: SupertagPropertyKey,
+    value: SupertagValue,
+    index: Int,
+    createdAt: Date
+  ) -> KnowledgeFact {
+    let graphValue: GraphFactValue
+    switch value {
+    case .text(let value): graphValue = .text(value)
+    case .number(let value): graphValue = .number(value)
+    case .boolean(let value): graphValue = .boolean(value)
+    case .date(let value): graphValue = .localDate(.init(date: value))
+    case .dateTime(let value): graphValue = .dateTime(value)
+    case .select(let value): graphValue = .select(value)
+    case .url(let value): graphValue = .url(value)
+    case .email(let value): graphValue = .email(value)
+    case .phone(let value): graphValue = .phone(value)
+    case .page: preconditionFailure("References are projected as edges")
+    }
+    let predicate = PredicateID.property(tagID: key.supertagID, fieldID: key.fieldID)
+    return .init(
+      id: .init(rawValue: "fact_\(digest("\(nodeID.rawValue)|\(predicate.rawValue)|\(index)|\(value.id)"))"),
+      nodeID: nodeID,
+      predicateID: predicate,
+      value: graphValue,
+      createdAt: createdAt
+    )
+  }
+
+  private static func insert(
+    fact: KnowledgeFact,
+    key: SupertagPropertyKey,
+    index: Int,
+    in db: Database
+  ) throws {
+    var text: String?
+    var number: Double?
+    var boolean: Bool?
+    var localDate: String?
+    var dateTime: Double?
+    switch fact.value {
+    case .text(let value), .select(let value), .url(let value), .email(let value),
+      .phone(let value): text = value
+    case .number(let value): number = value
+    case .boolean(let value): boolean = value
+    case .localDate(let value): localDate = value.rawValue
+    case .dateTime(let value): dateTime = value.timeIntervalSince1970
+    }
+    try db.execute(
+      sql: """
+        INSERT OR REPLACE INTO _graph_facts
+          (fact_id,node_id,predicate_id,tag_id,field_id,value_index,value_type,
+           text_value,number_value,boolean_value,local_date_value,date_time_value,origin,created_at)
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+        """,
+      arguments: [
+        fact.id.rawValue,
+        fact.nodeID.rawValue,
+        fact.predicateID.rawValue,
+        key.supertagID.rawValue,
+        key.fieldID.rawValue,
+        index,
+        fact.value.type.rawValue,
+        text,
+        number,
+        boolean,
+        localDate,
+        dateTime,
+        fact.origin.rawValue,
+        fact.createdAt.timeIntervalSince1970,
+      ]
+    )
+  }
+
+  private static func insert(edge: KnowledgeEdge, in db: Database) throws {
+    try db.execute(
+      sql: """
+        INSERT OR REPLACE INTO _graph_edges
+          (edge_id,relation_id,source_node_id,target_node_id,origin,created_at)
+        VALUES (?,?,?,?,?,?)
+        """,
+      arguments: [
+        edge.id.rawValue,
+        edge.relationID.rawValue,
+        edge.sourceNodeID.rawValue,
+        edge.targetNodeID.rawValue,
+        edge.origin.rawValue,
+        edge.createdAt.timeIntervalSince1970,
+      ]
+    )
+  }
+
+  private static func insertIssue(
+    kind: GraphIssueKind,
+    edge: KnowledgeEdge,
+    message: String,
+    in db: Database
+  ) throws {
+    let id = "issue_\(digest("\(kind.rawValue)|\(edge.id.rawValue)"))"
+    try db.execute(
+      sql: """
+        INSERT OR IGNORE INTO _graph_issues
+          (issue_id,kind,node_id,edge_id,relation_id,message,created_at)
+        VALUES (?,?,?,?,?,?,?)
+        """,
+      arguments: [
+        id,
+        kind.rawValue,
+        edge.sourceNodeID.rawValue,
+        edge.id.rawValue,
+        edge.relationID.rawValue,
+        message,
+        Date().timeIntervalSince1970,
+      ]
+    )
+  }
+
+  private static func decodeEdge(_ row: Row) -> KnowledgeEdge? {
+    guard let edgeID: String = row["edge_id"],
+      let relationID: String = row["relation_id"],
+      let sourceID: String = row["source_node_id"],
+      let targetID: String = row["target_node_id"],
+      let originRaw: String = row["origin"],
+      let origin = GraphEdgeOrigin(rawValue: originRaw),
+      let createdAt: Double = row["created_at"]
+    else { return nil }
+    return .init(
+      id: .init(rawValue: edgeID),
+      relationID: .init(rawValue: relationID),
+      sourceNodeID: .init(rawValue: sourceID),
+      targetNodeID: .init(rawValue: targetID),
+      origin: origin,
+      createdAt: Date(timeIntervalSince1970: createdAt)
+    )
+  }
+
+  private static func tuple(_ relationID: RelationID, _ targetID: NodeID) -> String {
+    "\(relationID.rawValue)|\(targetID.rawValue)"
+  }
+
+  private static func deterministicEdgeID(
+    source: NodeID,
+    relation: RelationID,
+    target: NodeID,
+    ordinal: Int
+  ) -> EdgeID {
+    .init(rawValue: "edge_\(digest("\(source.rawValue)|\(relation.rawValue)|\(target.rawValue)|\(ordinal)"))")
+  }
+
+  private static func digest(_ value: String) -> String {
+    SHA256.hash(data: Data(value.utf8)).prefix(20).map { String(format: "%02x", $0) }.joined()
+  }
+}
+
+public enum GraphModelError: Error, LocalizedError, Equatable {
+  case inheritanceCycle([TagID])
+  case unknownTag(TagID)
+  case unknownRelation(RelationID)
+  case invalidEndpoint
+  case cardinalityViolation(RelationID)
+  case immutableSystemDefinition
+
+  public var errorDescription: String? {
+    switch self {
+    case .inheritanceCycle: "Tag inheritance must not contain a cycle."
+    case .unknownTag: "The tag is unavailable."
+    case .unknownRelation: "The relationship definition is unavailable."
+    case .invalidEndpoint: "The relationship endpoint is unavailable or has an incompatible type."
+    case .cardinalityViolation: "This relationship allows only one value."
+    case .immutableSystemDefinition: "System relationship definitions cannot be changed."
+    }
+  }
+}

--- a/apps/enchiridion/Sources/EnchiridionCore/GraphDatabase.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/GraphDatabase.swift
@@ -128,7 +128,25 @@ enum GraphDatabaseSchema {
 
     for row in try Row.fetchAll(db, sql: "SELECT * FROM pages") {
       let page = try LibraryRepository.decodePage(row)
-      try GraphProjectionStore.replacePage(page, references: nil, in: db)
+      let references = try Row.fetchAll(
+        db,
+        sql: """
+          SELECT target_page_id, fallback_label
+          FROM page_references
+          WHERE source_page_id = ?
+          """,
+        arguments: [page.id.rawValue]
+      ).compactMap { referenceRow -> PageReference? in
+        guard let targetID: String = referenceRow["target_page_id"],
+          let fallbackLabel: String = referenceRow["fallback_label"]
+        else { return nil }
+        return .init(
+          sourcePageID: page.id,
+          targetPageID: .init(rawValue: targetID),
+          fallbackLabel: fallbackLabel
+        )
+      }
+      try GraphProjectionStore.replacePage(page, references: references, in: db)
     }
     try GraphProjectionStore.refreshIssues(in: db)
   }
@@ -304,10 +322,10 @@ enum GraphDatabaseSchema {
 
     func ancestors(of id: TagID, path: [TagID]) throws -> [TagID: Int] {
       if let cached = closure[id] { return cached }
-      guard let definition = byID[id] else { throw GraphModelError.unknownTag(id) }
+      guard let definition = byID[id] else { return [:] }
       guard !path.contains(id) else { throw GraphModelError.inheritanceCycle(path + [id]) }
       var result: [TagID: Int] = [id: 0]
-      for parentID in definition.parentIDs {
+      for parentID in definition.parentIDs where byID[parentID] != nil {
         for (ancestorID, parentDepth) in try ancestors(of: parentID, path: path + [id]) {
           result[ancestorID] = min(result[ancestorID] ?? .max, parentDepth + 1)
         }
@@ -320,7 +338,7 @@ enum GraphDatabaseSchema {
     try db.execute(sql: "DELETE FROM _graph_tag_parents")
     try db.execute(sql: "DELETE FROM _graph_tag_closure")
     for definition in definitions {
-      for parentID in definition.parentIDs {
+      for parentID in definition.parentIDs where byID[parentID] != nil {
         try db.execute(
           sql: "INSERT INTO _graph_tag_parents (tag_id,parent_tag_id) VALUES (?,?)",
           arguments: [definition.id.rawValue, parentID.rawValue]
@@ -499,6 +517,7 @@ enum GraphProjectionStore {
   ) throws {
     let nodeIDs = Set(edges.flatMap { [$0.sourceNodeID.rawValue, $0.targetNodeID.rawValue] })
     let existingNodes: Set<String>
+    var tagsByNodeID: [String: Set<TagID>] = [:]
     if nodeIDs.isEmpty {
       existingNodes = []
     } else {
@@ -509,6 +528,20 @@ enum GraphProjectionStore {
         sql: "SELECT id FROM pages WHERE deleted_at IS NULL AND id IN (\(placeholders))",
         arguments: StatementArguments(rawIDs)
       ))
+      for row in try Row.fetchAll(
+        db,
+        sql: """
+          SELECT node_id, tag_id
+          FROM graph_node_tags
+          WHERE node_id IN (\(placeholders))
+          """,
+        arguments: StatementArguments(rawIDs)
+      ) {
+        guard let nodeID: String = row["node_id"],
+          let tagID: String = row["tag_id"]
+        else { continue }
+        tagsByNodeID[nodeID, default: []].insert(.init(rawValue: tagID))
+      }
     }
 
     for edge in edges where !existingNodes.contains(edge.targetNodeID.rawValue) {
@@ -550,11 +583,7 @@ enum GraphProjectionStore {
       }
       if !relation.sourceTagIDs.isEmpty {
         for edge in relationEdges where existingNodes.contains(edge.sourceNodeID.rawValue) {
-          let sourceTags = Set(try String.fetchAll(
-            db,
-            sql: "SELECT tag_id FROM graph_node_tags WHERE node_id = ?",
-            arguments: [edge.sourceNodeID.rawValue]
-          ).map(TagID.init(rawValue:)))
+          let sourceTags = tagsByNodeID[edge.sourceNodeID.rawValue] ?? []
           guard sourceTags.isDisjoint(with: relation.sourceTagIDs) else { continue }
           try insertIssue(
             kind: .invalidSourceType,
@@ -566,11 +595,7 @@ enum GraphProjectionStore {
       }
       if !relation.targetTagIDs.isEmpty {
         for edge in relationEdges where existingNodes.contains(edge.targetNodeID.rawValue) {
-          let targetTags = Set(try String.fetchAll(
-            db,
-            sql: "SELECT tag_id FROM graph_node_tags WHERE node_id = ?",
-            arguments: [edge.targetNodeID.rawValue]
-          ).map(TagID.init(rawValue:)))
+          let targetTags = tagsByNodeID[edge.targetNodeID.rawValue] ?? []
           guard targetTags.isDisjoint(with: relation.targetTagIDs) else { continue }
           try insertIssue(
             kind: .invalidTargetType,

--- a/apps/enchiridion/Sources/EnchiridionCore/GraphDatabase.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/GraphDatabase.swift
@@ -441,7 +441,75 @@ enum GraphProjectionStore {
         return (definition.id, definition)
       }
     )
-    let existingNodes = Set(try String.fetchAll(db, sql: "SELECT id FROM pages WHERE deleted_at IS NULL"))
+    try insertIssues(for: edges, relations: relations, in: db)
+  }
+
+  static func refreshIssues(
+    for relationIDs: Set<RelationID>,
+    in db: Database
+  ) throws {
+    guard !relationIDs.isEmpty else { return }
+    let rawIDs = relationIDs.map(\.rawValue).sorted()
+    let placeholders = Array(repeating: "?", count: rawIDs.count).joined(separator: ",")
+    let arguments = StatementArguments(rawIDs)
+    try db.execute(
+      sql: "DELETE FROM _graph_issues WHERE relation_id IN (\(placeholders))",
+      arguments: arguments
+    )
+    let edges = try Row.fetchAll(
+      db,
+      sql: "SELECT * FROM _graph_edges WHERE relation_id IN (\(placeholders))",
+      arguments: arguments
+    ).compactMap(decodeEdge)
+    let relations = Dictionary(uniqueKeysWithValues:
+      try Row.fetchAll(
+        db,
+        sql: """
+          SELECT definition_json
+          FROM _graph_relation_definitions
+          WHERE is_deleted = 0 AND id IN (\(placeholders))
+          """,
+        arguments: arguments
+      ).compactMap { row -> (RelationID, RelationDefinition)? in
+        guard let data: Data = row["definition_json"],
+          let definition = try? JSONDecoder.enchiridion.decode(RelationDefinition.self, from: data)
+        else { return nil }
+        return (definition.id, definition)
+      }
+    )
+    try insertIssues(for: edges, relations: relations, in: db)
+  }
+
+  static func relationIDs(touching nodeID: NodeID, in db: Database) throws -> Set<RelationID> {
+    Set(try String.fetchAll(
+      db,
+      sql: """
+        SELECT DISTINCT relation_id
+        FROM _graph_edges
+        WHERE source_node_id = ? OR target_node_id = ?
+        """,
+      arguments: [nodeID.rawValue, nodeID.rawValue]
+    ).map(RelationID.init(rawValue:)))
+  }
+
+  private static func insertIssues(
+    for edges: [KnowledgeEdge],
+    relations: [RelationID: RelationDefinition],
+    in db: Database
+  ) throws {
+    let nodeIDs = Set(edges.flatMap { [$0.sourceNodeID.rawValue, $0.targetNodeID.rawValue] })
+    let existingNodes: Set<String>
+    if nodeIDs.isEmpty {
+      existingNodes = []
+    } else {
+      let rawIDs = nodeIDs.sorted()
+      let placeholders = Array(repeating: "?", count: rawIDs.count).joined(separator: ",")
+      existingNodes = Set(try String.fetchAll(
+        db,
+        sql: "SELECT id FROM pages WHERE deleted_at IS NULL AND id IN (\(placeholders))",
+        arguments: StatementArguments(rawIDs)
+      ))
+    }
 
     for edge in edges where !existingNodes.contains(edge.targetNodeID.rawValue) {
       try insertIssue(

--- a/apps/enchiridion/Sources/EnchiridionCore/GraphIdentifiers.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/GraphIdentifiers.swift
@@ -13,8 +13,13 @@ public struct VaultID: RawRepresentable, Codable, Hashable, Sendable, Identifiab
     .init(rawValue: "vault_\(UUID().uuidString.lowercased())")
   }
 
+  /// Stable identity shared by fresh installations so the built-in graph uses one CloudKit zone.
+  public static let personal = Self(rawValue: "vault_personal")
+
   /// Identity used only by explicitly standalone repositories, such as isolated tests.
   public static let standalone = Self(rawValue: "vault_standalone")
+
+  public var cloudZoneName: String { "EnchiridionGraph-\(rawValue)" }
 }
 
 /// Nodes are the durable identities in an Enchiridion knowledge graph. PageID remains the

--- a/apps/enchiridion/Sources/EnchiridionCore/GraphIdentifiers.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/GraphIdentifiers.swift
@@ -19,7 +19,12 @@ public struct VaultID: RawRepresentable, Codable, Hashable, Sendable, Identifiab
   /// Identity used only by explicitly standalone repositories, such as isolated tests.
   public static let standalone = Self(rawValue: "vault_standalone")
 
-  public var cloudZoneName: String { "EnchiridionGraph-\(rawValue)" }
+  /// Existing installations already synchronize the built-in vault through this zone.
+  public static let personalCloudZoneName = "EnchiridionVault"
+
+  public var cloudZoneName: String {
+    self == .personal ? Self.personalCloudZoneName : "EnchiridionGraph-\(rawValue)"
+  }
 }
 
 /// Nodes are the durable identities in an Enchiridion knowledge graph. PageID remains the
@@ -88,7 +93,12 @@ public struct VaultScopedNodeID: Codable, Hashable, Sendable, Identifiable {
   }
 
   public init?(serialized: String) {
-    guard let separator = serialized.firstIndex(of: "/") else { return nil }
+    guard !serialized.isEmpty else { return nil }
+    guard let separator = serialized.firstIndex(of: "/") else {
+      // AppEntity identifiers created before vault support stored only the page identity.
+      self.init(vaultID: .personal, nodeID: .init(rawValue: serialized))
+      return
+    }
     let vault = String(serialized[..<separator])
     let node = String(serialized[serialized.index(after: separator)...])
     guard vault.hasPrefix("vault_"), !node.isEmpty else { return nil }

--- a/apps/enchiridion/Sources/EnchiridionCore/GraphIdentifiers.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/GraphIdentifiers.swift
@@ -12,6 +12,9 @@ public struct VaultID: RawRepresentable, Codable, Hashable, Sendable, Identifiab
   public static func random() -> Self {
     .init(rawValue: "vault_\(UUID().uuidString.lowercased())")
   }
+
+  /// Identity used only by explicitly standalone repositories, such as isolated tests.
+  public static let standalone = Self(rawValue: "vault_standalone")
 }
 
 /// Nodes are the durable identities in an Enchiridion knowledge graph. PageID remains the
@@ -77,6 +80,17 @@ public struct VaultScopedNodeID: Codable, Hashable, Sendable, Identifiable {
   public init(vaultID: VaultID, nodeID: NodeID) {
     self.vaultID = vaultID
     self.nodeID = nodeID
+  }
+
+  public init?(serialized: String) {
+    guard let separator = serialized.firstIndex(of: "/") else { return nil }
+    let vault = String(serialized[..<separator])
+    let node = String(serialized[serialized.index(after: separator)...])
+    guard vault.hasPrefix("vault_"), !node.isEmpty else { return nil }
+    self.init(
+      vaultID: .init(rawValue: vault),
+      nodeID: .init(rawValue: node)
+    )
   }
 }
 

--- a/apps/enchiridion/Sources/EnchiridionCore/GraphIdentifiers.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/GraphIdentifiers.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+public struct VaultID: RawRepresentable, Codable, Hashable, Sendable, Identifiable,
+  CustomStringConvertible
+{
+  public let rawValue: String
+  public var id: String { rawValue }
+  public var description: String { rawValue }
+
+  public init(rawValue: String) { self.rawValue = rawValue }
+
+  public static func random() -> Self {
+    .init(rawValue: "vault_\(UUID().uuidString.lowercased())")
+  }
+}
+
+/// Nodes are the durable identities in an Enchiridion knowledge graph. PageID remains the
+/// concrete representation so task, note, and calendar domain APIs share the same identity.
+public typealias NodeID = PageID
+public typealias TagID = SupertagID
+
+public struct PredicateID: RawRepresentable, Codable, Hashable, Sendable, Identifiable,
+  CustomStringConvertible
+{
+  public let rawValue: String
+  public var id: String { rawValue }
+  public var description: String { rawValue }
+
+  public init(rawValue: String) { self.rawValue = rawValue }
+
+  public static func property(tagID: TagID, fieldID: SupertagFieldID) -> Self {
+    .init(rawValue: "property:\(tagID.rawValue):\(fieldID.rawValue)")
+  }
+}
+
+public struct FactID: RawRepresentable, Codable, Hashable, Sendable, Identifiable {
+  public let rawValue: String
+  public var id: String { rawValue }
+  public init(rawValue: String) { self.rawValue = rawValue }
+  public static func random() -> Self {
+    .init(rawValue: "fact_\(UUID().uuidString.lowercased())")
+  }
+}
+
+public struct RelationID: RawRepresentable, Codable, Hashable, Sendable, Identifiable,
+  CustomStringConvertible
+{
+  public let rawValue: String
+  public var id: String { rawValue }
+  public var description: String { rawValue }
+  public init(rawValue: String) { self.rawValue = rawValue }
+  public static func random() -> Self {
+    .init(rawValue: "relation_\(UUID().uuidString.lowercased())")
+  }
+}
+
+public struct EdgeID: RawRepresentable, Codable, Hashable, Sendable, Identifiable {
+  public let rawValue: String
+  public var id: String { rawValue }
+  public init(rawValue: String) { self.rawValue = rawValue }
+  public static func random() -> Self {
+    .init(rawValue: "edge_\(UUID().uuidString.lowercased())")
+  }
+}
+
+public struct GraphIssueID: RawRepresentable, Codable, Hashable, Sendable, Identifiable {
+  public let rawValue: String
+  public var id: String { rawValue }
+  public init(rawValue: String) { self.rawValue = rawValue }
+}
+
+public struct VaultScopedNodeID: Codable, Hashable, Sendable, Identifiable {
+  public var vaultID: VaultID
+  public var nodeID: NodeID
+  public var id: String { "\(vaultID.rawValue)/\(nodeID.rawValue)" }
+
+  public init(vaultID: VaultID, nodeID: NodeID) {
+    self.vaultID = vaultID
+    self.nodeID = nodeID
+  }
+}
+
+public struct LocalDate: RawRepresentable, Codable, Hashable, Sendable, Identifiable,
+  CustomStringConvertible
+{
+  public let rawValue: String
+  public var id: String { rawValue }
+  public var description: String { rawValue }
+
+  public init?(rawValue: String) {
+    let pieces = rawValue.split(separator: "-", omittingEmptySubsequences: false)
+    guard pieces.count == 3,
+      pieces[0].count == 4,
+      pieces[1].count == 2,
+      pieces[2].count == 2,
+      let year = Int(pieces[0]),
+      let month = Int(pieces[1]),
+      let day = Int(pieces[2]),
+      (1...12).contains(month),
+      (1...31).contains(day),
+      year > 0
+    else { return nil }
+    self.rawValue = rawValue
+  }
+
+  public init(date: Date, calendar: Calendar = .current) {
+    self.rawValue = DayKey(date: date, calendar: calendar).rawValue
+  }
+}

--- a/apps/enchiridion/Sources/EnchiridionCore/GraphIdentifiers.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/GraphIdentifiers.swift
@@ -126,10 +126,18 @@ public struct LocalDate: RawRepresentable, Codable, Hashable, Sendable, Identifi
       let month = Int(pieces[1]),
       let day = Int(pieces[2]),
       (1...12).contains(month),
-      (1...31).contains(day),
-      year > 0
+      year > 0,
+      (1...Self.daysInMonth(month: month, year: year)).contains(day)
     else { return nil }
     self.rawValue = rawValue
+  }
+
+  private static func daysInMonth(month: Int, year: Int) -> Int {
+    let isLeapYear = (year.isMultiple(of: 4) && !year.isMultiple(of: 100))
+      || year.isMultiple(of: 400)
+    return [31, isLeapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][
+      month - 1
+    ]
   }
 
   public init(date: Date, calendar: Calendar = .current) {

--- a/apps/enchiridion/Sources/EnchiridionCore/GraphOntology.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/GraphOntology.swift
@@ -1,5 +1,26 @@
 import Foundation
 
+public enum SupertagInheritance {
+  public static func effectiveTagIDs(
+    for directTagIDs: Set<TagID>,
+    definitions: [SupertagDefinition]
+  ) -> Set<TagID> {
+    let definitionsByID = definitions.reduce(into: [TagID: SupertagDefinition]()) {
+      $0[$1.id] = $1
+    }
+    var effectiveTagIDs = directTagIDs
+    var pendingTagIDs = Array(directTagIDs)
+
+    while let tagID = pendingTagIDs.popLast() {
+      guard let definition = definitionsByID[tagID] else { continue }
+      for parentID in definition.parentIDs where effectiveTagIDs.insert(parentID).inserted {
+        pendingTagIDs.append(parentID)
+      }
+    }
+    return effectiveTagIDs
+  }
+}
+
 public enum BuiltInRelations {
   public static let personOrganization = RelationID(rawValue: "person.organization")
   public static let projectArea = RelationID(rawValue: "project.area")

--- a/apps/enchiridion/Sources/EnchiridionCore/GraphOntology.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/GraphOntology.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+public enum BuiltInRelations {
+  public static let personOrganization = RelationID(rawValue: "person.organization")
+  public static let projectArea = RelationID(rawValue: "project.area")
+  public static let projectOwners = RelationID(rawValue: "project.owners")
+  public static let projectOrganization = RelationID(rawValue: "project.organization")
+  public static let projectPlace = RelationID(rawValue: "project.place")
+  public static let taskProject = RelationID(rawValue: "task.project")
+  public static let taskArea = RelationID(rawValue: "task.area")
+  public static let taskParent = RelationID(rawValue: "task.parent")
+  public static let taskAssignees = RelationID(rawValue: "task.assignees")
+  public static let eventOrganizer = RelationID(rawValue: "event.organizer")
+  public static let eventAttendees = RelationID(rawValue: "event.attendees")
+  public static let eventPlace = RelationID(rawValue: "event.place")
+  public static let mentions = RelationID(rawValue: "system.mentions")
+
+  public static let all: [RelationDefinition] = [
+    relation(personOrganization, [BuiltInSupertags.person], [BuiltInSupertags.organization], "organization", "people", .manyToOne),
+    relation(projectArea, [BuiltInSupertags.project], [BuiltInSupertags.area], "area", "projects", .manyToOne),
+    relation(projectOwners, [BuiltInSupertags.project], [BuiltInSupertags.person], "owners", "owned projects", .manyToMany),
+    relation(projectOrganization, [BuiltInSupertags.project], [BuiltInSupertags.organization], "organization", "projects", .manyToOne),
+    relation(projectPlace, [BuiltInSupertags.project], [BuiltInSupertags.place], "place", "projects", .manyToOne),
+    relation(taskProject, [BuiltInSupertags.task], [BuiltInSupertags.project], "project", "tasks", .manyToOne),
+    relation(taskArea, [BuiltInSupertags.task], [BuiltInSupertags.area], "area", "tasks", .manyToOne),
+    relation(taskParent, [BuiltInSupertags.task], [BuiltInSupertags.task], "parent", "subtasks", .manyToOne),
+    relation(taskAssignees, [BuiltInSupertags.task], [BuiltInSupertags.person], "assignees", "assigned tasks", .manyToMany),
+    relation(eventOrganizer, [BuiltInSupertags.event], [BuiltInSupertags.person], "organizer", "organized events", .manyToOne),
+    relation(eventAttendees, [BuiltInSupertags.event], [BuiltInSupertags.person], "attendees", "events", .manyToMany),
+    relation(eventPlace, [BuiltInSupertags.event], [BuiltInSupertags.place], "place", "events", .manyToOne),
+    relation(mentions, [], [], "mentions", "mentioned by", .manyToMany),
+  ]
+
+  public static func relationID(for key: SupertagPropertyKey) -> RelationID {
+    let pair = "\(key.supertagID.rawValue).\(key.fieldID.rawValue)"
+    return switch pair {
+    case "person.organization": personOrganization
+    case "project.area": projectArea
+    case "project.owner": projectOwners
+    case "project.organization": projectOrganization
+    case "project.place": projectPlace
+    case "task.project": taskProject
+    case "task.area": taskArea
+    case "task.parent": taskParent
+    case "task.assignee": taskAssignees
+    case "event.organizer": eventOrganizer
+    case "event.attendees": eventAttendees
+    case "event.place": eventPlace
+    default: .init(rawValue: "property-relation:\(key.supertagID.rawValue):\(key.fieldID.rawValue)")
+    }
+  }
+
+  public static func propertyKey(for relationID: RelationID) -> SupertagPropertyKey? {
+    switch relationID {
+    case personOrganization: return .init(supertagID: BuiltInSupertags.person, fieldID: .init(rawValue: "organization"))
+    case projectArea: return .init(supertagID: BuiltInSupertags.project, fieldID: .init(rawValue: "area"))
+    case projectOwners: return .init(supertagID: BuiltInSupertags.project, fieldID: .init(rawValue: "owner"))
+    case projectOrganization: return .init(supertagID: BuiltInSupertags.project, fieldID: .init(rawValue: "organization"))
+    case projectPlace: return .init(supertagID: BuiltInSupertags.project, fieldID: .init(rawValue: "place"))
+    case taskProject: return .init(supertagID: BuiltInSupertags.task, fieldID: .init(rawValue: "project"))
+    case taskArea: return .init(supertagID: BuiltInSupertags.task, fieldID: .init(rawValue: "area"))
+    case taskParent: return .init(supertagID: BuiltInSupertags.task, fieldID: .init(rawValue: "parent"))
+    case taskAssignees: return .init(supertagID: BuiltInSupertags.task, fieldID: .init(rawValue: "assignee"))
+    default:
+      guard relationID.rawValue.hasPrefix("property-relation:") else { return nil }
+      let parts = relationID.rawValue.split(separator: ":", omittingEmptySubsequences: false)
+      guard parts.count == 3 else { return nil }
+      return .init(
+        supertagID: .init(rawValue: String(parts[1])),
+        fieldID: .init(rawValue: String(parts[2]))
+      )
+    }
+  }
+
+  private static func relation(
+    _ id: RelationID,
+    _ sources: [TagID],
+    _ targets: [TagID],
+    _ forward: String,
+    _ inverse: String,
+    _ cardinality: RelationCardinality
+  ) -> RelationDefinition {
+    .init(
+      id: id,
+      sourceTagIDs: sources,
+      targetTagIDs: targets,
+      forwardName: forward,
+      inverseName: inverse,
+      cardinality: cardinality,
+      isSystem: true
+    )
+  }
+}

--- a/apps/enchiridion/Sources/EnchiridionCore/GraphOntology.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/GraphOntology.swift
@@ -61,6 +61,9 @@ public enum BuiltInRelations {
     case taskArea: return .init(supertagID: BuiltInSupertags.task, fieldID: .init(rawValue: "area"))
     case taskParent: return .init(supertagID: BuiltInSupertags.task, fieldID: .init(rawValue: "parent"))
     case taskAssignees: return .init(supertagID: BuiltInSupertags.task, fieldID: .init(rawValue: "assignee"))
+    case eventOrganizer: return .init(supertagID: BuiltInSupertags.event, fieldID: .init(rawValue: "organizer"))
+    case eventAttendees: return .init(supertagID: BuiltInSupertags.event, fieldID: .init(rawValue: "attendees"))
+    case eventPlace: return .init(supertagID: BuiltInSupertags.event, fieldID: .init(rawValue: "place"))
     default:
       guard relationID.rawValue.hasPrefix("property-relation:") else { return nil }
       let parts = relationID.rawValue.split(separator: ":", omittingEmptySubsequences: false)

--- a/apps/enchiridion/Sources/EnchiridionCore/GraphQueryModels.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/GraphQueryModels.swift
@@ -306,12 +306,16 @@ public enum GraphQueryCompiler {
           return "EXISTS (SELECT 1 FROM graph_facts fact WHERE fact.node_id = \(nodeAlias).node_id AND fact.predicate_id = \(predicate))"
         }
         guard let expected else { return "0" }
-        let (column, argument) = factOperand(expected)
+        let (column, argument) = factOperand(
+          expected,
+          escapingLikeWildcards: comparison == .contains
+        )
         let operation: String
         switch comparison {
         case .equals: operation = "= \(argument)"
         case .notEquals: operation = "= \(argument)"
-        case .contains: operation = "LIKE '%' || \(argument) || '%' COLLATE NOCASE"
+        case .contains:
+          operation = "LIKE '%' || \(argument) || '%' ESCAPE '\\' COLLATE NOCASE"
         case .before: operation = "< \(argument)"
         case .after: operation = "> \(argument)"
         case .isEmpty, .isNotEmpty: operation = "= \(argument)"
@@ -375,14 +379,24 @@ public enum GraphQueryCompiler {
       case .modifiedAt: return "\(nodeAlias).modified_at \(direction)"
       case .fact(let predicateID):
         let predicate = bind(.text(predicateID.rawValue))
-        return "(SELECT COALESCE(fact.text_value, fact.number_value, fact.local_date_value, fact.date_time_value) FROM graph_facts fact WHERE fact.node_id = \(nodeAlias).node_id AND fact.predicate_id = \(predicate) ORDER BY fact.value_index LIMIT 1) \(direction)"
+        return "(SELECT COALESCE(fact.text_value, fact.number_value, fact.boolean_value, fact.local_date_value, fact.date_time_value) FROM graph_facts fact WHERE fact.node_id = \(nodeAlias).node_id AND fact.predicate_id = \(predicate) ORDER BY fact.value_index LIMIT 1) \(direction)"
       }
     }
 
-    mutating func factOperand(_ value: GraphFactValue) -> (String, String) {
+    mutating func factOperand(
+      _ value: GraphFactValue,
+      escapingLikeWildcards: Bool = false
+    ) -> (String, String) {
       switch value {
       case .text(let value), .select(let value), .url(let value), .email(let value),
-        .phone(let value): return ("text_value", bind(.text(value)))
+        .phone(let value):
+        let boundValue = escapingLikeWildcards
+          ? value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "%", with: "\\%")
+            .replacingOccurrences(of: "_", with: "\\_")
+          : value
+        return ("text_value", bind(.text(boundValue)))
       case .number(let value): return ("number_value", bind(.real(value)))
       case .boolean(let value): return ("boolean_value", bind(.integer(value ? 1 : 0)))
       case .localDate(let value): return ("local_date_value", bind(.text(value.rawValue)))

--- a/apps/enchiridion/Sources/EnchiridionCore/GraphQueryModels.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/GraphQueryModels.swift
@@ -26,6 +26,8 @@ public enum GraphTraversalDirection: String, Codable, CaseIterable, Hashable, Se
 }
 
 public struct GraphTraversal: Codable, Hashable, Sendable {
+  public static let maximumAllowedDepth = 8
+
   public var relationID: RelationID?
   public var direction: GraphTraversalDirection
   public var minimumDepth: Int
@@ -41,9 +43,31 @@ public struct GraphTraversal: Codable, Hashable, Sendable {
   ) {
     self.relationID = relationID
     self.direction = direction
-    self.minimumDepth = min(max(minimumDepth, 1), 8)
-    self.maximumDepth = min(max(maximumDepth, self.minimumDepth), 8)
+    self.minimumDepth = min(max(minimumDepth, 1), Self.maximumAllowedDepth)
+    self.maximumDepth = min(
+      max(maximumDepth, self.minimumDepth),
+      Self.maximumAllowedDepth
+    )
     self.targetTagID = targetTagID
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case relationID
+    case direction
+    case minimumDepth
+    case maximumDepth
+    case targetTagID
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.init(
+      relationID: try container.decodeIfPresent(RelationID.self, forKey: .relationID),
+      direction: try container.decode(GraphTraversalDirection.self, forKey: .direction),
+      minimumDepth: try container.decode(Int.self, forKey: .minimumDepth),
+      maximumDepth: try container.decode(Int.self, forKey: .maximumDepth),
+      targetTagID: try container.decodeIfPresent(TagID.self, forKey: .targetTagID)
+    )
   }
 }
 
@@ -74,6 +98,8 @@ public struct GraphSort: Codable, Hashable, Sendable {
 }
 
 public struct GraphQueryDefinition: Codable, Hashable, Sendable {
+  public static let maximumAllowedLimit = 5_000
+
   public var expression: GraphExpression?
   public var sorts: [GraphSort]
   public var includeDeleted: Bool
@@ -88,7 +114,24 @@ public struct GraphQueryDefinition: Codable, Hashable, Sendable {
     self.expression = expression
     self.sorts = sorts
     self.includeDeleted = includeDeleted
-    self.limit = min(max(limit, 1), 5_000)
+    self.limit = min(max(limit, 1), Self.maximumAllowedLimit)
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case expression
+    case sorts
+    case includeDeleted
+    case limit
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.init(
+      expression: try container.decodeIfPresent(GraphExpression.self, forKey: .expression),
+      sorts: try container.decode([GraphSort].self, forKey: .sorts),
+      includeDeleted: try container.decode(Bool.self, forKey: .includeDeleted),
+      limit: try container.decode(Int.self, forKey: .limit)
+    )
   }
 }
 
@@ -224,25 +267,22 @@ public enum GraphQueryCompiler {
     if let expression = definition.expression {
       predicates.append(context.expression(expression, nodeAlias: "node"))
     }
-    let withClause = context.ctes.isEmpty
-      ? ""
-      : "WITH RECURSIVE \(context.ctes.joined(separator: ",\n"))\n"
     let whereClause = predicates.isEmpty ? "" : "\nWHERE \(predicates.joined(separator: " AND "))"
     let orderClause = definition.sorts.isEmpty
       ? ""
       : "\nORDER BY " + definition.sorts.map { context.sort($0, nodeAlias: "node") }.joined(separator: ", ")
+    let limit = min(max(definition.limit, 1), GraphQueryDefinition.maximumAllowedLimit)
     let sql = """
-      \(withClause)SELECT node.node_id, node.title, node.plain_text, node.kind,
+      SELECT node.node_id, node.title, node.plain_text, node.kind,
              node.created_at, node.modified_at, node.deleted_at
       FROM graph_nodes node\(whereClause)\(orderClause)
-      LIMIT \(definition.limit)
+      LIMIT \(limit)
       """
     return .init(sql: sql, arguments: context.arguments)
   }
 
   private struct Context {
     var arguments: [String: GraphSQLValue] = [:]
-    var ctes: [String] = []
     var nextArgument = 0
     var nextTraversal = 0
 
@@ -281,6 +321,14 @@ public enum GraphQueryCompiler {
       case .traversal(let traversal):
         let cteName = "walk_\(nextTraversal)"
         nextTraversal += 1
+        let minimumDepth = min(
+          max(traversal.minimumDepth, 1),
+          GraphTraversal.maximumAllowedDepth
+        )
+        let maximumDepth = min(
+          max(traversal.maximumDepth, minimumDepth),
+          GraphTraversal.maximumAllowedDepth
+        )
         let directionPredicate: String
         switch traversal.direction {
         case .forward: directionPredicate = "edge.direction = 'forward'"
@@ -290,22 +338,24 @@ public enum GraphQueryCompiler {
         let relationPredicate = traversal.relationID.map {
           " AND edge.relation_id = \(bind(.text($0.rawValue)))"
         } ?? ""
-        ctes.append("""
-          \(cteName)(origin_id, current_id, depth) AS (
-            SELECT seed.node_id, seed.node_id, 0 FROM graph_nodes seed
-            UNION ALL
-            SELECT walk.origin_id, edge.to_node_id, walk.depth + 1
-            FROM \(cteName) walk
-            JOIN graph_edges edge ON edge.from_node_id = walk.current_id
-            WHERE walk.depth < \(traversal.maximumDepth)
-              AND \(directionPredicate)\(relationPredicate)
-          )
-          """)
-        var target = "walk.origin_id = \(nodeAlias).node_id AND walk.depth BETWEEN \(traversal.minimumDepth) AND \(traversal.maximumDepth)"
+        var target = "walk.depth BETWEEN \(minimumDepth) AND \(maximumDepth)"
         if let tagID = traversal.targetTagID {
           target += " AND EXISTS (SELECT 1 FROM graph_node_tags target_tag WHERE target_tag.node_id = walk.current_id AND target_tag.tag_id = \(bind(.text(tagID.rawValue))))"
         }
-        return "EXISTS (SELECT 1 FROM \(cteName) walk WHERE \(target))"
+        return """
+          EXISTS (
+            WITH RECURSIVE \(cteName)(current_id, depth) AS (
+              SELECT \(nodeAlias).node_id, 0
+              UNION ALL
+              SELECT edge.to_node_id, walk.depth + 1
+              FROM \(cteName) walk
+              JOIN graph_edges edge ON edge.from_node_id = walk.current_id
+              WHERE walk.depth < \(maximumDepth)
+                AND \(directionPredicate)\(relationPredicate)
+            )
+            SELECT 1 FROM \(cteName) walk WHERE \(target)
+          )
+          """
       case .and(let expressions):
         guard !expressions.isEmpty else { return "1" }
         return "(" + expressions.map { expression($0, nodeAlias: nodeAlias) }.joined(separator: " AND ") + ")"

--- a/apps/enchiridion/Sources/EnchiridionCore/GraphQueryModels.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/GraphQueryModels.swift
@@ -1,0 +1,343 @@
+import Foundation
+
+public struct GraphQueryID: RawRepresentable, Codable, Hashable, Sendable, Identifiable {
+  public let rawValue: String
+  public var id: String { rawValue }
+  public init(rawValue: String) { self.rawValue = rawValue }
+  public static func random() -> Self {
+    .init(rawValue: "graph_query_\(UUID().uuidString.lowercased())")
+  }
+}
+
+public enum GraphComparison: String, Codable, CaseIterable, Hashable, Sendable {
+  case equals
+  case notEquals
+  case contains
+  case before
+  case after
+  case isEmpty
+  case isNotEmpty
+}
+
+public enum GraphTraversalDirection: String, Codable, CaseIterable, Hashable, Sendable {
+  case forward
+  case inverse
+  case either
+}
+
+public struct GraphTraversal: Codable, Hashable, Sendable {
+  public var relationID: RelationID?
+  public var direction: GraphTraversalDirection
+  public var minimumDepth: Int
+  public var maximumDepth: Int
+  public var targetTagID: TagID?
+
+  public init(
+    relationID: RelationID? = nil,
+    direction: GraphTraversalDirection = .forward,
+    minimumDepth: Int = 1,
+    maximumDepth: Int = 1,
+    targetTagID: TagID? = nil
+  ) {
+    self.relationID = relationID
+    self.direction = direction
+    self.minimumDepth = min(max(minimumDepth, 1), 8)
+    self.maximumDepth = min(max(maximumDepth, self.minimumDepth), 8)
+    self.targetTagID = targetTagID
+  }
+}
+
+public indirect enum GraphExpression: Codable, Hashable, Sendable {
+  case tag(TagID)
+  case fact(PredicateID, GraphComparison, GraphFactValue?)
+  case traversal(GraphTraversal)
+  case and([GraphExpression])
+  case or([GraphExpression])
+  case not(GraphExpression)
+}
+
+public enum GraphSortKey: Codable, Hashable, Sendable {
+  case title
+  case createdAt
+  case modifiedAt
+  case fact(PredicateID)
+}
+
+public struct GraphSort: Codable, Hashable, Sendable {
+  public var key: GraphSortKey
+  public var ascending: Bool
+
+  public init(key: GraphSortKey, ascending: Bool = true) {
+    self.key = key
+    self.ascending = ascending
+  }
+}
+
+public struct GraphQueryDefinition: Codable, Hashable, Sendable {
+  public var expression: GraphExpression?
+  public var sorts: [GraphSort]
+  public var includeDeleted: Bool
+  public var limit: Int
+
+  public init(
+    expression: GraphExpression? = nil,
+    sorts: [GraphSort] = [.init(key: .title)],
+    includeDeleted: Bool = false,
+    limit: Int = 500
+  ) {
+    self.expression = expression
+    self.sorts = sorts
+    self.includeDeleted = includeDeleted
+    self.limit = min(max(limit, 1), 5_000)
+  }
+}
+
+public enum GraphViewKind: String, Codable, CaseIterable, Hashable, Sendable {
+  case list
+  case table
+  case board
+  case gallery
+  case calendar
+
+  public var title: String { rawValue.capitalized }
+  public var systemImage: String {
+    switch self {
+    case .list: "list.bullet"
+    case .table: "tablecells"
+    case .board: "rectangle.split.3x1"
+    case .gallery: "square.grid.2x2"
+    case .calendar: "calendar"
+    }
+  }
+}
+
+public struct GraphViewPresentation: Codable, Hashable, Sendable {
+  public var kind: GraphViewKind
+  public var titleColumn: String
+  public var groupColumn: String?
+  public var startColumn: String?
+  public var endColumn: String?
+
+  public init(
+    kind: GraphViewKind = .list,
+    titleColumn: String = "title",
+    groupColumn: String? = nil,
+    startColumn: String? = nil,
+    endColumn: String? = nil
+  ) {
+    self.kind = kind
+    self.titleColumn = titleColumn
+    self.groupColumn = groupColumn
+    self.startColumn = startColumn
+    self.endColumn = endColumn
+  }
+}
+
+public struct SavedGraphQuery: Codable, Hashable, Sendable, Identifiable {
+  public enum Source: Codable, Hashable, Sendable {
+    case builder(GraphQueryDefinition)
+    case sql(String)
+  }
+
+  public var id: GraphQueryID
+  public var name: String
+  public var source: Source
+  public var presentation: GraphViewPresentation
+
+  public init(
+    id: GraphQueryID = .random(),
+    name: String,
+    source: Source,
+    presentation: GraphViewPresentation = .init()
+  ) {
+    self.id = id
+    self.name = name
+    self.source = source
+    self.presentation = presentation
+  }
+}
+
+public enum GraphSQLValue: Codable, Hashable, Sendable {
+  case null
+  case integer(Int64)
+  case real(Double)
+  case text(String)
+  case blob(Data)
+}
+
+public struct GraphQueryColumn: Codable, Hashable, Sendable, Identifiable {
+  public var name: String
+  public var id: String { name }
+  public init(name: String) { self.name = name }
+}
+
+public struct GraphQueryRow: Codable, Hashable, Sendable, Identifiable {
+  public var values: [GraphSQLValue]
+  public var id: Int
+  public init(id: Int, values: [GraphSQLValue]) {
+    self.id = id
+    self.values = values
+  }
+}
+
+public struct GraphQueryResult: Codable, Hashable, Sendable {
+  public var columns: [GraphQueryColumn]
+  public var rows: [GraphQueryRow]
+  public var wasTruncated: Bool
+  public var elapsed: TimeInterval
+
+  public init(
+    columns: [GraphQueryColumn],
+    rows: [GraphQueryRow],
+    wasTruncated: Bool,
+    elapsed: TimeInterval
+  ) {
+    self.columns = columns
+    self.rows = rows
+    self.wasTruncated = wasTruncated
+    self.elapsed = elapsed
+  }
+
+  public func value(column name: String, in row: GraphQueryRow) -> GraphSQLValue? {
+    guard let index = columns.firstIndex(where: { $0.name == name }),
+      row.values.indices.contains(index)
+    else { return nil }
+    return row.values[index]
+  }
+}
+
+public struct CompiledGraphQuery: Equatable, Sendable {
+  public var sql: String
+  public var arguments: [String: GraphSQLValue]
+
+  public init(sql: String, arguments: [String: GraphSQLValue]) {
+    self.sql = sql
+    self.arguments = arguments
+  }
+}
+
+public enum GraphQueryCompiler {
+  public static func compile(_ definition: GraphQueryDefinition) -> CompiledGraphQuery {
+    var context = Context()
+    var predicates: [String] = []
+    if !definition.includeDeleted { predicates.append("node.deleted_at IS NULL") }
+    if let expression = definition.expression {
+      predicates.append(context.expression(expression, nodeAlias: "node"))
+    }
+    let withClause = context.ctes.isEmpty
+      ? ""
+      : "WITH RECURSIVE \(context.ctes.joined(separator: ",\n"))\n"
+    let whereClause = predicates.isEmpty ? "" : "\nWHERE \(predicates.joined(separator: " AND "))"
+    let orderClause = definition.sorts.isEmpty
+      ? ""
+      : "\nORDER BY " + definition.sorts.map { context.sort($0, nodeAlias: "node") }.joined(separator: ", ")
+    let sql = """
+      \(withClause)SELECT node.node_id, node.title, node.plain_text, node.kind,
+             node.created_at, node.modified_at, node.deleted_at
+      FROM graph_nodes node\(whereClause)\(orderClause)
+      LIMIT \(definition.limit)
+      """
+    return .init(sql: sql, arguments: context.arguments)
+  }
+
+  private struct Context {
+    var arguments: [String: GraphSQLValue] = [:]
+    var ctes: [String] = []
+    var nextArgument = 0
+    var nextTraversal = 0
+
+    mutating func bind(_ value: GraphSQLValue) -> String {
+      let name = "p\(nextArgument)"
+      nextArgument += 1
+      arguments[name] = value
+      return ":\(name)"
+    }
+
+    mutating func expression(_ value: GraphExpression, nodeAlias: String) -> String {
+      switch value {
+      case .tag(let tagID):
+        return "EXISTS (SELECT 1 FROM graph_node_tags tag WHERE tag.node_id = \(nodeAlias).node_id AND tag.tag_id = \(bind(.text(tagID.rawValue))))"
+      case .fact(let predicateID, let comparison, let expected):
+        let predicate = bind(.text(predicateID.rawValue))
+        if comparison == .isEmpty {
+          return "NOT EXISTS (SELECT 1 FROM graph_facts fact WHERE fact.node_id = \(nodeAlias).node_id AND fact.predicate_id = \(predicate))"
+        }
+        if comparison == .isNotEmpty {
+          return "EXISTS (SELECT 1 FROM graph_facts fact WHERE fact.node_id = \(nodeAlias).node_id AND fact.predicate_id = \(predicate))"
+        }
+        guard let expected else { return "0" }
+        let (column, argument) = factOperand(expected)
+        let operation: String
+        switch comparison {
+        case .equals: operation = "= \(argument)"
+        case .notEquals: operation = "= \(argument)"
+        case .contains: operation = "LIKE '%' || \(argument) || '%' COLLATE NOCASE"
+        case .before: operation = "< \(argument)"
+        case .after: operation = "> \(argument)"
+        case .isEmpty, .isNotEmpty: operation = "= \(argument)"
+        }
+        let exists = "EXISTS (SELECT 1 FROM graph_facts fact WHERE fact.node_id = \(nodeAlias).node_id AND fact.predicate_id = \(predicate) AND fact.\(column) \(operation))"
+        return comparison == .notEquals ? "NOT \(exists)" : exists
+      case .traversal(let traversal):
+        let cteName = "walk_\(nextTraversal)"
+        nextTraversal += 1
+        let directionPredicate: String
+        switch traversal.direction {
+        case .forward: directionPredicate = "edge.direction = 'forward'"
+        case .inverse: directionPredicate = "edge.direction = 'inverse'"
+        case .either: directionPredicate = "1"
+        }
+        let relationPredicate = traversal.relationID.map {
+          " AND edge.relation_id = \(bind(.text($0.rawValue)))"
+        } ?? ""
+        ctes.append("""
+          \(cteName)(origin_id, current_id, depth) AS (
+            SELECT seed.node_id, seed.node_id, 0 FROM graph_nodes seed
+            UNION ALL
+            SELECT walk.origin_id, edge.to_node_id, walk.depth + 1
+            FROM \(cteName) walk
+            JOIN graph_edges edge ON edge.from_node_id = walk.current_id
+            WHERE walk.depth < \(traversal.maximumDepth)
+              AND \(directionPredicate)\(relationPredicate)
+          )
+          """)
+        var target = "walk.origin_id = \(nodeAlias).node_id AND walk.depth BETWEEN \(traversal.minimumDepth) AND \(traversal.maximumDepth)"
+        if let tagID = traversal.targetTagID {
+          target += " AND EXISTS (SELECT 1 FROM graph_node_tags target_tag WHERE target_tag.node_id = walk.current_id AND target_tag.tag_id = \(bind(.text(tagID.rawValue))))"
+        }
+        return "EXISTS (SELECT 1 FROM \(cteName) walk WHERE \(target))"
+      case .and(let expressions):
+        guard !expressions.isEmpty else { return "1" }
+        return "(" + expressions.map { expression($0, nodeAlias: nodeAlias) }.joined(separator: " AND ") + ")"
+      case .or(let expressions):
+        guard !expressions.isEmpty else { return "0" }
+        return "(" + expressions.map { expression($0, nodeAlias: nodeAlias) }.joined(separator: " OR ") + ")"
+      case .not(let expressionValue):
+        return "NOT (\(expression(expressionValue, nodeAlias: nodeAlias)))"
+      }
+    }
+
+    mutating func sort(_ sort: GraphSort, nodeAlias: String) -> String {
+      let direction = sort.ascending ? "ASC" : "DESC"
+      switch sort.key {
+      case .title: return "\(nodeAlias).title COLLATE NOCASE \(direction)"
+      case .createdAt: return "\(nodeAlias).created_at \(direction)"
+      case .modifiedAt: return "\(nodeAlias).modified_at \(direction)"
+      case .fact(let predicateID):
+        let predicate = bind(.text(predicateID.rawValue))
+        return "(SELECT COALESCE(fact.text_value, fact.number_value, fact.local_date_value, fact.date_time_value) FROM graph_facts fact WHERE fact.node_id = \(nodeAlias).node_id AND fact.predicate_id = \(predicate) ORDER BY fact.value_index LIMIT 1) \(direction)"
+      }
+    }
+
+    mutating func factOperand(_ value: GraphFactValue) -> (String, String) {
+      switch value {
+      case .text(let value), .select(let value), .url(let value), .email(let value),
+        .phone(let value): return ("text_value", bind(.text(value)))
+      case .number(let value): return ("number_value", bind(.real(value)))
+      case .boolean(let value): return ("boolean_value", bind(.integer(value ? 1 : 0)))
+      case .localDate(let value): return ("local_date_value", bind(.text(value.rawValue)))
+      case .dateTime(let value): return ("date_time_value", bind(.real(value.timeIntervalSince1970)))
+      }
+    }
+  }
+}

--- a/apps/enchiridion/Sources/EnchiridionCore/GraphQueryRepository.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/GraphQueryRepository.swift
@@ -1,6 +1,15 @@
 import Foundation
 import GRDB
 
+public struct SavedGraphQueryCloudRecord: Sendable {
+  public var query: SavedGraphQuery
+  public var isDeleted: Bool
+  public var sortOrder: Int
+  public var modifiedAt: Date
+  public var dirtyGeneration: Int64
+  public var cloudRecord: Data?
+}
+
 extension LibraryRepository {
   public nonisolated func runGraphSQL(
     _ sql: String,
@@ -128,6 +137,126 @@ extension LibraryRepository {
     }
   }
 
+  public func dirtyGraphQueries() throws -> [SavedGraphQueryCloudRecord] {
+    try database.read { db in
+      try Row.fetchAll(
+        db,
+        sql: "SELECT * FROM _saved_graph_queries WHERE cloud_dirty = 1 ORDER BY modified_at, id"
+      ).compactMap(Self.decodeSavedGraphQueryCloudRecord)
+    }
+  }
+
+  public func savedGraphQueryCloudRecord(
+    id: GraphQueryID
+  ) throws -> SavedGraphQueryCloudRecord? {
+    try database.read { db in
+      try Row.fetchOne(
+        db,
+        sql: "SELECT * FROM _saved_graph_queries WHERE id = ?",
+        arguments: [id.rawValue]
+      ).flatMap(Self.decodeSavedGraphQueryCloudRecord)
+    }
+  }
+
+  @discardableResult
+  public func markGraphQueryCloudSaved(
+    id: GraphQueryID,
+    sentGeneration: Int64,
+    systemFields: Data
+  ) throws -> Bool {
+    try database.write { db in
+      try db.execute(
+        sql: """
+          UPDATE _saved_graph_queries
+          SET cloud_record = ?,
+              cloud_synced_generation = MAX(cloud_synced_generation, ?),
+              cloud_dirty = CASE WHEN dirty_generation <= ? THEN 0 ELSE 1 END
+          WHERE id = ?
+          """,
+        arguments: [systemFields, sentGeneration, sentGeneration, id.rawValue]
+      )
+      return try Bool.fetchOne(
+        db,
+        sql: "SELECT cloud_dirty FROM _saved_graph_queries WHERE id = ?",
+        arguments: [id.rawValue]
+      ) ?? false
+    }
+  }
+
+  @discardableResult
+  public func mergeCloudGraphQuery(
+    id: GraphQueryID,
+    query: SavedGraphQuery,
+    isDeleted: Bool,
+    sortOrder: Int,
+    modifiedAt: Date,
+    dirtyGeneration: Int64,
+    systemFields: Data
+  ) throws -> Bool {
+    try database.write { db in
+      if let isDirty = try Bool.fetchOne(
+        db,
+        sql: "SELECT cloud_dirty FROM _saved_graph_queries WHERE id = ?",
+        arguments: [id.rawValue]
+      ), isDirty {
+        try db.execute(
+          sql: "UPDATE _saved_graph_queries SET cloud_record = ? WHERE id = ?",
+          arguments: [systemFields, id.rawValue]
+        )
+        return true
+      }
+      var normalized = query
+      normalized.id = id
+      try Self.writeCloudGraphQuery(
+        normalized,
+        isDeleted: isDeleted,
+        sortOrder: sortOrder,
+        modifiedAt: modifiedAt,
+        dirtyGeneration: dirtyGeneration,
+        systemFields: systemFields,
+        in: db
+      )
+      return false
+    }
+  }
+
+  @discardableResult
+  public func applyCloudGraphQueryRecordDeletion(id: GraphQueryID) throws -> Bool {
+    try database.write { db in
+      guard let isDirty = try Bool.fetchOne(
+        db,
+        sql: "SELECT cloud_dirty FROM _saved_graph_queries WHERE id = ?",
+        arguments: [id.rawValue]
+      ) else { return false }
+      if isDirty {
+        try db.execute(
+          sql: "UPDATE _saved_graph_queries SET cloud_record = NULL WHERE id = ?",
+          arguments: [id.rawValue]
+        )
+        return true
+      }
+      try db.execute(
+        sql: """
+          UPDATE _saved_graph_queries
+          SET deleted = 1, cloud_record = NULL, cloud_dirty = 0,
+              cloud_synced_generation = dirty_generation
+          WHERE id = ?
+          """,
+        arguments: [id.rawValue]
+      )
+      return false
+    }
+  }
+
+  public func clearGraphQueryCloudRecordMetadata(id: GraphQueryID) throws {
+    try database.write { db in
+      try db.execute(
+        sql: "UPDATE _saved_graph_queries SET cloud_record = NULL, cloud_dirty = 1 WHERE id = ?",
+        arguments: [id.rawValue]
+      )
+    }
+  }
+
   public func graphFacts(for nodeID: NodeID) throws -> [KnowledgeFact] {
     try database.read { db in
       try Row.fetchAll(
@@ -193,6 +322,84 @@ extension LibraryRepository {
       name: name,
       source: source,
       presentation: presentation
+    )
+  }
+
+  private static func decodeSavedGraphQueryCloudRecord(
+    _ row: Row
+  ) -> SavedGraphQueryCloudRecord? {
+    guard let query = decodeSavedGraphQuery(row),
+      let isDeleted: Bool = row["deleted"],
+      let sortOrder: Int = row["sort_order"],
+      let modifiedAt: Double = row["modified_at"],
+      let dirtyGeneration: Int64 = row["dirty_generation"]
+    else { return nil }
+    return .init(
+      query: query,
+      isDeleted: isDeleted,
+      sortOrder: sortOrder,
+      modifiedAt: Date(timeIntervalSince1970: modifiedAt),
+      dirtyGeneration: dirtyGeneration,
+      cloudRecord: row["cloud_record"]
+    )
+  }
+
+  private static func writeCloudGraphQuery(
+    _ query: SavedGraphQuery,
+    isDeleted: Bool,
+    sortOrder: Int,
+    modifiedAt: Date,
+    dirtyGeneration: Int64,
+    systemFields: Data,
+    in db: Database
+  ) throws {
+    let sourceKind: String
+    let builderJSON: Data?
+    let sqlText: String?
+    switch query.source {
+    case .builder(let definition):
+      sourceKind = "builder"
+      builderJSON = try JSONEncoder.enchiridion.encode(definition)
+      sqlText = nil
+    case .sql(let sql):
+      sourceKind = "sql"
+      builderJSON = nil
+      sqlText = sql
+    }
+    try db.execute(
+      sql: """
+        INSERT INTO _saved_graph_queries
+          (id,name,source_kind,builder_json,sql_text,presentation_json,modified_at,
+           sort_order,deleted,dirty_generation,cloud_dirty,cloud_synced_generation,cloud_record)
+        VALUES (?,?,?,?,?,?,?,?,?,?,0,?,?)
+        ON CONFLICT(id) DO UPDATE SET
+          name=excluded.name,
+          source_kind=excluded.source_kind,
+          builder_json=excluded.builder_json,
+          sql_text=excluded.sql_text,
+          presentation_json=excluded.presentation_json,
+          modified_at=excluded.modified_at,
+          sort_order=excluded.sort_order,
+          deleted=excluded.deleted,
+          dirty_generation=excluded.dirty_generation,
+          cloud_dirty=0,
+          cloud_synced_generation=excluded.cloud_synced_generation,
+          cloud_record=excluded.cloud_record
+        """,
+      arguments: [
+        query.id.rawValue,
+        query.name,
+        sourceKind,
+        builderJSON,
+        sqlText,
+        try JSONEncoder.enchiridion.encode(query.presentation),
+        modifiedAt.timeIntervalSince1970,
+        sortOrder,
+        isDeleted,
+        dirtyGeneration,
+        dirtyGeneration,
+        systemFields,
+      ]
     )
   }
 

--- a/apps/enchiridion/Sources/EnchiridionCore/GraphQueryRepository.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/GraphQueryRepository.swift
@@ -1,0 +1,250 @@
+import Foundation
+import GRDB
+
+extension LibraryRepository {
+  public nonisolated func runGraphSQL(
+    _ sql: String,
+    arguments: [String: GraphSQLValue] = [:],
+    limits: GraphQueryLimits = .init()
+  ) throws -> GraphQueryResult {
+    try GraphSQLExecutor.execute(
+      path: path,
+      sql: sql,
+      arguments: arguments,
+      limits: limits
+    )
+  }
+
+  public nonisolated func runGraphQuery(
+    _ definition: GraphQueryDefinition,
+    limits: GraphQueryLimits = .init()
+  ) throws -> GraphQueryResult {
+    let compiled = GraphQueryCompiler.compile(definition)
+    return try runGraphSQL(
+      compiled.sql,
+      arguments: compiled.arguments,
+      limits: limits
+    )
+  }
+
+  public nonisolated func runGraphQuery(
+    _ query: SavedGraphQuery,
+    limits: GraphQueryLimits = .init()
+  ) throws -> GraphQueryResult {
+    let result: GraphQueryResult
+    switch query.source {
+    case .builder(let definition):
+      result = try runGraphQuery(definition, limits: limits)
+    case .sql(let sql):
+      result = try runGraphSQL(sql, limits: limits)
+    }
+    try Self.validate(result: result, presentation: query.presentation)
+    return result
+  }
+
+  public func savedGraphQueries() throws -> [SavedGraphQuery] {
+    try database.read { db in
+      try Row.fetchAll(
+        db,
+        sql: """
+          SELECT * FROM _saved_graph_queries
+          WHERE deleted = 0
+          ORDER BY sort_order, name COLLATE NOCASE
+          """
+      ).compactMap(Self.decodeSavedGraphQuery)
+    }
+  }
+
+  public func saveGraphQuery(
+    _ query: SavedGraphQuery,
+    now: Date = Date()
+  ) throws {
+    let name = query.name.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !name.isEmpty else { throw GraphQueryError.sqlite("Enter a query name.") }
+    switch query.source {
+    case .builder(let definition):
+      _ = try runGraphQuery(definition, limits: .init(maximumRows: 1))
+    case .sql(let sql):
+      _ = try runGraphSQL(sql, limits: .init(maximumRows: 1))
+    }
+    try database.write { db in
+      let sourceKind: String
+      let builderJSON: Data?
+      let sqlText: String?
+      switch query.source {
+      case .builder(let definition):
+        sourceKind = "builder"
+        builderJSON = try JSONEncoder.enchiridion.encode(definition)
+        sqlText = nil
+      case .sql(let sql):
+        sourceKind = "sql"
+        builderJSON = nil
+        sqlText = sql
+      }
+      try db.execute(
+        sql: """
+          INSERT INTO _saved_graph_queries
+            (id,name,source_kind,builder_json,sql_text,presentation_json,modified_at,
+             sort_order,deleted,dirty_generation,cloud_dirty)
+          VALUES (?,?,?,?,?,?,?,COALESCE((SELECT sort_order FROM _saved_graph_queries WHERE id = ?),999),0,1,1)
+          ON CONFLICT(id) DO UPDATE SET
+            name=excluded.name,
+            source_kind=excluded.source_kind,
+            builder_json=excluded.builder_json,
+            sql_text=excluded.sql_text,
+            presentation_json=excluded.presentation_json,
+            modified_at=excluded.modified_at,
+            deleted=0,
+            dirty_generation=_saved_graph_queries.dirty_generation + 1,
+            cloud_dirty=1
+          """,
+        arguments: [
+          query.id.rawValue,
+          name,
+          sourceKind,
+          builderJSON,
+          sqlText,
+          try JSONEncoder.enchiridion.encode(query.presentation),
+          now.timeIntervalSince1970,
+          query.id.rawValue,
+        ]
+      )
+    }
+  }
+
+  public func deleteGraphQuery(_ id: GraphQueryID, now: Date = Date()) throws {
+    try database.write { db in
+      try db.execute(
+        sql: """
+          UPDATE _saved_graph_queries
+          SET deleted = 1,
+              modified_at = ?,
+              dirty_generation = dirty_generation + 1,
+              cloud_dirty = 1
+          WHERE id = ?
+          """,
+        arguments: [now.timeIntervalSince1970, id.rawValue]
+      )
+    }
+  }
+
+  public func graphFacts(for nodeID: NodeID) throws -> [KnowledgeFact] {
+    try database.read { db in
+      try Row.fetchAll(
+        db,
+        sql: "SELECT * FROM _graph_facts WHERE node_id = ? ORDER BY predicate_id,value_index",
+        arguments: [nodeID.rawValue]
+      ).compactMap(Self.decodeFact)
+    }
+  }
+
+  private nonisolated static func validate(
+    result: GraphQueryResult,
+    presentation: GraphViewPresentation
+  ) throws {
+    let columns = Set(result.columns.map(\.name))
+    switch presentation.kind {
+    case .table:
+      return
+    case .list, .board, .gallery:
+      guard columns.contains("node_id") else {
+        throw GraphQueryError.sqlite("This presentation requires a node_id column.")
+      }
+    case .calendar:
+      guard columns.contains("node_id"),
+        columns.contains(presentation.startColumn ?? "start_at"),
+        columns.contains(presentation.endColumn ?? "end_at")
+      else {
+        throw GraphQueryError.sqlite(
+          "Calendar presentation requires node_id, start_at, and end_at columns."
+        )
+      }
+    }
+  }
+
+  private static func decodeSavedGraphQuery(_ row: Row) -> SavedGraphQuery? {
+    guard let rawID: String = row["id"],
+      let name: String = row["name"],
+      let sourceKind: String = row["source_kind"],
+      let presentationData: Data = row["presentation_json"],
+      let presentation = try? JSONDecoder.enchiridion.decode(
+        GraphViewPresentation.self,
+        from: presentationData
+      )
+    else { return nil }
+    let source: SavedGraphQuery.Source
+    switch sourceKind {
+    case "builder":
+      guard let data: Data = row["builder_json"],
+        let definition = try? JSONDecoder.enchiridion.decode(
+          GraphQueryDefinition.self,
+          from: data
+        )
+      else { return nil }
+      source = .builder(definition)
+    case "sql":
+      guard let sql: String = row["sql_text"] else { return nil }
+      source = .sql(sql)
+    default:
+      return nil
+    }
+    return .init(
+      id: .init(rawValue: rawID),
+      name: name,
+      source: source,
+      presentation: presentation
+    )
+  }
+
+  private static func decodeFact(_ row: Row) -> KnowledgeFact? {
+    guard let rawID: String = row["fact_id"],
+      let rawNodeID: String = row["node_id"],
+      let rawPredicateID: String = row["predicate_id"],
+      let rawType: String = row["value_type"],
+      let type = GraphValueType(rawValue: rawType),
+      let rawOrigin: String = row["origin"],
+      let origin = GraphFactOrigin(rawValue: rawOrigin),
+      let createdAt: Double = row["created_at"]
+    else { return nil }
+    let value: GraphFactValue
+    switch type {
+    case .text:
+      guard let stored: String = row["text_value"] else { return nil }
+      value = .text(stored)
+    case .number:
+      guard let stored: Double = row["number_value"] else { return nil }
+      value = .number(stored)
+    case .boolean:
+      guard let stored: Bool = row["boolean_value"] else { return nil }
+      value = .boolean(stored)
+    case .localDate:
+      guard let stored: String = row["local_date_value"],
+        let date = LocalDate(rawValue: stored)
+      else { return nil }
+      value = .localDate(date)
+    case .dateTime:
+      guard let stored: Double = row["date_time_value"] else { return nil }
+      value = .dateTime(Date(timeIntervalSince1970: stored))
+    case .select:
+      guard let stored: String = row["text_value"] else { return nil }
+      value = .select(stored)
+    case .url:
+      guard let stored: String = row["text_value"] else { return nil }
+      value = .url(stored)
+    case .email:
+      guard let stored: String = row["text_value"] else { return nil }
+      value = .email(stored)
+    case .phone:
+      guard let stored: String = row["text_value"] else { return nil }
+      value = .phone(stored)
+    }
+    return .init(
+      id: .init(rawValue: rawID),
+      nodeID: .init(rawValue: rawNodeID),
+      predicateID: .init(rawValue: rawPredicateID),
+      value: value,
+      origin: origin,
+      createdAt: Date(timeIntervalSince1970: createdAt)
+    )
+  }
+}

--- a/apps/enchiridion/Sources/EnchiridionCore/GraphQueryRepository.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/GraphQueryRepository.swift
@@ -72,9 +72,11 @@ extension LibraryRepository {
     guard !name.isEmpty else { throw GraphQueryError.sqlite("Enter a query name.") }
     switch query.source {
     case .builder(let definition):
-      _ = try runGraphQuery(definition, limits: .init(maximumRows: 1))
+      let result = try runGraphQuery(definition, limits: .init(maximumRows: 1))
+      try Self.validate(result: result, presentation: query.presentation)
     case .sql(let sql):
-      _ = try runGraphSQL(sql, limits: .init(maximumRows: 1))
+      let result = try runGraphSQL(sql, limits: .init(maximumRows: 1))
+      try Self.validate(result: result, presentation: query.presentation)
     }
     try database.write { db in
       let sourceKind: String

--- a/apps/enchiridion/Sources/EnchiridionCore/GraphRepository.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/GraphRepository.swift
@@ -49,7 +49,7 @@ extension LibraryRepository {
       normalized.forwardName = forward
       normalized.inverseName = inverse
       try GraphDatabaseSchema.saveRelation(normalized, in: db, modifiedAt: now)
-      try GraphProjectionStore.refreshIssues(in: db)
+      try GraphProjectionStore.refreshIssues(for: [definition.id], in: db)
     }
   }
 
@@ -66,7 +66,7 @@ extension LibraryRepository {
       guard !existing.isSystem else { throw GraphModelError.immutableSystemDefinition }
       existing.isDeleted = true
       try GraphDatabaseSchema.saveRelation(existing, in: db, modifiedAt: now)
-      try GraphProjectionStore.refreshIssues(in: db)
+      try GraphProjectionStore.refreshIssues(for: [id], in: db)
     }
   }
 
@@ -132,7 +132,6 @@ extension LibraryRepository {
       let mutation = try PageDocument.upsertEdge(edge, in: source.document)
       let updated = Self.updatedPage(source, with: mutation, now: now)
       try Self.writePage(db, page: updated, cloudDirty: origin != .provider)
-      try GraphProjectionStore.refreshIssues(in: db)
       return edge
     }
   }
@@ -165,7 +164,6 @@ extension LibraryRepository {
       }
       let updated = Self.updatedPage(source, with: mutation, now: now)
       try Self.writePage(db, page: updated, cloudDirty: true)
-      try GraphProjectionStore.refreshIssues(in: db)
     }
   }
 
@@ -303,7 +301,7 @@ extension LibraryRepository {
         systemFields: systemFields,
         in: db
       )
-      try GraphProjectionStore.refreshIssues(in: db)
+      try GraphProjectionStore.refreshIssues(for: [id], in: db)
       return false
     }
   }
@@ -337,7 +335,7 @@ extension LibraryRepository {
           """,
         arguments: [try JSONEncoder.enchiridion.encode(definition), id.rawValue]
       )
-      try GraphProjectionStore.refreshIssues(in: db)
+      try GraphProjectionStore.refreshIssues(for: [id], in: db)
       return false
     }
   }

--- a/apps/enchiridion/Sources/EnchiridionCore/GraphRepository.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/GraphRepository.swift
@@ -1,0 +1,304 @@
+import Foundation
+import GRDB
+
+extension LibraryRepository {
+  public func relationDefinitions() throws -> [RelationDefinition] {
+    try database.read { db in
+      try Row.fetchAll(
+        db,
+        sql: """
+          SELECT definition_json
+          FROM _graph_relation_definitions
+          WHERE is_deleted = 0
+          ORDER BY is_system DESC, forward_name COLLATE NOCASE
+          """
+      ).compactMap(Self.decodeRelation)
+    }
+  }
+
+  public func saveRelationDefinition(
+    _ definition: RelationDefinition,
+    now: Date = Date()
+  ) throws {
+    let forward = definition.forwardName.trimmingCharacters(in: .whitespacesAndNewlines)
+    let inverse = definition.inverseName.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !forward.isEmpty, !inverse.isEmpty else { throw GraphModelError.invalidEndpoint }
+    try database.write { db in
+      if let existing = try Row.fetchOne(
+        db,
+        sql: "SELECT definition_json FROM _graph_relation_definitions WHERE id = ?",
+        arguments: [definition.id.rawValue]
+      ).flatMap(Self.decodeRelation), existing.isSystem, existing != definition {
+        throw GraphModelError.immutableSystemDefinition
+      }
+      let availableTags = Set(try String.fetchAll(
+        db,
+        sql: "SELECT id FROM supertag_schemas WHERE deleted = 0"
+      ).map(TagID.init(rawValue:)))
+      guard Set(definition.sourceTagIDs).isSubset(of: availableTags),
+        Set(definition.targetTagIDs).isSubset(of: availableTags)
+      else { throw GraphModelError.invalidEndpoint }
+      var normalized = definition
+      normalized.forwardName = forward
+      normalized.inverseName = inverse
+      try GraphDatabaseSchema.saveRelation(normalized, in: db, modifiedAt: now)
+      try GraphProjectionStore.refreshIssues(in: db)
+    }
+  }
+
+  public func deleteRelationDefinition(
+    _ id: RelationID,
+    now: Date = Date()
+  ) throws {
+    try database.write { db in
+      guard var existing = try Row.fetchOne(
+        db,
+        sql: "SELECT definition_json FROM _graph_relation_definitions WHERE id = ?",
+        arguments: [id.rawValue]
+      ).flatMap(Self.decodeRelation) else { throw GraphModelError.unknownRelation(id) }
+      guard !existing.isSystem else { throw GraphModelError.immutableSystemDefinition }
+      existing.isDeleted = true
+      try GraphDatabaseSchema.saveRelation(existing, in: db, modifiedAt: now)
+      try GraphProjectionStore.refreshIssues(in: db)
+    }
+  }
+
+  @discardableResult
+  public func createEdge(
+    relationID: RelationID,
+    from sourceID: NodeID,
+    to targetID: NodeID,
+    origin: GraphEdgeOrigin = .user,
+    now: Date = Date()
+  ) throws -> KnowledgeEdge {
+    try database.write { db in
+      guard let relation = try Row.fetchOne(
+        db,
+        sql: "SELECT definition_json FROM _graph_relation_definitions WHERE id = ? AND is_deleted = 0",
+        arguments: [relationID.rawValue]
+      ).flatMap(Self.decodeRelation) else { throw GraphModelError.unknownRelation(relationID) }
+      guard let source = try Self.fetchPage(db, id: sourceID), source.deletedAt == nil,
+        let target = try Self.fetchPage(db, id: targetID), target.deletedAt == nil
+      else { throw GraphModelError.invalidEndpoint }
+      let sourceTags = try Self.effectiveTagIDs(db, nodeID: sourceID)
+      let targetTags = try Self.effectiveTagIDs(db, nodeID: targetID)
+      guard relation.sourceTagIDs.isEmpty
+        || !sourceTags.isDisjoint(with: relation.sourceTagIDs),
+        relation.targetTagIDs.isEmpty
+        || !targetTags.isDisjoint(with: relation.targetTagIDs)
+      else { throw GraphModelError.invalidEndpoint }
+
+      if relation.cardinality.targetsPerSource == .one,
+        try Int.fetchOne(
+          db,
+          sql: "SELECT COUNT(DISTINCT target_node_id) FROM _graph_edges WHERE relation_id = ? AND source_node_id = ? AND target_node_id <> ?",
+          arguments: [relationID.rawValue, sourceID.rawValue, targetID.rawValue]
+        ) ?? 0 > 0
+      {
+        throw GraphModelError.cardinalityViolation(relationID)
+      }
+      if relation.cardinality.sourcesPerTarget == .one,
+        try Int.fetchOne(
+          db,
+          sql: "SELECT COUNT(DISTINCT source_node_id) FROM _graph_edges WHERE relation_id = ? AND target_node_id = ? AND source_node_id <> ?",
+          arguments: [relationID.rawValue, targetID.rawValue, sourceID.rawValue]
+        ) ?? 0 > 0
+      {
+        throw GraphModelError.cardinalityViolation(relationID)
+      }
+
+      if let existing = try Row.fetchOne(
+        db,
+        sql: "SELECT * FROM _graph_edges WHERE relation_id = ? AND source_node_id = ? AND target_node_id = ?",
+        arguments: [relationID.rawValue, sourceID.rawValue, targetID.rawValue]
+      ).flatMap(Self.decodeEdge) {
+        return existing
+      }
+
+      let edge = KnowledgeEdge(
+        relationID: relationID,
+        sourceNodeID: sourceID,
+        targetNodeID: targetID,
+        origin: origin,
+        createdAt: now
+      )
+      let mutation = try PageDocument.upsertEdge(edge, in: source.document)
+      let updated = Self.updatedPage(source, with: mutation, now: now)
+      try Self.writePage(db, page: updated, cloudDirty: origin != .provider)
+      try GraphProjectionStore.refreshIssues(in: db)
+      return edge
+    }
+  }
+
+  public func removeEdge(_ edgeID: EdgeID, now: Date = Date()) throws {
+    try database.write { db in
+      guard let edge = try Row.fetchOne(
+        db,
+        sql: "SELECT * FROM _graph_edges WHERE edge_id = ?",
+        arguments: [edgeID.rawValue]
+      ).flatMap(Self.decodeEdge),
+        let source = try Self.fetchPage(db, id: edge.sourceNodeID)
+      else { throw GraphModelError.invalidEndpoint }
+      guard edge.origin != .provider, edge.origin != .inlineReference else {
+        throw GraphModelError.immutableSystemDefinition
+      }
+
+      let explicit = (try? PageDocument.inspect(source.document, pageID: source.id).graphEdges) ?? []
+      let mutation: (document: Data, heads: AutomergeHeads, projection: PageDocumentProjection)
+      if explicit.contains(where: { $0.id == edgeID }) {
+        mutation = try PageDocument.removeEdge(edgeID, in: source.document)
+      } else if let key = BuiltInRelations.propertyKey(for: edge.relationID) {
+        let retained = (source.objectMetadata.properties[key] ?? []).filter { value in
+          guard case .page(let pageID) = value else { return true }
+          return pageID != edge.targetNodeID
+        }
+        mutation = try PageDocument.setProperty(key: key, values: retained, in: source.document)
+      } else {
+        throw GraphModelError.invalidEndpoint
+      }
+      let updated = Self.updatedPage(source, with: mutation, now: now)
+      try Self.writePage(db, page: updated, cloudDirty: true)
+      try GraphProjectionStore.refreshIssues(in: db)
+    }
+  }
+
+  public func outgoingEdges(from nodeID: NodeID) throws -> [KnowledgeEdge] {
+    try database.read { db in
+      try Row.fetchAll(
+        db,
+        sql: "SELECT * FROM _graph_edges WHERE source_node_id = ? ORDER BY created_at, edge_id",
+        arguments: [nodeID.rawValue]
+      ).compactMap(Self.decodeEdge)
+    }
+  }
+
+  public func graphBacklinks(to nodeID: NodeID) throws -> [GraphBacklink] {
+    try database.read { db in
+      try Row.fetchAll(
+        db,
+        sql: """
+          SELECT edge.*,
+                 relation.definition_json,
+                 source.title AS source_title
+          FROM _graph_edges edge
+          JOIN _graph_relation_definitions relation ON relation.id = edge.relation_id
+          JOIN pages source ON source.id = edge.source_node_id
+          WHERE edge.target_node_id = ?
+            AND source.deleted_at IS NULL
+            AND relation.is_deleted = 0
+          ORDER BY source.modified_at DESC, edge.edge_id
+          """,
+        arguments: [nodeID.rawValue]
+      ).compactMap { row in
+        guard let edge = Self.decodeEdge(row),
+          let relation = Self.decodeRelation(row),
+          let title: String = row["source_title"]
+        else { return nil }
+        return GraphBacklink(edge: edge, relation: relation, sourceTitle: title)
+      }
+    }
+  }
+
+  public func graphIssues() throws -> [GraphIssue] {
+    try database.read { db in
+      try Row.fetchAll(
+        db,
+        sql: "SELECT * FROM _graph_issues ORDER BY created_at, issue_id"
+      ).compactMap(Self.decodeIssue)
+    }
+  }
+
+  /// Resolves a merge-created max-one conflict without inventing last-writer-wins semantics.
+  public func resolveCardinalityConflict(
+    relationID: RelationID,
+    keeping edgeID: EdgeID,
+    now: Date = Date()
+  ) throws {
+    let conflicts = try database.read { db in
+      guard let keep = try Row.fetchOne(
+        db,
+        sql: "SELECT * FROM _graph_edges WHERE edge_id = ? AND relation_id = ?",
+        arguments: [edgeID.rawValue, relationID.rawValue]
+      ).flatMap(Self.decodeEdge),
+        let relation = try Row.fetchOne(
+          db,
+          sql: "SELECT definition_json FROM _graph_relation_definitions WHERE id = ?",
+          arguments: [relationID.rawValue]
+        ).flatMap(Self.decodeRelation)
+      else { throw GraphModelError.invalidEndpoint }
+      return try Row.fetchAll(
+        db,
+        sql: """
+          SELECT * FROM _graph_edges
+          WHERE relation_id = ? AND edge_id <> ?
+            AND ((? = 'one' AND source_node_id = ?)
+              OR (? = 'one' AND target_node_id = ?))
+          """,
+        arguments: [
+          relationID.rawValue,
+          edgeID.rawValue,
+          relation.cardinality.targetsPerSource.rawValue,
+          keep.sourceNodeID.rawValue,
+          relation.cardinality.sourcesPerTarget.rawValue,
+          keep.targetNodeID.rawValue,
+        ]
+      ).compactMap(Self.decodeEdge)
+    }
+    for edge in conflicts { try removeEdge(edge.id, now: now) }
+  }
+
+  public func effectiveTagIDs(for nodeID: NodeID) throws -> Set<TagID> {
+    try database.read { db in try Self.effectiveTagIDs(db, nodeID: nodeID) }
+  }
+
+  private static func effectiveTagIDs(_ db: Database, nodeID: NodeID) throws -> Set<TagID> {
+    Set(try String.fetchAll(
+      db,
+      sql: "SELECT tag_id FROM graph_node_tags WHERE node_id = ?",
+      arguments: [nodeID.rawValue]
+    ).map(TagID.init(rawValue:)))
+  }
+
+  private static func decodeRelation(_ row: Row) -> RelationDefinition? {
+    guard let data: Data = row["definition_json"] else { return nil }
+    return try? JSONDecoder.enchiridion.decode(RelationDefinition.self, from: data)
+  }
+
+  private static func decodeEdge(_ row: Row) -> KnowledgeEdge? {
+    guard let edgeID: String = row["edge_id"],
+      let relationID: String = row["relation_id"],
+      let sourceID: String = row["source_node_id"],
+      let targetID: String = row["target_node_id"],
+      let originRaw: String = row["origin"],
+      let origin = GraphEdgeOrigin(rawValue: originRaw),
+      let createdAt: Double = row["created_at"]
+    else { return nil }
+    return .init(
+      id: .init(rawValue: edgeID),
+      relationID: .init(rawValue: relationID),
+      sourceNodeID: .init(rawValue: sourceID),
+      targetNodeID: .init(rawValue: targetID),
+      origin: origin,
+      createdAt: Date(timeIntervalSince1970: createdAt)
+    )
+  }
+
+  private static func decodeIssue(_ row: Row) -> GraphIssue? {
+    guard let issueID: String = row["issue_id"],
+      let kindRaw: String = row["kind"],
+      let kind = GraphIssueKind(rawValue: kindRaw),
+      let nodeID: String = row["node_id"],
+      let message: String = row["message"],
+      let createdAt: Double = row["created_at"]
+    else { return nil }
+    return .init(
+      id: .init(rawValue: issueID),
+      kind: kind,
+      nodeID: .init(rawValue: nodeID),
+      edgeID: (row["edge_id"] as String?).map(EdgeID.init(rawValue:)),
+      relationID: (row["relation_id"] as String?).map(RelationID.init(rawValue:)),
+      message: message,
+      createdAt: Date(timeIntervalSince1970: createdAt)
+    )
+  }
+}

--- a/apps/enchiridion/Sources/EnchiridionCore/GraphRepository.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/GraphRepository.swift
@@ -136,7 +136,8 @@ extension LibraryRepository {
     }
   }
 
-  public func removeEdge(_ edgeID: EdgeID, now: Date = Date()) throws {
+  @discardableResult
+  public func removeEdge(_ edgeID: EdgeID, now: Date = Date()) throws -> NodeID {
     try database.write { db in
       guard let edge = try Row.fetchOne(
         db,
@@ -145,25 +146,9 @@ extension LibraryRepository {
       ).flatMap(Self.decodeEdge),
         let source = try Self.fetchPage(db, id: edge.sourceNodeID)
       else { throw GraphModelError.invalidEndpoint }
-      guard edge.origin != .provider, edge.origin != .inlineReference else {
-        throw GraphModelError.immutableSystemDefinition
-      }
-
-      let explicit = (try? PageDocument.inspect(source.document, pageID: source.id).graphEdges) ?? []
-      let mutation: (document: Data, heads: AutomergeHeads, projection: PageDocumentProjection)
-      if explicit.contains(where: { $0.id == edgeID }) {
-        mutation = try PageDocument.removeEdge(edgeID, in: source.document)
-      } else if let key = BuiltInRelations.propertyKey(for: edge.relationID) {
-        let retained = (source.objectMetadata.properties[key] ?? []).filter { value in
-          guard case .page(let pageID) = value else { return true }
-          return pageID != edge.targetNodeID
-        }
-        mutation = try PageDocument.setProperty(key: key, values: retained, in: source.document)
-      } else {
-        throw GraphModelError.invalidEndpoint
-      }
-      let updated = Self.updatedPage(source, with: mutation, now: now)
+      let updated = try Self.removingEdge(edge, from: source, now: now)
       try Self.writePage(db, page: updated, cloudDirty: true)
+      return edge.sourceNodeID
     }
   }
 
@@ -359,7 +344,7 @@ extension LibraryRepository {
     keeping edgeID: EdgeID,
     now: Date = Date()
   ) throws {
-    let conflicts = try database.read { db in
+    try database.write { db in
       guard let keep = try Row.fetchOne(
         db,
         sql: "SELECT * FROM _graph_edges WHERE edge_id = ? AND relation_id = ?",
@@ -371,7 +356,7 @@ extension LibraryRepository {
           arguments: [relationID.rawValue]
         ).flatMap(Self.decodeRelation)
       else { throw GraphModelError.invalidEndpoint }
-      return try Row.fetchAll(
+      let conflicts = try Row.fetchAll(
         db,
         sql: """
           SELECT * FROM _graph_edges
@@ -388,8 +373,22 @@ extension LibraryRepository {
           keep.targetNodeID.rawValue,
         ]
       ).compactMap(Self.decodeEdge)
+      var updatedPages: [NodeID: PageSnapshot] = [:]
+      for edge in conflicts {
+        let source: PageSnapshot
+        if let updated = updatedPages[edge.sourceNodeID] {
+          source = updated
+        } else if let fetched = try Self.fetchPage(db, id: edge.sourceNodeID) {
+          source = fetched
+        } else {
+          throw GraphModelError.invalidEndpoint
+        }
+        updatedPages[edge.sourceNodeID] = try Self.removingEdge(edge, from: source, now: now)
+      }
+      for page in updatedPages.values.sorted(by: { $0.id.rawValue < $1.id.rawValue }) {
+        try Self.writePage(db, page: page, cloudDirty: true)
+      }
     }
-    for edge in conflicts { try removeEdge(edge.id, now: now) }
   }
 
   public func effectiveTagIDs(for nodeID: NodeID) throws -> Set<TagID> {
@@ -402,6 +401,30 @@ extension LibraryRepository {
       sql: "SELECT tag_id FROM graph_node_tags WHERE node_id = ?",
       arguments: [nodeID.rawValue]
     ).map(TagID.init(rawValue:)))
+  }
+
+  private static func removingEdge(
+    _ edge: KnowledgeEdge,
+    from source: PageSnapshot,
+    now: Date
+  ) throws -> PageSnapshot {
+    guard edge.origin != .provider, edge.origin != .inlineReference else {
+      throw GraphModelError.immutableSystemDefinition
+    }
+    let explicit = (try? PageDocument.inspect(source.document, pageID: source.id).graphEdges) ?? []
+    let mutation: (document: Data, heads: AutomergeHeads, projection: PageDocumentProjection)
+    if explicit.contains(where: { $0.id == edge.id }) {
+      mutation = try PageDocument.removeEdge(edge.id, in: source.document)
+    } else if let key = BuiltInRelations.propertyKey(for: edge.relationID) {
+      let retained = (source.objectMetadata.properties[key] ?? []).filter { value in
+        guard case .page(let pageID) = value else { return true }
+        return pageID != edge.targetNodeID
+      }
+      mutation = try PageDocument.setProperty(key: key, values: retained, in: source.document)
+    } else {
+      throw GraphModelError.invalidEndpoint
+    }
+    return Self.updatedPage(source, with: mutation, now: now)
   }
 
   private static func decodeRelation(_ row: Row) -> RelationDefinition? {

--- a/apps/enchiridion/Sources/EnchiridionCore/GraphRepository.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/GraphRepository.swift
@@ -1,6 +1,13 @@
 import Foundation
 import GRDB
 
+public struct RelationDefinitionCloudRecord: Sendable {
+  public var definition: RelationDefinition
+  public var modifiedAt: Date
+  public var dirtyGeneration: Int64
+  public var cloudRecord: Data?
+}
+
 extension LibraryRepository {
   public func relationDefinitions() throws -> [RelationDefinition] {
     try database.read { db in
@@ -208,6 +215,146 @@ extension LibraryRepository {
     }
   }
 
+  public func dirtyRelationDefinitions() throws -> [RelationDefinitionCloudRecord] {
+    try database.read { db in
+      try Row.fetchAll(
+        db,
+        sql: """
+          SELECT * FROM _graph_relation_definitions
+          WHERE cloud_dirty = 1 AND is_system = 0
+          ORDER BY modified_at, id
+          """
+      ).compactMap(Self.decodeRelationCloudRecord)
+    }
+  }
+
+  public func relationDefinitionCloudRecord(
+    id: RelationID
+  ) throws -> RelationDefinitionCloudRecord? {
+    try database.read { db in
+      try Row.fetchOne(
+        db,
+        sql: "SELECT * FROM _graph_relation_definitions WHERE id = ? AND is_system = 0",
+        arguments: [id.rawValue]
+      ).flatMap(Self.decodeRelationCloudRecord)
+    }
+  }
+
+  @discardableResult
+  public func markRelationDefinitionCloudSaved(
+    id: RelationID,
+    sentGeneration: Int64,
+    systemFields: Data
+  ) throws -> Bool {
+    try database.write { db in
+      try db.execute(
+        sql: """
+          UPDATE _graph_relation_definitions
+          SET cloud_record = ?,
+              cloud_synced_generation = MAX(cloud_synced_generation, ?),
+              cloud_dirty = CASE WHEN dirty_generation <= ? THEN 0 ELSE 1 END
+          WHERE id = ? AND is_system = 0
+          """,
+        arguments: [systemFields, sentGeneration, sentGeneration, id.rawValue]
+      )
+      return try Bool.fetchOne(
+        db,
+        sql: "SELECT cloud_dirty FROM _graph_relation_definitions WHERE id = ?",
+        arguments: [id.rawValue]
+      ) ?? false
+    }
+  }
+
+  @discardableResult
+  public func mergeCloudRelationDefinition(
+    id: RelationID,
+    definition: RelationDefinition,
+    isDeleted: Bool,
+    modifiedAt: Date,
+    dirtyGeneration: Int64,
+    systemFields: Data
+  ) throws -> Bool {
+    try database.write { db in
+      if let row = try Row.fetchOne(
+        db,
+        sql: "SELECT is_system, cloud_dirty FROM _graph_relation_definitions WHERE id = ?",
+        arguments: [id.rawValue]
+      ) {
+        let isSystem: Bool = row["is_system"] ?? false
+        guard !isSystem else { throw GraphModelError.immutableSystemDefinition }
+        let isDirty: Bool = row["cloud_dirty"] ?? false
+        if isDirty {
+          try db.execute(
+            sql: "UPDATE _graph_relation_definitions SET cloud_record = ? WHERE id = ?",
+            arguments: [systemFields, id.rawValue]
+          )
+          return true
+        }
+      }
+
+      var normalized = definition
+      normalized.id = id
+      normalized.isSystem = false
+      normalized.isDeleted = isDeleted
+      try Self.writeCloudRelationDefinition(
+        normalized,
+        modifiedAt: modifiedAt,
+        dirtyGeneration: dirtyGeneration,
+        systemFields: systemFields,
+        in: db
+      )
+      try GraphProjectionStore.refreshIssues(in: db)
+      return false
+    }
+  }
+
+  @discardableResult
+  public func applyCloudRelationDefinitionRecordDeletion(id: RelationID) throws -> Bool {
+    try database.write { db in
+      guard let row = try Row.fetchOne(
+        db,
+        sql: "SELECT definition_json,is_system,cloud_dirty FROM _graph_relation_definitions WHERE id = ?",
+        arguments: [id.rawValue]
+      ), !(row["is_system"] as Bool? ?? false)
+      else { return false }
+      if row["cloud_dirty"] as Bool? ?? false {
+        try db.execute(
+          sql: "UPDATE _graph_relation_definitions SET cloud_record = NULL WHERE id = ?",
+          arguments: [id.rawValue]
+        )
+        return true
+      }
+      guard let data: Data = row["definition_json"],
+        var definition = try? JSONDecoder.enchiridion.decode(RelationDefinition.self, from: data)
+      else { throw LibraryRepositoryError.invalidRecord }
+      definition.isDeleted = true
+      try db.execute(
+        sql: """
+          UPDATE _graph_relation_definitions
+          SET is_deleted = 1, definition_json = ?, cloud_record = NULL,
+              cloud_dirty = 0, cloud_synced_generation = dirty_generation
+          WHERE id = ?
+          """,
+        arguments: [try JSONEncoder.enchiridion.encode(definition), id.rawValue]
+      )
+      try GraphProjectionStore.refreshIssues(in: db)
+      return false
+    }
+  }
+
+  public func clearRelationDefinitionCloudRecordMetadata(id: RelationID) throws {
+    try database.write { db in
+      try db.execute(
+        sql: """
+          UPDATE _graph_relation_definitions
+          SET cloud_record = NULL, cloud_dirty = 1
+          WHERE id = ? AND is_system = 0
+          """,
+        arguments: [id.rawValue]
+      )
+    }
+  }
+
   /// Resolves a merge-created max-one conflict without inventing last-writer-wins semantics.
   public func resolveCardinalityConflict(
     relationID: RelationID,
@@ -262,6 +409,84 @@ extension LibraryRepository {
   private static func decodeRelation(_ row: Row) -> RelationDefinition? {
     guard let data: Data = row["definition_json"] else { return nil }
     return try? JSONDecoder.enchiridion.decode(RelationDefinition.self, from: data)
+  }
+
+  private static func decodeRelationCloudRecord(_ row: Row) -> RelationDefinitionCloudRecord? {
+    guard let definition = decodeRelation(row),
+      let modifiedAt: Double = row["modified_at"],
+      let dirtyGeneration: Int64 = row["dirty_generation"]
+    else { return nil }
+    return .init(
+      definition: definition,
+      modifiedAt: Date(timeIntervalSince1970: modifiedAt),
+      dirtyGeneration: dirtyGeneration,
+      cloudRecord: row["cloud_record"]
+    )
+  }
+
+  private static func writeCloudRelationDefinition(
+    _ definition: RelationDefinition,
+    modifiedAt: Date,
+    dirtyGeneration: Int64,
+    systemFields: Data,
+    in db: Database
+  ) throws {
+    try db.execute(
+      sql: """
+        INSERT INTO _graph_relation_definitions
+          (id,forward_name,inverse_name,targets_per_source,sources_per_target,
+           is_system,is_deleted,definition_json,modified_at,dirty_generation,
+           cloud_dirty,cloud_synced_generation,cloud_record)
+        VALUES (?,?,?,?,?,?,?,?,?,?,0,?,?)
+        ON CONFLICT(id) DO UPDATE SET
+          forward_name=excluded.forward_name,
+          inverse_name=excluded.inverse_name,
+          targets_per_source=excluded.targets_per_source,
+          sources_per_target=excluded.sources_per_target,
+          is_system=0,
+          is_deleted=excluded.is_deleted,
+          definition_json=excluded.definition_json,
+          modified_at=excluded.modified_at,
+          dirty_generation=excluded.dirty_generation,
+          cloud_dirty=0,
+          cloud_synced_generation=excluded.cloud_synced_generation,
+          cloud_record=excluded.cloud_record
+        """,
+      arguments: [
+        definition.id.rawValue,
+        definition.forwardName,
+        definition.inverseName,
+        definition.cardinality.targetsPerSource.rawValue,
+        definition.cardinality.sourcesPerTarget.rawValue,
+        false,
+        definition.isDeleted,
+        try JSONEncoder.enchiridion.encode(definition),
+        modifiedAt.timeIntervalSince1970,
+        dirtyGeneration,
+        dirtyGeneration,
+        systemFields,
+      ]
+    )
+    try db.execute(
+      sql: "DELETE FROM _graph_relation_source_tags WHERE relation_id = ?",
+      arguments: [definition.id.rawValue]
+    )
+    try db.execute(
+      sql: "DELETE FROM _graph_relation_target_tags WHERE relation_id = ?",
+      arguments: [definition.id.rawValue]
+    )
+    for tagID in definition.sourceTagIDs {
+      try db.execute(
+        sql: "INSERT INTO _graph_relation_source_tags (relation_id,tag_id) VALUES (?,?)",
+        arguments: [definition.id.rawValue, tagID.rawValue]
+      )
+    }
+    for tagID in definition.targetTagIDs {
+      try db.execute(
+        sql: "INSERT INTO _graph_relation_target_tags (relation_id,tag_id) VALUES (?,?)",
+        arguments: [definition.id.rawValue, tagID.rawValue]
+      )
+    }
   }
 
   private static func decodeEdge(_ row: Row) -> KnowledgeEdge? {

--- a/apps/enchiridion/Sources/EnchiridionCore/GraphSQLExecutor.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/GraphSQLExecutor.swift
@@ -307,18 +307,24 @@ enum GraphSQLExecutor {
       switch bytes[index] {
       case 39: // String literal.
         index += 1
+        var literal: [UInt8] = []
         while index < bytes.count {
           if bytes[index] == 39 {
             if index + 1 < bytes.count, bytes[index + 1] == 39 {
+              literal.append(39)
               index += 2
             } else {
               index += 1
               break
             }
           } else {
+            literal.append(bytes[index])
             index += 1
           }
         }
+        // SQLite accepts single-quoted table names in FROM clauses for compatibility.
+        let identifier = String(decoding: literal, as: UTF8.self).lowercased()
+        if ftsShadowSources.contains(identifier) { return identifier }
       case 34, 96, 91: // Quoted identifier.
         let terminator: UInt8 = bytes[index] == 91 ? 93 : bytes[index]
         index += 1

--- a/apps/enchiridion/Sources/EnchiridionCore/GraphSQLExecutor.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/GraphSQLExecutor.swift
@@ -64,11 +64,11 @@ enum GraphSQLExecutor {
   ]
 
   private static let allowedFunctions: Set<String> = [
-    "abs", "avg", "coalesce", "count", "date", "datetime", "glob", "group_concat",
+    "abs", "avg", "bm25", "coalesce", "count", "date", "datetime", "glob", "group_concat",
     "hex", "ifnull", "iif", "instr", "julianday", "json_array", "json_extract",
     "json_object", "json_type", "length", "like", "likely", "lower", "ltrim", "match",
     "max", "min", "nullif", "printf", "quote", "random", "replace", "round", "row_number",
-    "rtrim", "strftime", "substr", "substring", "sum", "time", "total", "trim", "typeof",
+    "rtrim", "snippet", "strftime", "substr", "substring", "sum", "time", "total", "trim", "typeof",
     "unicode", "unixepoch", "unlikely", "upper",
   ]
 

--- a/apps/enchiridion/Sources/EnchiridionCore/GraphSQLExecutor.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/GraphSQLExecutor.swift
@@ -1,0 +1,371 @@
+import Foundation
+import GRDBSQLite
+
+public struct GraphQueryLimits: Equatable, Sendable {
+  public var maximumRows: Int
+  public var maximumBytes: Int
+  public var maximumDuration: TimeInterval
+
+  public init(
+    maximumRows: Int = 5_000,
+    maximumBytes: Int = 8 * 1_024 * 1_024,
+    maximumDuration: TimeInterval = 2
+  ) {
+    self.maximumRows = min(max(maximumRows, 1), 20_000)
+    self.maximumBytes = min(max(maximumBytes, 1_024), 32 * 1_024 * 1_024)
+    self.maximumDuration = min(max(maximumDuration, 0.05), 10)
+  }
+}
+
+public enum GraphQueryError: Error, LocalizedError, Equatable {
+  case empty
+  case readOnlyRequired
+  case multipleStatements
+  case unauthorized(String)
+  case invalidArgument(String)
+  case sqlite(String)
+  case interrupted
+  case resultTooLarge
+
+  public var errorDescription: String? {
+    switch self {
+    case .empty: "Enter a SELECT query."
+    case .readOnlyRequired: "Graph queries must be a read-only SELECT or WITH statement."
+    case .multipleStatements: "Run one SQL statement at a time."
+    case .unauthorized(let operation): "The query cannot access \(operation)."
+    case .invalidArgument(let name): "The query argument \(name) is invalid."
+    case .sqlite(let message): message
+    case .interrupted: "The query exceeded its execution limit."
+    case .resultTooLarge: "The query result exceeded its memory limit."
+    }
+  }
+}
+
+enum GraphSQLExecutor {
+  private static let allowedSources: Set<String> = [
+    "graph_nodes",
+    "graph_tags",
+    "graph_tag_parents",
+    "graph_tag_closure",
+    "graph_node_tags",
+    "graph_facts",
+    "graph_relation_definitions",
+    "graph_edges",
+    "graph_issues",
+    "graph_text_search",
+  ]
+
+  private static let ftsShadowSources: Set<String> = [
+    "graph_text_search_config",
+    "graph_text_search_content",
+    "graph_text_search_data",
+    "graph_text_search_docsize",
+    "graph_text_search_idx",
+  ]
+
+  private static let allowedFunctions: Set<String> = [
+    "abs", "avg", "coalesce", "count", "date", "datetime", "glob", "group_concat",
+    "hex", "ifnull", "iif", "instr", "julianday", "json_array", "json_extract",
+    "json_object", "json_type", "length", "like", "likely", "lower", "ltrim", "match",
+    "max", "min", "nullif", "printf", "quote", "random", "replace", "round", "row_number",
+    "rtrim", "strftime", "substr", "substring", "sum", "time", "total", "trim", "typeof",
+    "unicode", "unixepoch", "unlikely", "upper",
+  ]
+
+  static func execute(
+    path: String,
+    sql: String,
+    arguments: [String: GraphSQLValue] = [:],
+    limits: GraphQueryLimits = .init()
+  ) throws -> GraphQueryResult {
+    let trimmed = sql.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { throw GraphQueryError.empty }
+    if let forbiddenSource = forbiddenIdentifier(in: trimmed) {
+      throw GraphQueryError.unauthorized(forbiddenSource)
+    }
+    let firstToken = trimmed.prefix { !$0.isWhitespace && $0 != "(" }.uppercased()
+    guard firstToken == "SELECT" || firstToken == "WITH" else {
+      throw GraphQueryError.readOnlyRequired
+    }
+
+    var connection: OpaquePointer?
+    let openCode = sqlite3_open_v2(
+      path,
+      &connection,
+      SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX,
+      nil
+    )
+    guard openCode == SQLITE_OK, let connection else {
+      defer { if connection != nil { sqlite3_close(connection) } }
+      throw GraphQueryError.sqlite(errorMessage(connection))
+    }
+    defer { sqlite3_close(connection) }
+    sqlite3_busy_timeout(connection, 2_000)
+    sqlite3_limit(connection, SQLITE_LIMIT_SQL_LENGTH, 256 * 1_024)
+    sqlite3_limit(connection, SQLITE_LIMIT_COLUMN, 256)
+    sqlite3_limit(connection, SQLITE_LIMIT_COMPOUND_SELECT, 50)
+    sqlite3_limit(connection, SQLITE_LIMIT_EXPR_DEPTH, 100)
+
+    let authorizer = AuthorizerState()
+    let authorizerPointer = Unmanaged.passRetained(authorizer).toOpaque()
+    defer { Unmanaged<AuthorizerState>.fromOpaque(authorizerPointer).release() }
+    sqlite3_set_authorizer(connection, authorizerCallback, authorizerPointer)
+
+    let deadline = DispatchTime.now().uptimeNanoseconds
+      + UInt64(limits.maximumDuration * 1_000_000_000)
+    let progress = ProgressState(deadline: deadline)
+    let progressPointer = Unmanaged.passRetained(progress).toOpaque()
+    defer { Unmanaged<ProgressState>.fromOpaque(progressPointer).release() }
+    sqlite3_progress_handler(connection, 1_000, progressCallback, progressPointer)
+
+    var statement: OpaquePointer?
+    var remainder = ""
+    let prepareCode = trimmed.utf8CString.withUnsafeBufferPointer { sqlBuffer in
+      var tail: UnsafePointer<CChar>?
+      let code = sqlite3_prepare_v3(
+        connection,
+        sqlBuffer.baseAddress,
+        -1,
+        UInt32(SQLITE_PREPARE_PERSISTENT),
+        &statement,
+        &tail
+      )
+      if let tail { remainder = String(cString: tail) }
+      return code
+    }
+    guard prepareCode == SQLITE_OK, let statement else {
+      if let denied = authorizer.deniedOperation {
+        throw GraphQueryError.unauthorized(denied)
+      }
+      throw GraphQueryError.sqlite(errorMessage(connection))
+    }
+    defer { sqlite3_finalize(statement) }
+    let trailingSQL = remainder.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard trailingSQL.isEmpty || trailingSQL.allSatisfy({ $0 == ";" || $0.isWhitespace }) else {
+      throw GraphQueryError.multipleStatements
+    }
+    guard sqlite3_stmt_readonly(statement) != 0 else { throw GraphQueryError.readOnlyRequired }
+
+    for (name, value) in arguments {
+      let normalized = name.hasPrefix(":") ? name : ":\(name)"
+      let index = sqlite3_bind_parameter_index(statement, normalized)
+      guard index > 0 else { throw GraphQueryError.invalidArgument(name) }
+      try bind(value, at: index, statement: statement)
+    }
+
+    let columnCount = Int(sqlite3_column_count(statement))
+    let columns = (0..<columnCount).map { index in
+      GraphQueryColumn(name: String(cString: sqlite3_column_name(statement, Int32(index))))
+    }
+    var rows: [GraphQueryRow] = []
+    var bytes = 0
+    var truncated = false
+    let started = DispatchTime.now().uptimeNanoseconds
+
+    while true {
+      let code = sqlite3_step(statement)
+      if code == SQLITE_DONE { break }
+      if code == SQLITE_INTERRUPT { throw GraphQueryError.interrupted }
+      guard code == SQLITE_ROW else {
+        if let denied = authorizer.deniedOperation {
+          throw GraphQueryError.unauthorized(denied)
+        }
+        throw GraphQueryError.sqlite(errorMessage(connection))
+      }
+      if rows.count >= limits.maximumRows {
+        truncated = true
+        break
+      }
+      var values: [GraphSQLValue] = []
+      values.reserveCapacity(columnCount)
+      for index in 0..<columnCount {
+        let value = columnValue(statement, index: Int32(index))
+        bytes += byteCount(value)
+        guard bytes <= limits.maximumBytes else { throw GraphQueryError.resultTooLarge }
+        values.append(value)
+      }
+      rows.append(.init(id: rows.count, values: values))
+    }
+    let elapsed = Double(DispatchTime.now().uptimeNanoseconds - started) / 1_000_000_000
+    return .init(columns: columns, rows: rows, wasTruncated: truncated, elapsed: elapsed)
+  }
+
+  private static let authorizerCallback: @convention(c) (
+    UnsafeMutableRawPointer?,
+    Int32,
+    UnsafePointer<CChar>?,
+    UnsafePointer<CChar>?,
+    UnsafePointer<CChar>?,
+    UnsafePointer<CChar>?
+  ) -> Int32 = { pointer, action, first, second, _, context in
+    guard let pointer else { return SQLITE_DENY }
+    let state = Unmanaged<AuthorizerState>.fromOpaque(pointer).takeUnretainedValue()
+    switch action {
+    case SQLITE_SELECT, SQLITE_RECURSIVE:
+      return SQLITE_OK
+    case SQLITE_READ:
+      let source = first.map { String(cString: $0).lowercased() } ?? ""
+      let view = context.map { String(cString: $0).lowercased() }
+      if allowedSources.contains(source) || ftsShadowSources.contains(source)
+        || view.map(allowedSources.contains) == true
+      {
+        return SQLITE_OK
+      }
+      state.deniedOperation = source.isEmpty ? "private storage" : source
+      return SQLITE_DENY
+    case SQLITE_FUNCTION:
+      let function = second.map { String(cString: $0).lowercased() }
+        ?? first.map { String(cString: $0).lowercased() }
+        ?? ""
+      guard allowedFunctions.contains(function) else {
+        state.deniedOperation = function.isEmpty ? "an unsafe SQL function" : "the \(function) function"
+        return SQLITE_DENY
+      }
+      return SQLITE_OK
+    case SQLITE_PRAGMA:
+      let pragma = first.map { String(cString: $0).lowercased() } ?? ""
+      if pragma == "data_version" { return SQLITE_OK }
+      state.deniedOperation = pragma.isEmpty ? "a pragma" : "the \(pragma) pragma"
+      return SQLITE_DENY
+    default:
+      state.deniedOperation = "a write or schema operation"
+      return SQLITE_DENY
+    }
+  }
+
+  private static let progressCallback: @convention(c) (UnsafeMutableRawPointer?) -> Int32 = {
+    pointer in
+    guard let pointer else { return 1 }
+    let state = Unmanaged<ProgressState>.fromOpaque(pointer).takeUnretainedValue()
+    return DispatchTime.now().uptimeNanoseconds >= state.deadline ? 1 : 0
+  }
+
+  private static func bind(
+    _ value: GraphSQLValue,
+    at index: Int32,
+    statement: OpaquePointer
+  ) throws {
+    let code: Int32
+    switch value {
+    case .null:
+      code = sqlite3_bind_null(statement, index)
+    case .integer(let value):
+      code = sqlite3_bind_int64(statement, index, value)
+    case .real(let value):
+      code = sqlite3_bind_double(statement, index, value)
+    case .text(let value):
+      code = value.withCString { pointer in
+        sqlite3_bind_text(statement, index, pointer, -1, sqliteTransient)
+      }
+    case .blob(let value):
+      code = value.withUnsafeBytes { buffer in
+        sqlite3_bind_blob(statement, index, buffer.baseAddress, Int32(buffer.count), sqliteTransient)
+      }
+    }
+    guard code == SQLITE_OK else { throw GraphQueryError.sqlite("Could not bind query argument.") }
+  }
+
+  private static func columnValue(_ statement: OpaquePointer, index: Int32) -> GraphSQLValue {
+    switch sqlite3_column_type(statement, index) {
+    case SQLITE_INTEGER: .integer(sqlite3_column_int64(statement, index))
+    case SQLITE_FLOAT: .real(sqlite3_column_double(statement, index))
+    case SQLITE_TEXT:
+      sqlite3_column_text(statement, index).map { .text(String(cString: $0)) } ?? .null
+    case SQLITE_BLOB:
+      if let pointer = sqlite3_column_blob(statement, index) {
+        .blob(Data(bytes: pointer, count: Int(sqlite3_column_bytes(statement, index))))
+      } else {
+        .blob(Data())
+      }
+    default: .null
+    }
+  }
+
+  private static func byteCount(_ value: GraphSQLValue) -> Int {
+    switch value {
+    case .null: 0
+    case .integer, .real: 8
+    case .text(let value): value.utf8.count
+    case .blob(let value): value.count
+    }
+  }
+
+  private static func errorMessage(_ connection: OpaquePointer?) -> String {
+    guard let connection, let message = sqlite3_errmsg(connection) else {
+      return "The SQLite query could not be prepared."
+    }
+    return String(cString: message)
+  }
+
+  /// FTS5 expands a public MATCH query into reads of its private shadow tables before the
+  /// authorizer reports the public virtual table. Reject explicit references up front so those
+  /// internal reads can be authorized without exposing the shadow schema to query authors.
+  private static func forbiddenIdentifier(in sql: String) -> String? {
+    let bytes = Array(sql.utf8)
+    var index = 0
+    while index < bytes.count {
+      switch bytes[index] {
+      case 39: // String literal.
+        index += 1
+        while index < bytes.count {
+          if bytes[index] == 39 {
+            if index + 1 < bytes.count, bytes[index + 1] == 39 {
+              index += 2
+            } else {
+              index += 1
+              break
+            }
+          } else {
+            index += 1
+          }
+        }
+      case 34, 96, 91: // Quoted identifier.
+        let terminator: UInt8 = bytes[index] == 91 ? 93 : bytes[index]
+        index += 1
+        let start = index
+        while index < bytes.count, bytes[index] != terminator { index += 1 }
+        let identifier = String(decoding: bytes[start..<index], as: UTF8.self).lowercased()
+        if ftsShadowSources.contains(identifier) { return identifier }
+        if index < bytes.count { index += 1 }
+      case 45 where index + 1 < bytes.count && bytes[index + 1] == 45:
+        index += 2
+        while index < bytes.count, bytes[index] != 10, bytes[index] != 13 { index += 1 }
+      case 47 where index + 1 < bytes.count && bytes[index + 1] == 42:
+        index += 2
+        while index + 1 < bytes.count, !(bytes[index] == 42 && bytes[index + 1] == 47) {
+          index += 1
+        }
+        index = min(index + 2, bytes.count)
+      default:
+        guard isIdentifierByte(bytes[index]) else {
+          index += 1
+          continue
+        }
+        let start = index
+        while index < bytes.count, isIdentifierByte(bytes[index]) { index += 1 }
+        let identifier = String(decoding: bytes[start..<index], as: UTF8.self).lowercased()
+        if ftsShadowSources.contains(identifier) { return identifier }
+      }
+    }
+    return nil
+  }
+
+  private static func isIdentifierByte(_ byte: UInt8) -> Bool {
+    (byte >= 65 && byte <= 90) || (byte >= 97 && byte <= 122)
+      || (byte >= 48 && byte <= 57) || byte == 95 || byte >= 128
+  }
+
+  private static let sqliteTransient = unsafeBitCast(
+    -1,
+    to: sqlite3_destructor_type.self
+  )
+}
+
+private final class AuthorizerState {
+  var deniedOperation: String?
+}
+
+private final class ProgressState {
+  let deadline: UInt64
+  init(deadline: UInt64) { self.deadline = deadline }
+}

--- a/apps/enchiridion/Sources/EnchiridionCore/GraphSchema.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/GraphSchema.swift
@@ -1,0 +1,211 @@
+import Foundation
+
+public enum GraphValueType: String, Codable, CaseIterable, Hashable, Sendable {
+  case text
+  case number
+  case boolean
+  case localDate
+  case dateTime
+  case select
+  case url
+  case email
+  case phone
+}
+
+public enum GraphFactValue: Codable, Hashable, Sendable {
+  case text(String)
+  case number(Double)
+  case boolean(Bool)
+  case localDate(LocalDate)
+  case dateTime(Date)
+  case select(String)
+  case url(String)
+  case email(String)
+  case phone(String)
+
+  public var type: GraphValueType {
+    switch self {
+    case .text: .text
+    case .number: .number
+    case .boolean: .boolean
+    case .localDate: .localDate
+    case .dateTime: .dateTime
+    case .select: .select
+    case .url: .url
+    case .email: .email
+    case .phone: .phone
+    }
+  }
+
+  public var displayValue: String {
+    switch self {
+    case .text(let value), .select(let value), .url(let value), .email(let value),
+      .phone(let value): value
+    case .number(let value): value.formatted()
+    case .boolean(let value): value ? "Yes" : "No"
+    case .localDate(let value): value.rawValue
+    case .dateTime(let value): value.formatted(date: .abbreviated, time: .shortened)
+    }
+  }
+}
+
+public enum GraphFactOrigin: String, Codable, Hashable, Sendable {
+  case user
+  case provider
+  case system
+}
+
+public struct KnowledgeFact: Codable, Hashable, Sendable, Identifiable {
+  public var id: FactID
+  public var nodeID: NodeID
+  public var predicateID: PredicateID
+  public var value: GraphFactValue
+  public var origin: GraphFactOrigin
+  public var createdAt: Date
+
+  public init(
+    id: FactID = .random(),
+    nodeID: NodeID,
+    predicateID: PredicateID,
+    value: GraphFactValue,
+    origin: GraphFactOrigin = .user,
+    createdAt: Date = Date()
+  ) {
+    self.id = id
+    self.nodeID = nodeID
+    self.predicateID = predicateID
+    self.value = value
+    self.origin = origin
+    self.createdAt = createdAt
+  }
+}
+
+public enum EndpointMaximum: String, Codable, CaseIterable, Hashable, Sendable {
+  case one
+  case many
+}
+
+public struct RelationCardinality: Codable, Hashable, Sendable {
+  /// Maximum outgoing targets allowed for one source node.
+  public var targetsPerSource: EndpointMaximum
+  /// Maximum incoming sources allowed for one target node.
+  public var sourcesPerTarget: EndpointMaximum
+
+  public init(
+    targetsPerSource: EndpointMaximum,
+    sourcesPerTarget: EndpointMaximum
+  ) {
+    self.targetsPerSource = targetsPerSource
+    self.sourcesPerTarget = sourcesPerTarget
+  }
+
+  public static let oneToOne = Self(targetsPerSource: .one, sourcesPerTarget: .one)
+  public static let manyToOne = Self(targetsPerSource: .one, sourcesPerTarget: .many)
+  public static let oneToMany = Self(targetsPerSource: .many, sourcesPerTarget: .one)
+  public static let manyToMany = Self(targetsPerSource: .many, sourcesPerTarget: .many)
+}
+
+public struct RelationDefinition: Codable, Hashable, Sendable, Identifiable {
+  public var id: RelationID
+  public var sourceTagIDs: [TagID]
+  public var targetTagIDs: [TagID]
+  public var forwardName: String
+  public var inverseName: String
+  public var cardinality: RelationCardinality
+  public var isSystem: Bool
+  public var isDeleted: Bool
+
+  public init(
+    id: RelationID,
+    sourceTagIDs: [TagID] = [],
+    targetTagIDs: [TagID] = [],
+    forwardName: String,
+    inverseName: String,
+    cardinality: RelationCardinality = .manyToMany,
+    isSystem: Bool = false,
+    isDeleted: Bool = false
+  ) {
+    self.id = id
+    self.sourceTagIDs = sourceTagIDs
+    self.targetTagIDs = targetTagIDs
+    self.forwardName = forwardName
+    self.inverseName = inverseName
+    self.cardinality = cardinality
+    self.isSystem = isSystem
+    self.isDeleted = isDeleted
+  }
+}
+
+public enum GraphEdgeOrigin: String, Codable, Hashable, Sendable {
+  case user
+  case inlineReference
+  case provider
+  case system
+}
+
+public struct KnowledgeEdge: Codable, Hashable, Sendable, Identifiable {
+  public var id: EdgeID
+  public var relationID: RelationID
+  public var sourceNodeID: NodeID
+  public var targetNodeID: NodeID
+  public var origin: GraphEdgeOrigin
+  public var createdAt: Date
+
+  public init(
+    id: EdgeID = .random(),
+    relationID: RelationID,
+    sourceNodeID: NodeID,
+    targetNodeID: NodeID,
+    origin: GraphEdgeOrigin = .user,
+    createdAt: Date = Date()
+  ) {
+    self.id = id
+    self.relationID = relationID
+    self.sourceNodeID = sourceNodeID
+    self.targetNodeID = targetNodeID
+    self.origin = origin
+    self.createdAt = createdAt
+  }
+}
+
+public struct GraphBacklink: Codable, Hashable, Sendable, Identifiable {
+  public var edge: KnowledgeEdge
+  public var relation: RelationDefinition
+  public var sourceTitle: String
+  public var id: EdgeID { edge.id }
+}
+
+public enum GraphIssueKind: String, Codable, CaseIterable, Hashable, Sendable {
+  case cardinalityViolation
+  case unresolvedTarget
+  case invalidTargetType
+  case inheritanceCycle
+}
+
+public struct GraphIssue: Codable, Hashable, Sendable, Identifiable {
+  public var id: GraphIssueID
+  public var kind: GraphIssueKind
+  public var nodeID: NodeID
+  public var edgeID: EdgeID?
+  public var relationID: RelationID?
+  public var message: String
+  public var createdAt: Date
+
+  public init(
+    id: GraphIssueID,
+    kind: GraphIssueKind,
+    nodeID: NodeID,
+    edgeID: EdgeID? = nil,
+    relationID: RelationID? = nil,
+    message: String,
+    createdAt: Date = Date()
+  ) {
+    self.id = id
+    self.kind = kind
+    self.nodeID = nodeID
+    self.edgeID = edgeID
+    self.relationID = relationID
+    self.message = message
+    self.createdAt = createdAt
+  }
+}

--- a/apps/enchiridion/Sources/EnchiridionCore/GraphSchema.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/GraphSchema.swift
@@ -209,6 +209,7 @@ public struct GraphBacklink: Codable, Hashable, Sendable, Identifiable {
 public enum GraphIssueKind: String, Codable, CaseIterable, Hashable, Sendable {
   case cardinalityViolation
   case unresolvedTarget
+  case invalidSourceType
   case invalidTargetType
   case inheritanceCycle
 }

--- a/apps/enchiridion/Sources/EnchiridionCore/GraphSchema.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/GraphSchema.swift
@@ -76,7 +76,7 @@ public struct KnowledgeFact: Codable, Hashable, Sendable, Identifiable {
     self.predicateID = predicateID
     self.value = value
     self.origin = origin
-    self.createdAt = createdAt
+    self.createdAt = Date(timeIntervalSince1970: createdAt.timeIntervalSince1970)
   }
 }
 
@@ -164,7 +164,38 @@ public struct KnowledgeEdge: Codable, Hashable, Sendable, Identifiable {
     self.sourceNodeID = sourceNodeID
     self.targetNodeID = targetNodeID
     self.origin = origin
-    self.createdAt = createdAt
+    self.createdAt = Date(timeIntervalSince1970: createdAt.timeIntervalSince1970)
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case id
+    case relationID
+    case sourceNodeID
+    case targetNodeID
+    case origin
+    case createdAt
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decode(EdgeID.self, forKey: .id)
+    relationID = try container.decode(RelationID.self, forKey: .relationID)
+    sourceNodeID = try container.decode(NodeID.self, forKey: .sourceNodeID)
+    targetNodeID = try container.decode(NodeID.self, forKey: .targetNodeID)
+    origin = try container.decode(GraphEdgeOrigin.self, forKey: .origin)
+    createdAt = Date(
+      timeIntervalSince1970: try container.decode(Double.self, forKey: .createdAt)
+    )
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(id, forKey: .id)
+    try container.encode(relationID, forKey: .relationID)
+    try container.encode(sourceNodeID, forKey: .sourceNodeID)
+    try container.encode(targetNodeID, forKey: .targetNodeID)
+    try container.encode(origin, forKey: .origin)
+    try container.encode(createdAt.timeIntervalSince1970, forKey: .createdAt)
   }
 }
 

--- a/apps/enchiridion/Sources/EnchiridionCore/LibraryRepository.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/LibraryRepository.swift
@@ -167,10 +167,6 @@ public actor LibraryRepository {
     }
   }
 
-  public static func defaultLocalPath() throws -> String {
-    try VaultRegistry.defaultGraphPath(selection: .defaultCapture)
-  }
-
   func pendingTaskEffectOutboxIdentities() throws -> [TaskEffectOutboxIdentity] {
     try database.read { db in
       try Row.fetchAll(

--- a/apps/enchiridion/Sources/EnchiridionCore/LibraryRepository.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/LibraryRepository.swift
@@ -4220,6 +4220,20 @@ public actor LibraryRepository {
           """
       )
       try db.execute(
+        sql: """
+          UPDATE _graph_relation_definitions
+          SET cloud_dirty = CASE WHEN is_system = 1 THEN 0 ELSE 1 END,
+              cloud_record = NULL,
+              cloud_synced_generation = 0
+          """
+      )
+      try db.execute(
+        sql: """
+          UPDATE _saved_graph_queries
+          SET cloud_dirty = 1, cloud_record = NULL, cloud_synced_generation = 0
+          """
+      )
+      try db.execute(
         sql: "UPDATE purge_markers SET cloud_dirty = 1, cloud_record = NULL"
       )
     }
@@ -5344,6 +5358,20 @@ public actor LibraryRepository {
     }
     migrator.registerMigration("v19-knowledge-graph") { db in
       try GraphDatabaseSchema.install(in: db)
+    }
+    migrator.registerMigration("v20-synced-graph-metadata") { db in
+      let columns = try db.columns(in: "_graph_relation_definitions")
+      if !columns.contains(where: { $0.name == "dirty_generation" }) {
+        try db.alter(table: "_graph_relation_definitions") { table in
+          table.add(column: "dirty_generation", .integer).notNull().defaults(to: 1)
+          table.add(column: "cloud_dirty", .boolean).notNull().defaults(to: true).indexed()
+          table.add(column: "cloud_synced_generation", .integer).notNull().defaults(to: 0)
+          table.add(column: "cloud_record", .blob)
+        }
+        try db.execute(
+          sql: "UPDATE _graph_relation_definitions SET cloud_dirty = 0 WHERE is_system = 1"
+        )
+      }
     }
     return migrator
   }()

--- a/apps/enchiridion/Sources/EnchiridionCore/LibraryRepository.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/LibraryRepository.swift
@@ -168,25 +168,7 @@ public actor LibraryRepository {
   }
 
   public static func defaultLocalPath() throws -> String {
-    let manager = FileManager.default
-#if os(iOS)
-    if let sharedContainer = manager.containerURL(
-      forSecurityApplicationGroupIdentifier: applicationGroupIdentifier
-    ) {
-      let sharedDirectory = sharedContainer
-        .appendingPathComponent("vaults", isDirectory: true)
-        .appendingPathComponent("local", isDirectory: true)
-      try manager.createDirectory(at: sharedDirectory, withIntermediateDirectories: true)
-      let sharedDatabase = sharedDirectory.appendingPathComponent("library.sqlite")
-      try migrateLegacyDatabaseIfNeeded(to: sharedDatabase, manager: manager)
-      try manager.setAttributes(
-        [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication],
-        ofItemAtPath: sharedDirectory.path
-      )
-      return sharedDatabase.path
-    }
-#endif
-    return try legacyLocalPath(manager: manager)
+    try VaultRegistry.defaultGraphPath(selection: .defaultCapture)
   }
 
   func pendingTaskEffectOutboxIdentities() throws -> [TaskEffectOutboxIdentity] {

--- a/apps/enchiridion/Sources/EnchiridionCore/LibraryRepository.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/LibraryRepository.swift
@@ -167,6 +167,10 @@ public actor LibraryRepository {
     }
   }
 
+  public func closeDatabase() throws {
+    try database.close()
+  }
+
   func pendingTaskEffectOutboxIdentities() throws -> [TaskEffectOutboxIdentity] {
     try database.read { db in
       try Row.fetchAll(

--- a/apps/enchiridion/Sources/EnchiridionCore/LibraryRepository.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/LibraryRepository.swift
@@ -135,7 +135,7 @@ public actor LibraryRepository {
   private static let migrationLockTimeout: TimeInterval = 5
 
   public nonisolated let path: String
-  private let database: DatabasePool
+  let database: DatabasePool
 
   func assistantRead<T: Sendable>(
     _ access: @Sendable (Database) throws -> T
@@ -2930,6 +2930,8 @@ public actor LibraryRepository {
           now.timeIntervalSince1970,
         ]
       )
+      try GraphDatabaseSchema.rebuildTagClosure(in: db)
+      try GraphProjectionStore.refreshIssues(in: db)
     }
   }
 
@@ -3031,6 +3033,8 @@ public actor LibraryRepository {
           systemFields,
         ]
       )
+      try GraphDatabaseSchema.rebuildTagClosure(in: db)
+      try GraphProjectionStore.refreshIssues(in: db)
       return false
     }
   }
@@ -3059,6 +3063,8 @@ public actor LibraryRepository {
           """,
         arguments: [id.rawValue]
       )
+      try GraphDatabaseSchema.rebuildTagClosure(in: db)
+      try GraphProjectionStore.refreshIssues(in: db)
       return false
     }
   }
@@ -5340,6 +5346,9 @@ public actor LibraryRepository {
         ]
       )
     }
+    migrator.registerMigration("v19-knowledge-graph") { db in
+      try GraphDatabaseSchema.install(in: db)
+    }
     return migrator
   }()
 
@@ -5374,7 +5383,7 @@ public actor LibraryRepository {
     }
   }
 
-  private static func writePage(
+  static func writePage(
     _ db: Database,
     page: PageSnapshot,
     cloudDirty: Bool,
@@ -5441,6 +5450,8 @@ public actor LibraryRepository {
       ]
     )
     try replaceObjectProjection(db, pageID: page.id, metadata: page.objectMetadata)
+    try GraphProjectionStore.replacePage(page, references: nil, in: db)
+    try GraphProjectionStore.refreshIssues(in: db)
     switch page.kind {
     case .calendarEvent(let identity):
       try mapOccurrencePage(
@@ -5460,7 +5471,7 @@ public actor LibraryRepository {
     }
   }
 
-  private static func updatedPage(
+  static func updatedPage(
     _ current: PageSnapshot,
     with result: (
       document: Data,
@@ -5500,9 +5511,11 @@ public actor LibraryRepository {
         arguments: [pageID.rawValue, reference.targetPageID.rawValue, reference.fallbackLabel]
       )
     }
+    try GraphProjectionStore.replaceMentions(from: pageID, references: references, in: db)
+    try GraphProjectionStore.refreshIssues(in: db)
   }
 
-  private static func fetchPage(_ db: Database, id: PageID) throws -> PageSnapshot? {
+  static func fetchPage(_ db: Database, id: PageID) throws -> PageSnapshot? {
     guard let row = try Row.fetchOne(db, sql: "SELECT * FROM pages WHERE id = ?", arguments: [id.rawValue]) else {
       return nil
     }

--- a/apps/enchiridion/Sources/EnchiridionCore/LibraryRepository.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/LibraryRepository.swift
@@ -356,7 +356,25 @@ public actor LibraryRepository {
     }
   }
 
-  private static func legacyLocalPath(manager: FileManager) throws -> String {
+  static func legacyDefaultDatabaseURLs(manager: FileManager = .default) throws -> [URL] {
+    var databases: [URL] = []
+    #if os(iOS)
+    if let container = manager.containerURL(
+      forSecurityApplicationGroupIdentifier: applicationGroupIdentifier
+    ) {
+      databases.append(
+        container
+          .appendingPathComponent("vaults", isDirectory: true)
+          .appendingPathComponent("local", isDirectory: true)
+          .appendingPathComponent("library.sqlite")
+      )
+    }
+    #endif
+    databases.append(try legacyLocalDatabaseURL(manager: manager))
+    return databases
+  }
+
+  private static func legacyLocalDatabaseURL(manager: FileManager) throws -> URL {
     let base = try manager.url(
       for: .applicationSupportDirectory,
       in: .userDomainMask,
@@ -374,22 +392,8 @@ public actor LibraryRepository {
       ofItemAtPath: directory.path
     )
 #endif
-    return directory.appendingPathComponent("library.sqlite").path
+    return directory.appendingPathComponent("library.sqlite")
   }
-
-#if os(iOS)
-  private static func migrateLegacyDatabaseIfNeeded(
-    to sharedDatabase: URL,
-    manager: FileManager
-  ) throws {
-    let legacyDatabase = URL(fileURLWithPath: try legacyLocalPath(manager: manager))
-    try migrateSQLiteDatabaseIfNeeded(
-      from: legacyDatabase,
-      to: sharedDatabase,
-      manager: manager
-    )
-  }
-#endif
 
   /// Publishes the main database file last, so its presence is a durable
   /// completion marker even if copying a WAL-backed database is interrupted.

--- a/apps/enchiridion/Sources/EnchiridionCore/LibraryRepository.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/LibraryRepository.swift
@@ -5417,6 +5417,7 @@ public actor LibraryRepository {
     cloudDirty: Bool,
     cloudRecord: Data? = nil
   ) throws {
+    var affectedRelationIDs = try GraphProjectionStore.relationIDs(touching: page.id, in: db)
     let kindTag: String
     let dayKey: String?
     switch page.kind {
@@ -5479,7 +5480,10 @@ public actor LibraryRepository {
     )
     try replaceObjectProjection(db, pageID: page.id, metadata: page.objectMetadata)
     try GraphProjectionStore.replacePage(page, references: nil, in: db)
-    try GraphProjectionStore.refreshIssues(in: db)
+    affectedRelationIDs.formUnion(
+      try GraphProjectionStore.relationIDs(touching: page.id, in: db)
+    )
+    try GraphProjectionStore.refreshIssues(for: affectedRelationIDs, in: db)
     switch page.kind {
     case .calendarEvent(let identity):
       try mapOccurrencePage(
@@ -5540,7 +5544,7 @@ public actor LibraryRepository {
       )
     }
     try GraphProjectionStore.replaceMentions(from: pageID, references: references, in: db)
-    try GraphProjectionStore.refreshIssues(in: db)
+    try GraphProjectionStore.refreshIssues(for: [BuiltInRelations.mentions], in: db)
   }
 
   static func fetchPage(_ db: Database, id: PageID) throws -> PageSnapshot? {

--- a/apps/enchiridion/Sources/EnchiridionCore/LibraryStore.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/LibraryStore.swift
@@ -82,7 +82,7 @@ public final class LibraryStore {
   public private(set) var whiteboardError: String?
   public var selectedPageID: PageID?
 
-  @ObservationIgnored private let repository: LibraryRepository?
+  @ObservationIgnored let repository: LibraryRepository?
   @ObservationIgnored private var syncCoordinator: CloudSyncCoordinator?
   @ObservationIgnored private var calendarProvider: EventKitCalendarProvider?
   @ObservationIgnored private var googleCalendarProvider: GoogleCalendarProvider?
@@ -1055,14 +1055,13 @@ public final class LibraryStore {
     }
   }
 
-  public func saveSupertag(_ definition: SupertagDefinition) {
-    Task {
-      do {
-        try await repository?.saveSupertag(definition)
-        await reload()
-        await syncCoordinator?.supertagDidChange(definition.id)
-      } catch { startupError = error.localizedDescription }
+  public func saveSupertag(_ definition: SupertagDefinition) async throws {
+    guard let repository else {
+      throw LibraryRepositoryError.databaseUnavailable(startupError ?? "The vault is unavailable.")
     }
+    try await repository.saveSupertag(definition)
+    await reload()
+    await syncCoordinator?.supertagDidChange(definition.id)
   }
 
   public func saveView(_ definition: LiveQueryDefinition) {

--- a/apps/enchiridion/Sources/EnchiridionCore/LibraryStore.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/LibraryStore.swift
@@ -254,7 +254,7 @@ public final class LibraryStore {
       if CloudSyncCoordinator.hasRequiredEntitlement {
         let coordinator = CloudSyncCoordinator(
           repository: repository,
-          zoneName: "EnchiridionGraph-\(vaultID.rawValue)",
+          zoneName: vaultID.cloudZoneName,
           statusHandler: { [weak self] status in
             Task { @MainActor in self?.syncStatus = status }
           },

--- a/apps/enchiridion/Sources/EnchiridionCore/LibraryStore.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/LibraryStore.swift
@@ -1079,6 +1079,14 @@ public final class LibraryStore {
     await syncCoordinator?.supertagDidChange(definition.id)
   }
 
+  func synchronizeRelationDefinition(_ id: RelationID) async {
+    await syncCoordinator?.relationDefinitionDidChange(id)
+  }
+
+  func synchronizeGraphQuery(_ id: GraphQueryID) async {
+    await syncCoordinator?.graphQueryDidChange(id)
+  }
+
   public func saveView(_ definition: LiveQueryDefinition) {
     Task {
       do {

--- a/apps/enchiridion/Sources/EnchiridionCore/LibraryStore.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/LibraryStore.swift
@@ -57,7 +57,7 @@ public enum TaskClarificationMutationResponse: Sendable {
 @MainActor
 @Observable
 public final class LibraryStore {
-  public let vaultID: VaultID
+  public private(set) var vaultID: VaultID
   public private(set) var pages: [PageSnapshot] = []
   public private(set) var calendarEvents: [CalendarEventSnapshot] = []
   public private(set) var calendarPageContexts: [PageID: CalendarPageContext] = [:]
@@ -83,7 +83,7 @@ public final class LibraryStore {
   public private(set) var whiteboardError: String?
   public var selectedPageID: PageID?
 
-  @ObservationIgnored let repository: LibraryRepository?
+  @ObservationIgnored var repository: LibraryRepository?
   @ObservationIgnored private var syncCoordinator: CloudSyncCoordinator?
   @ObservationIgnored private var calendarProvider: EventKitCalendarProvider?
   @ObservationIgnored private var googleCalendarProvider: GoogleCalendarProvider?
@@ -95,6 +95,10 @@ public final class LibraryStore {
   @ObservationIgnored private var reloadGeneration: UInt64 = 0
   @ObservationIgnored private var taskMutationCoordinator: TaskMutationCoordinator?
   @ObservationIgnored private var undoOfferGeneration: UInt64 = 0
+  @ObservationIgnored private let requestedVaultID: VaultID?
+  @ObservationIgnored private let taskMutationEffects: TaskMutationEffectExecutor?
+  @ObservationIgnored private let shouldOpenRepository: Bool
+  @ObservationIgnored private var isOpeningRepository = false
 
   public init(
     vaultID: VaultID? = nil,
@@ -106,61 +110,17 @@ public final class LibraryStore {
     taskMutationEffects: TaskMutationEffectExecutor? = nil,
     taskInterpreter: any TaskInputInterpreting = FoundationTaskInterpreter()
   ) {
-    let resolvedRepository: LibraryRepository?
-    let resolvedVaultID: VaultID
-    var repositoryStartupError: String?
-    if let repository {
-      resolvedRepository = repository
-      resolvedVaultID = vaultID ?? .standalone
-    } else {
-      do {
-        let context = try VaultRepositoryContext.open(.selected)
-        resolvedRepository = context.repository
-        resolvedVaultID = context.vault.id
-      } catch {
-        resolvedRepository = nil
-        resolvedVaultID = vaultID ?? .standalone
-        repositoryStartupError = error.localizedDescription
-      }
-    }
-
-    self.vaultID = resolvedVaultID
+    self.vaultID = vaultID ?? .standalone
     self.calendar = calendar
     self.taskInterpreter = taskInterpreter
     self.contactResolver = contactResolver
     self.taskSystemReconciliationCoordinator = taskSystemReconciliationCoordinator
-    self.repository = resolvedRepository
-    startupError = repositoryStartupError
-    if let repository = self.repository {
-      let effects =
-        taskMutationEffects
-        ?? TaskMutationEffectExecutor.live(
-          surface: .application,
-          vaultID: resolvedVaultID,
-          reload: { [weak self] in
-            guard let self else { return .failed("The library is unavailable.") }
-            guard await self.reload(policy: .refreshOnly) != nil else {
-              return .failed(self.startupError ?? "The library could not be refreshed.")
-            }
-            return .applied
-          },
-          sync: { [weak self] pageID in
-            guard let coordinator = self?.syncCoordinator else { return .notNeeded }
-            await coordinator.pageDidChange(pageID)
-            return .applied
-          },
-          purgeSync: { [weak self] pageID in
-            guard let coordinator = self?.syncCoordinator else { return .notNeeded }
-            await coordinator.pageWasPurged(pageID)
-            return .applied
-          }
-        )
-      taskMutationCoordinator = TaskMutationCoordinator(
-        repository: repository,
-        calendar: calendar,
-        effects: effects
-      )
-    }
+    self.repository = repository
+    requestedVaultID = vaultID
+    self.taskMutationEffects = taskMutationEffects
+    shouldOpenRepository = repository == nil
+    startupError = nil
+    if let repository { configureTaskMutationCoordinator(repository: repository) }
     if startImmediately {
       Task { await start() }
     }
@@ -236,6 +196,23 @@ public final class LibraryStore {
   }
 
   public func start() async {
+    if repository == nil, shouldOpenRepository {
+      guard !isOpeningRepository else { return }
+      isOpeningRepository = true
+      do {
+        let selection = requestedVaultID.map(VaultSelection.vault) ?? .selected
+        let context = try await Task.detached(priority: .userInitiated) {
+          try VaultRepositoryContext.open(selection)
+        }.value
+        repository = context.repository
+        vaultID = context.vault.id
+        configureTaskMutationCoordinator(repository: context.repository)
+      } catch {
+        startupError = error.localizedDescription
+        isLoading = false
+      }
+      isOpeningRepository = false
+    }
     guard let repository else {
       isLoading = false
       return
@@ -271,6 +248,44 @@ public final class LibraryStore {
       startupError = error.localizedDescription
       isLoading = false
     }
+  }
+
+  public func stop() async {
+    reloadGeneration &+= 1
+    await syncCoordinator?.stop()
+    syncCoordinator = nil
+    taskMutationCoordinator = nil
+  }
+
+  private func configureTaskMutationCoordinator(repository: LibraryRepository) {
+    let effects =
+      taskMutationEffects
+      ?? TaskMutationEffectExecutor.live(
+        surface: .application,
+        vaultID: vaultID,
+        reload: { [weak self] in
+          guard let self else { return .failed("The library is unavailable.") }
+          guard await self.reload(policy: .refreshOnly) != nil else {
+            return .failed(self.startupError ?? "The library could not be refreshed.")
+          }
+          return .applied
+        },
+        sync: { [weak self] pageID in
+          guard let coordinator = self?.syncCoordinator else { return .notNeeded }
+          await coordinator.pageDidChange(pageID)
+          return .applied
+        },
+        purgeSync: { [weak self] pageID in
+          guard let coordinator = self?.syncCoordinator else { return .notNeeded }
+          await coordinator.pageWasPurged(pageID)
+          return .applied
+        }
+      )
+    taskMutationCoordinator = TaskMutationCoordinator(
+      repository: repository,
+      calendar: calendar,
+      effects: effects
+    )
   }
 
   /// Dismisses the current presentation only. Durable side effects remain queued.
@@ -1085,6 +1100,10 @@ public final class LibraryStore {
 
   func synchronizeGraphQuery(_ id: GraphQueryID) async {
     await syncCoordinator?.graphQueryDidChange(id)
+  }
+
+  func synchronizePage(_ id: PageID) async {
+    await syncCoordinator?.pageDidChange(id)
   }
 
   public func saveView(_ definition: LiveQueryDefinition) {

--- a/apps/enchiridion/Sources/EnchiridionCore/LibraryStore.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/LibraryStore.swift
@@ -57,6 +57,7 @@ public enum TaskClarificationMutationResponse: Sendable {
 @MainActor
 @Observable
 public final class LibraryStore {
+  public let vaultID: VaultID
   public private(set) var pages: [PageSnapshot] = []
   public private(set) var calendarEvents: [CalendarEventSnapshot] = []
   public private(set) var calendarPageContexts: [PageID: CalendarPageContext] = [:]
@@ -96,6 +97,7 @@ public final class LibraryStore {
   @ObservationIgnored private var undoOfferGeneration: UInt64 = 0
 
   public init(
+    vaultID: VaultID? = nil,
     repository: LibraryRepository? = nil,
     calendar: Calendar = .current,
     contactResolver: (any DeviceContactResolving)? = nil,
@@ -104,25 +106,37 @@ public final class LibraryStore {
     taskMutationEffects: TaskMutationEffectExecutor? = nil,
     taskInterpreter: any TaskInputInterpreting = FoundationTaskInterpreter()
   ) {
+    let resolvedRepository: LibraryRepository?
+    let resolvedVaultID: VaultID
+    var repositoryStartupError: String?
+    if let repository {
+      resolvedRepository = repository
+      resolvedVaultID = vaultID ?? .standalone
+    } else {
+      do {
+        let context = try VaultRepositoryContext.open(.selected)
+        resolvedRepository = context.repository
+        resolvedVaultID = context.vault.id
+      } catch {
+        resolvedRepository = nil
+        resolvedVaultID = vaultID ?? .standalone
+        repositoryStartupError = error.localizedDescription
+      }
+    }
+
+    self.vaultID = resolvedVaultID
     self.calendar = calendar
     self.taskInterpreter = taskInterpreter
     self.contactResolver = contactResolver
     self.taskSystemReconciliationCoordinator = taskSystemReconciliationCoordinator
-    if let repository {
-      self.repository = repository
-    } else {
-      do {
-        self.repository = try LibraryRepository(path: LibraryRepository.defaultLocalPath())
-      } catch {
-        self.repository = nil
-        startupError = error.localizedDescription
-      }
-    }
+    self.repository = resolvedRepository
+    startupError = repositoryStartupError
     if let repository = self.repository {
       let effects =
         taskMutationEffects
         ?? TaskMutationEffectExecutor.live(
           surface: .application,
+          vaultID: resolvedVaultID,
           reload: { [weak self] in
             guard let self else { return .failed("The library is unavailable.") }
             guard await self.reload(policy: .refreshOnly) != nil else {
@@ -240,6 +254,7 @@ public final class LibraryStore {
       if CloudSyncCoordinator.hasRequiredEntitlement {
         let coordinator = CloudSyncCoordinator(
           repository: repository,
+          zoneName: "EnchiridionGraph-\(vaultID.rawValue)",
           statusHandler: { [weak self] status in
             Task { @MainActor in self?.syncStatus = status }
           },
@@ -314,7 +329,7 @@ public final class LibraryStore {
       otherPeople = loadedOtherPeople
       contactLinks = loadedContactLinks
       if policy == .reconcileSystemState {
-        await taskSystemReconciliationCoordinator.submit(live)
+        await taskSystemReconciliationCoordinator.submit(vaultID: vaultID, pages: live)
       }
       if let selectedPageID, page(id: selectedPageID) == nil {
         self.selectedPageID = live.first?.id

--- a/apps/enchiridion/Sources/EnchiridionCore/LibraryStoreGraph.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/LibraryStoreGraph.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+extension LibraryStore {
+  public func graphRelationDefinitions() async throws -> [RelationDefinition] {
+    guard let repository else {
+      throw LibraryRepositoryError.databaseUnavailable(startupError ?? "The vault is unavailable.")
+    }
+    return try await repository.relationDefinitions()
+  }
+
+  public func saveGraphRelationDefinition(_ definition: RelationDefinition) async throws {
+    guard let repository else {
+      throw LibraryRepositoryError.databaseUnavailable(startupError ?? "The vault is unavailable.")
+    }
+    try await repository.saveRelationDefinition(definition)
+    await reload(policy: .refreshOnly)
+  }
+
+  public func deleteGraphRelationDefinition(_ id: RelationID) async throws {
+    guard let repository else {
+      throw LibraryRepositoryError.databaseUnavailable(startupError ?? "The vault is unavailable.")
+    }
+    try await repository.deleteRelationDefinition(id)
+    await reload(policy: .refreshOnly)
+  }
+
+  public func graphOutgoingEdges(from nodeID: NodeID) async throws -> [KnowledgeEdge] {
+    guard let repository else {
+      throw LibraryRepositoryError.databaseUnavailable(startupError ?? "The vault is unavailable.")
+    }
+    return try await repository.outgoingEdges(from: nodeID)
+  }
+
+  public func graphBacklinks(to nodeID: NodeID) async throws -> [GraphBacklink] {
+    guard let repository else {
+      throw LibraryRepositoryError.databaseUnavailable(startupError ?? "The vault is unavailable.")
+    }
+    return try await repository.graphBacklinks(to: nodeID)
+  }
+
+  public func graphIssues() async throws -> [GraphIssue] {
+    guard let repository else {
+      throw LibraryRepositoryError.databaseUnavailable(startupError ?? "The vault is unavailable.")
+    }
+    return try await repository.graphIssues()
+  }
+
+  @discardableResult
+  public func createGraphEdge(
+    relationID: RelationID,
+    from sourceID: NodeID,
+    to targetID: NodeID
+  ) async throws -> KnowledgeEdge {
+    guard let repository else {
+      throw LibraryRepositoryError.databaseUnavailable(startupError ?? "The vault is unavailable.")
+    }
+    let edge = try await repository.createEdge(
+      relationID: relationID,
+      from: sourceID,
+      to: targetID
+    )
+    await reload(policy: .refreshOnly)
+    return edge
+  }
+
+  public func removeGraphEdge(_ edgeID: EdgeID) async throws {
+    guard let repository else {
+      throw LibraryRepositoryError.databaseUnavailable(startupError ?? "The vault is unavailable.")
+    }
+    try await repository.removeEdge(edgeID)
+    await reload(policy: .refreshOnly)
+  }
+
+  public func resolveGraphCardinalityConflict(
+    relationID: RelationID,
+    keeping edgeID: EdgeID
+  ) async throws {
+    guard let repository else {
+      throw LibraryRepositoryError.databaseUnavailable(startupError ?? "The vault is unavailable.")
+    }
+    try await repository.resolveCardinalityConflict(relationID: relationID, keeping: edgeID)
+    await reload(policy: .refreshOnly)
+  }
+
+  public func runGraphSQL(
+    _ sql: String,
+    arguments: [String: GraphSQLValue] = [:]
+  ) throws -> GraphQueryResult {
+    guard let repository else {
+      throw LibraryRepositoryError.databaseUnavailable(startupError ?? "The vault is unavailable.")
+    }
+    return try repository.runGraphSQL(sql, arguments: arguments)
+  }
+
+  public func runGraphQuery(_ definition: GraphQueryDefinition) throws -> GraphQueryResult {
+    guard let repository else {
+      throw LibraryRepositoryError.databaseUnavailable(startupError ?? "The vault is unavailable.")
+    }
+    return try repository.runGraphQuery(definition)
+  }
+}

--- a/apps/enchiridion/Sources/EnchiridionCore/LibraryStoreGraph.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/LibraryStoreGraph.swift
@@ -62,6 +62,7 @@ extension LibraryStore {
       to: targetID
     )
     await reload(policy: .refreshOnly)
+    await synchronizePage(sourceID)
     return edge
   }
 
@@ -69,8 +70,9 @@ extension LibraryStore {
     guard let repository else {
       throw LibraryRepositoryError.databaseUnavailable(startupError ?? "The vault is unavailable.")
     }
-    try await repository.removeEdge(edgeID)
+    let sourceID = try await repository.removeEdge(edgeID)
     await reload(policy: .refreshOnly)
+    await synchronizePage(sourceID)
   }
 
   public func resolveGraphCardinalityConflict(
@@ -113,6 +115,38 @@ extension LibraryStore {
       throw LibraryRepositoryError.databaseUnavailable(startupError ?? "The vault is unavailable.")
     }
     return try repository.runGraphQuery(query)
+  }
+
+  public func runGraphSQLAsync(
+    _ sql: String,
+    arguments: [String: GraphSQLValue] = [:]
+  ) async throws -> GraphQueryResult {
+    guard let repository else {
+      throw LibraryRepositoryError.databaseUnavailable(startupError ?? "The vault is unavailable.")
+    }
+    return try await Task.detached(priority: .userInitiated) {
+      try repository.runGraphSQL(sql, arguments: arguments)
+    }.value
+  }
+
+  public func runGraphQueryAsync(
+    _ definition: GraphQueryDefinition
+  ) async throws -> GraphQueryResult {
+    guard let repository else {
+      throw LibraryRepositoryError.databaseUnavailable(startupError ?? "The vault is unavailable.")
+    }
+    return try await Task.detached(priority: .userInitiated) {
+      try repository.runGraphQuery(definition)
+    }.value
+  }
+
+  public func runGraphQueryAsync(_ query: SavedGraphQuery) async throws -> GraphQueryResult {
+    guard let repository else {
+      throw LibraryRepositoryError.databaseUnavailable(startupError ?? "The vault is unavailable.")
+    }
+    return try await Task.detached(priority: .userInitiated) {
+      try repository.runGraphQuery(query)
+    }.value
   }
 
   public func saveGraphQuery(_ query: SavedGraphQuery) async throws {

--- a/apps/enchiridion/Sources/EnchiridionCore/LibraryStoreGraph.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/LibraryStoreGraph.swift
@@ -14,6 +14,7 @@ extension LibraryStore {
     }
     try await repository.saveRelationDefinition(definition)
     await reload(policy: .refreshOnly)
+    await synchronizeRelationDefinition(definition.id)
   }
 
   public func deleteGraphRelationDefinition(_ id: RelationID) async throws {
@@ -22,6 +23,7 @@ extension LibraryStore {
     }
     try await repository.deleteRelationDefinition(id)
     await reload(policy: .refreshOnly)
+    await synchronizeRelationDefinition(id)
   }
 
   public func graphOutgoingEdges(from nodeID: NodeID) async throws -> [KnowledgeEdge] {
@@ -118,6 +120,7 @@ extension LibraryStore {
       throw LibraryRepositoryError.databaseUnavailable(startupError ?? "The vault is unavailable.")
     }
     try await repository.saveGraphQuery(query)
+    await synchronizeGraphQuery(query.id)
   }
 
   public func deleteGraphQuery(_ id: GraphQueryID) async throws {
@@ -125,5 +128,6 @@ extension LibraryStore {
       throw LibraryRepositoryError.databaseUnavailable(startupError ?? "The vault is unavailable.")
     }
     try await repository.deleteGraphQuery(id)
+    await synchronizeGraphQuery(id)
   }
 }

--- a/apps/enchiridion/Sources/EnchiridionCore/LibraryStoreGraph.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/LibraryStoreGraph.swift
@@ -98,4 +98,32 @@ extension LibraryStore {
     }
     return try repository.runGraphQuery(definition)
   }
+
+  public func savedGraphQueries() async throws -> [SavedGraphQuery] {
+    guard let repository else {
+      throw LibraryRepositoryError.databaseUnavailable(startupError ?? "The vault is unavailable.")
+    }
+    return try await repository.savedGraphQueries()
+  }
+
+  public func runGraphQuery(_ query: SavedGraphQuery) throws -> GraphQueryResult {
+    guard let repository else {
+      throw LibraryRepositoryError.databaseUnavailable(startupError ?? "The vault is unavailable.")
+    }
+    return try repository.runGraphQuery(query)
+  }
+
+  public func saveGraphQuery(_ query: SavedGraphQuery) async throws {
+    guard let repository else {
+      throw LibraryRepositoryError.databaseUnavailable(startupError ?? "The vault is unavailable.")
+    }
+    try await repository.saveGraphQuery(query)
+  }
+
+  public func deleteGraphQuery(_ id: GraphQueryID) async throws {
+    guard let repository else {
+      throw LibraryRepositoryError.databaseUnavailable(startupError ?? "The vault is unavailable.")
+    }
+    try await repository.deleteGraphQuery(id)
+  }
 }

--- a/apps/enchiridion/Sources/EnchiridionCore/PageDocument.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/PageDocument.swift
@@ -21,6 +21,7 @@ public struct PageDocumentProjection: Hashable, Sendable {
   public var deletedAt: Date?
   public var isPinned: Bool
   public var references: [PageReference]
+  public var graphEdges: [KnowledgeEdge]
   public var objectMetadata: PageObjectMetadata
 }
 
@@ -58,6 +59,7 @@ public enum PageDocument {
     try document.put(obj: metadata, key: "version", value: .Int(1))
     _ = try document.putObject(obj: metadata, key: "tags", ty: .Map)
     _ = try document.putObject(obj: metadata, key: "values", ty: .Map)
+    _ = try document.putObject(obj: .ROOT, key: "edges", ty: .Map)
     let titleObject = try document.putObject(obj: .ROOT, key: "title", ty: .Text)
     try document.spliceText(obj: titleObject, start: 0, delete: 0, value: title)
     _ = try document.putObject(obj: .ROOT, key: "body", ty: .Text)
@@ -215,9 +217,13 @@ public enum PageDocument {
     values: [SupertagValue],
     in snapshot: Data
   ) throws -> (document: Data, heads: AutomergeHeads, projection: PageDocumentProjection) {
-    try mutateMetadata(in: snapshot, message: "Set \(key.fieldID.rawValue)") { document, tags, properties in
+    if !values.isEmpty && values.allSatisfy({ if case .page = $0 { true } else { false } }) {
+      return try setRelationship(key: key, values: values, in: snapshot)
+    }
+    return try mutateMetadata(in: snapshot, message: "Set \(key.fieldID.rawValue)") { document, tags, properties in
       try document.put(obj: tags, key: key.supertagID.rawValue, value: .Boolean(true))
       if values.isEmpty {
+        try replaceRelationshipEdges(document, key: key, targets: [])
         try document.delete(obj: properties, key: key.storageKey)
       } else {
         let data = try JSONEncoder.enchiridion.encode(values)
@@ -240,7 +246,24 @@ public enum PageDocument {
       try document.put(obj: tags, key: supertagID.rawValue, value: .Boolean(true))
       for key in updates.keys.sorted(by: { $0.storageKey < $1.storageKey }) {
         let values = updates[key] ?? []
+        if values.allSatisfy({ if case .page = $0 { true } else { false } }),
+          values.contains(where: { if case .page = $0 { true } else { false } })
+        {
+          try replaceRelationshipEdges(
+            document,
+            key: key,
+            targets: values.compactMap { value in
+              guard case .page(let pageID) = value else { return nil }
+              return pageID
+            }
+          )
+          if try document.get(obj: properties, key: key.storageKey) != nil {
+            try document.delete(obj: properties, key: key.storageKey)
+          }
+          continue
+        }
         if values.isEmpty {
+          try replaceRelationshipEdges(document, key: key, targets: [])
           if try document.get(obj: properties, key: key.storageKey) != nil {
             try document.delete(obj: properties, key: key.storageKey)
           }
@@ -262,6 +285,39 @@ public enum PageDocument {
     in snapshot: Data
   ) throws -> (document: Data, heads: AutomergeHeads, projection: PageDocumentProjection) {
     try setProperty(key: key, values: values, in: snapshot)
+  }
+
+  public static func upsertEdge(
+    _ edge: KnowledgeEdge,
+    in snapshot: Data
+  ) throws -> (document: Data, heads: AutomergeHeads, projection: PageDocumentProjection) {
+    let document = try Document(snapshot)
+    try validate(document)
+    let pageID = try resolvedPageID(document)
+    guard edge.sourceNodeID == pageID else { throw PageDocumentError.invalidSchema }
+    let edges = try edgesObject(document)
+    let encoded = try JSONEncoder.enchiridion.encode(edge)
+    try document.put(
+      obj: edges,
+      key: edge.id.rawValue,
+      value: .String(String(decoding: encoded, as: UTF8.self))
+    )
+    document.commitWith(message: "Add \(edge.relationID.rawValue)", timestamp: Date())
+    return (document.save(), heads(document), try projection(document))
+  }
+
+  public static func removeEdge(
+    _ edgeID: EdgeID,
+    in snapshot: Data
+  ) throws -> (document: Data, heads: AutomergeHeads, projection: PageDocumentProjection) {
+    let document = try Document(snapshot)
+    try validate(document)
+    let edges = try edgesObject(document)
+    if try document.get(obj: edges, key: edgeID.rawValue) != nil {
+      try document.delete(obj: edges, key: edgeID.rawValue)
+    }
+    document.commitWith(message: "Remove relationship", timestamp: Date())
+    return (document.save(), heads(document), try projection(document))
   }
 
   public static func setPersonClassification(
@@ -345,10 +401,8 @@ public enum PageDocument {
     let resolvedPageID: PageID
     if let pageID {
       resolvedPageID = pageID
-    } else if case .Scalar(.String(let value))? = try document.get(obj: .ROOT, key: "pageID") {
-      resolvedPageID = PageID(rawValue: value)
     } else {
-      throw PageDocumentError.invalidSchema
+      resolvedPageID = try Self.resolvedPageID(document)
     }
 
     let deletedAt: Date?
@@ -383,14 +437,66 @@ public enum PageDocument {
       )
     }
 
+    let edges = try graphEdges(document, pageID: resolvedPageID)
     return PageDocumentProjection(
       title: try document.text(obj: titleObject),
       plainText: try document.text(obj: bodyObject),
       deletedAt: deletedAt,
       isPinned: isPinned,
       references: references,
-      objectMetadata: try metadataProjection(document)
+      graphEdges: edges,
+      objectMetadata: try metadataProjection(document, pageID: resolvedPageID, edges: edges)
     )
+  }
+
+  private static func setRelationship(
+    key: SupertagPropertyKey,
+    values: [SupertagValue],
+    in snapshot: Data
+  ) throws -> (document: Data, heads: AutomergeHeads, projection: PageDocumentProjection) {
+    try mutateMetadata(in: snapshot, message: "Set \(key.fieldID.rawValue)") { document, tags, properties in
+      try document.put(obj: tags, key: key.supertagID.rawValue, value: .Boolean(true))
+      if try document.get(obj: properties, key: key.storageKey) != nil {
+        try document.delete(obj: properties, key: key.storageKey)
+      }
+      try replaceRelationshipEdges(
+        document,
+        key: key,
+        targets: values.compactMap { value in
+          guard case .page(let pageID) = value else { return nil }
+          return pageID
+        }
+      )
+    }
+  }
+
+  private static func replaceRelationshipEdges(
+    _ document: Document,
+    key: SupertagPropertyKey,
+    targets: [PageID]
+  ) throws {
+    let edges = try edgesObject(document)
+    let relationID = BuiltInRelations.relationID(for: key)
+    let sourceID = try resolvedPageID(document)
+    for (edgeID, _) in try document.mapEntries(obj: edges) {
+      guard let edge = try decodedEdge(document, edges: edges, key: edgeID),
+        edge.relationID == relationID
+      else { continue }
+      try document.delete(obj: edges, key: edgeID)
+    }
+    for target in targets {
+      let edge = KnowledgeEdge(
+        relationID: relationID,
+        sourceNodeID: sourceID,
+        targetNodeID: target
+      )
+      let encoded = try JSONEncoder.enchiridion.encode(edge)
+      try document.put(
+        obj: edges,
+        key: edge.id.rawValue,
+        value: .String(String(decoding: encoded, as: UTF8.self))
+      )
+    }
   }
 
   private static func mutateMetadata(
@@ -432,7 +538,11 @@ public enum PageDocument {
     return (tags, values)
   }
 
-  private static func metadataProjection(_ document: Document) throws -> PageObjectMetadata {
+  private static func metadataProjection(
+    _ document: Document,
+    pageID: PageID,
+    edges: [KnowledgeEdge]
+  ) throws -> PageObjectMetadata {
     guard case .Object(let metadata, .Map)? = try document.get(obj: .ROOT, key: "objectMetadata") else {
       return .init()
     }
@@ -466,6 +576,24 @@ public enum PageDocument {
         if candidates.count > 1 { conflicts.append(.init(key: key, candidates: candidates)) }
       }
     }
+    for edge in edges where edge.sourceNodeID == pageID {
+      guard let key = BuiltInRelations.propertyKey(for: edge.relationID) else { continue }
+      projected[key, default: []].append(.page(edge.targetNodeID))
+    }
+    for key in projected.keys {
+      projected[key] = Array(Set(projected[key] ?? [])).sorted { $0.id < $1.id }
+    }
+    for key in projected.keys {
+      guard let field = BuiltInSupertags.all
+        .first(where: { $0.id == key.supertagID })?
+        .fields.first(where: { $0.id == key.fieldID }),
+        !field.allowsMultiple,
+        let values = projected[key],
+        values.count > 1,
+        values.allSatisfy({ if case .page = $0 { true } else { false } })
+      else { continue }
+      conflicts.append(.init(key: key, candidates: values.map { [$0] }))
+    }
     let personVisibility: PersonVisibility?
     if case .Scalar(.String(let value))? = try document.get(
       obj: metadata,
@@ -491,6 +619,51 @@ public enum PageDocument {
       personVisibility: personVisibility,
       personOrigin: personOrigin
     )
+  }
+
+  private static func resolvedPageID(_ document: Document) throws -> PageID {
+    guard case .Scalar(.String(let value))? = try document.get(obj: .ROOT, key: "pageID")
+    else { throw PageDocumentError.invalidSchema }
+    return PageID(rawValue: value)
+  }
+
+  private static func edgesObject(_ document: Document) throws -> ObjId {
+    if case .Object(let object, .Map)? = try document.get(obj: .ROOT, key: "edges") {
+      return object
+    }
+    return try document.putObject(obj: .ROOT, key: "edges", ty: .Map)
+  }
+
+  private static func decodedEdge(
+    _ document: Document,
+    edges: ObjId,
+    key: String
+  ) throws -> KnowledgeEdge? {
+    let candidates: [KnowledgeEdge] = try document.getAll(obj: edges, key: key).compactMap { value in
+      guard case .Scalar(.String(let json)) = value,
+        let data = json.data(using: .utf8)
+      else { return nil }
+      return try? JSONDecoder.enchiridion.decode(KnowledgeEdge.self, from: data)
+    }
+    return candidates.sorted { lhs, rhs in
+      let left = (try? String(data: JSONEncoder.enchiridion.encode(lhs), encoding: .utf8)) ?? ""
+      let right = (try? String(data: JSONEncoder.enchiridion.encode(rhs), encoding: .utf8)) ?? ""
+      return left < right
+    }.first
+  }
+
+  private static func graphEdges(
+    _ document: Document,
+    pageID: PageID
+  ) throws -> [KnowledgeEdge] {
+    guard case .Object(let edges, .Map)? = try document.get(obj: .ROOT, key: "edges") else {
+      return []
+    }
+    return try document.mapEntries(obj: edges).compactMap { key, _ in
+      guard var edge = try decodedEdge(document, edges: edges, key: key) else { return nil }
+      edge.sourceNodeID = pageID
+      return edge
+    }.sorted { $0.id.rawValue < $1.id.rawValue }
   }
 
   private static func heads(_ document: Document) -> AutomergeHeads {

--- a/apps/enchiridion/Sources/EnchiridionCore/PageDocument.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/PageDocument.swift
@@ -581,11 +581,13 @@ public enum PageDocument {
         if candidates.count > 1 { conflicts.append(.init(key: key, candidates: candidates)) }
       }
     }
+    var relationshipKeys: Set<SupertagPropertyKey> = []
     for edge in edges where edge.sourceNodeID == pageID {
       guard let key = BuiltInRelations.propertyKey(for: edge.relationID) else { continue }
+      relationshipKeys.insert(key)
       projected[key, default: []].append(.page(edge.targetNodeID))
     }
-    for key in projected.keys {
+    for key in relationshipKeys {
       projected[key] = Array(Set(projected[key] ?? [])).sorted { $0.id < $1.id }
     }
     for key in projected.keys {

--- a/apps/enchiridion/Sources/EnchiridionCore/PageDocument.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/PageDocument.swift
@@ -478,13 +478,18 @@ public enum PageDocument {
     let edges = try edgesObject(document)
     let relationID = BuiltInRelations.relationID(for: key)
     let sourceID = try resolvedPageID(document)
-    for (edgeID, _) in try document.mapEntries(obj: edges) {
+    let targetSet = Set(targets)
+    var retainedTargets: Set<PageID> = []
+    for (edgeID, _) in try document.mapEntries(obj: edges).sorted(by: { $0.0 < $1.0 }) {
       guard let edge = try decodedEdge(document, edges: edges, key: edgeID),
         edge.relationID == relationID
       else { continue }
+      if targetSet.contains(edge.targetNodeID), retainedTargets.insert(edge.targetNodeID).inserted {
+        continue
+      }
       try document.delete(obj: edges, key: edgeID)
     }
-    for target in targets {
+    for target in targets where retainedTargets.insert(target).inserted {
       let edge = KnowledgeEdge(
         relationID: relationID,
         sourceNodeID: sourceID,
@@ -663,7 +668,10 @@ public enum PageDocument {
       guard var edge = try decodedEdge(document, edges: edges, key: key) else { return nil }
       edge.sourceNodeID = pageID
       return edge
-    }.sorted { $0.id.rawValue < $1.id.rawValue }
+    }.sorted {
+      if $0.createdAt != $1.createdAt { return $0.createdAt < $1.createdAt }
+      return $0.id.rawValue < $1.id.rawValue
+    }
   }
 
   private static func heads(_ document: Document) -> AutomergeHeads {

--- a/apps/enchiridion/Sources/EnchiridionCore/SupertagModels.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/SupertagModels.swift
@@ -89,6 +89,9 @@ public struct SupertagDefinition: Identifiable, Codable, Hashable, Sendable {
   public var name: String
   public var symbol: String
   public var fields: [SupertagFieldDefinition]
+  public var parentIDs: [SupertagID]
+  public var relationIDs: [RelationID]
+  public var presentationOrder: [PredicateID]
   public var isBuiltIn: Bool
   public var isDeleted: Bool
 
@@ -97,6 +100,9 @@ public struct SupertagDefinition: Identifiable, Codable, Hashable, Sendable {
     name: String,
     symbol: String,
     fields: [SupertagFieldDefinition],
+    parentIDs: [SupertagID] = [],
+    relationIDs: [RelationID] = [],
+    presentationOrder: [PredicateID] = [],
     isBuiltIn: Bool = false,
     isDeleted: Bool = false
   ) {
@@ -104,6 +110,9 @@ public struct SupertagDefinition: Identifiable, Codable, Hashable, Sendable {
     self.name = name
     self.symbol = symbol
     self.fields = fields
+    self.parentIDs = parentIDs
+    self.relationIDs = relationIDs
+    self.presentationOrder = presentationOrder
     self.isBuiltIn = isBuiltIn
     self.isDeleted = isDeleted
   }
@@ -195,6 +204,8 @@ public struct PageObjectMetadata: Codable, Hashable, Sendable {
 public enum BuiltInSupertags {
   public static let person = SupertagID(rawValue: "person")
   public static let organization = SupertagID(rawValue: "organization")
+  public static let company = SupertagID(rawValue: "company")
+  public static let event = SupertagID(rawValue: "event")
   public static let area = SupertagID(rawValue: "area")
   public static let project = SupertagID(rawValue: "project")
   public static let task = SupertagID(rawValue: "task")
@@ -214,6 +225,21 @@ public enum BuiltInSupertags {
       field("domain", "Domain", .text),
       selectField("relationship", "Relationship", ["Prospect", "Active", "Partner", "Former"]),
       field("notes", "Notes", .text, multiline: true),
+    ]),
+    definition(company, "Company", "building.2.crop.circle", [
+      field("registration-number", "Registration number", .text),
+      field("industry", "Industry", .text),
+    ], parents: [organization]),
+    definition(event, "Event", "calendar", [
+      field("start", "Starts", .dateTime),
+      field("end", "Ends", .dateTime),
+      field("all-day", "All day", .boolean),
+      field("calendar", "Calendar", .text),
+      field("source", "Source", .text),
+      field("location", "Location", .text),
+      field("organizer", "Organizer", .entityReference, allowed: [person]),
+      field("attendees", "Attendees", .entityReference, many: true, allowed: [person]),
+      field("place", "Place", .entityReference, allowed: [place]),
     ]),
     definition(area, "Area", "square.grid.2x2", [
       selectField("status", "Status", ["Active", "On Hold", "Archived"]),
@@ -260,9 +286,22 @@ public enum BuiltInSupertags {
   ]
 
   private static func definition(
-    _ id: SupertagID, _ name: String, _ symbol: String, _ fields: [SupertagFieldDefinition]
+    _ id: SupertagID,
+    _ name: String,
+    _ symbol: String,
+    _ fields: [SupertagFieldDefinition],
+    parents: [SupertagID] = []
   ) -> SupertagDefinition {
-    SupertagDefinition(id: id, name: name, symbol: symbol, fields: fields, isBuiltIn: true)
+    SupertagDefinition(
+      id: id,
+      name: name,
+      symbol: symbol,
+      fields: fields,
+      parentIDs: parents,
+      relationIDs: [],
+      presentationOrder: fields.map { PredicateID.property(tagID: id, fieldID: $0.id) },
+      isBuiltIn: true
+    )
   }
 
   private static func field(

--- a/apps/enchiridion/Sources/EnchiridionCore/TaskDeepLinkRoute.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/TaskDeepLinkRoute.swift
@@ -22,11 +22,16 @@ public enum TaskDeepLinkRoute: Hashable, Sendable {
     }
 
     let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
-    guard let rawVaultID = queryItems.first(where: { $0.name == "vault" })?.value?
-      .trimmingCharacters(in: .whitespacesAndNewlines),
-      rawVaultID.hasPrefix("vault_"), !rawVaultID.isEmpty
-    else { return nil }
-    let vaultID = VaultID(rawValue: rawVaultID)
+    let vaultID: VaultID
+    if let rawVaultID = queryItems.first(where: { $0.name == "vault" })?.value?
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    {
+      guard rawVaultID.hasPrefix("vault_"), !rawVaultID.isEmpty else { return nil }
+      vaultID = VaultID(rawValue: rawVaultID)
+    } else {
+      // Notifications, widgets, and Spotlight links created before vault support are Personal.
+      vaultID = .personal
+    }
 
     if let rawTaskID = queryItems.first(where: { $0.name == "task" })?.value {
       let taskID = rawTaskID.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/apps/enchiridion/Sources/EnchiridionCore/TaskDeepLinkRoute.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/TaskDeepLinkRoute.swift
@@ -1,10 +1,10 @@
 import Foundation
 
-/// The single in-app handoff surface for task links opened by system integrations.
+/// The single vault-scoped in-app handoff surface for task links opened by system integrations.
 public enum TaskDeepLinkRoute: Hashable, Sendable {
-  case list(TaskSmartList)
-  case task(PageID, list: TaskSmartList)
-  case quickAdd(TaskSmartList)
+  case list(TaskSmartList, vaultID: VaultID)
+  case task(VaultScopedNodeID, list: TaskSmartList)
+  case quickAdd(TaskSmartList, vaultID: VaultID)
 
   public init?(url: URL) {
     guard url.scheme?.lowercased() == "enchiridion", url.host?.lowercased() == "tasks"
@@ -22,33 +22,66 @@ public enum TaskDeepLinkRoute: Hashable, Sendable {
     }
 
     let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+    guard let rawVaultID = queryItems.first(where: { $0.name == "vault" })?.value?
+      .trimmingCharacters(in: .whitespacesAndNewlines),
+      rawVaultID.hasPrefix("vault_"), !rawVaultID.isEmpty
+    else { return nil }
+    let vaultID = VaultID(rawValue: rawVaultID)
+
     if let rawTaskID = queryItems.first(where: { $0.name == "task" })?.value {
       let taskID = rawTaskID.trimmingCharacters(in: .whitespacesAndNewlines)
       if !taskID.isEmpty {
-        self = .task(PageID(rawValue: taskID), list: list)
+        self = .task(
+          VaultScopedNodeID(vaultID: vaultID, nodeID: PageID(rawValue: taskID)),
+          list: list
+        )
         return
       }
     }
 
     if queryItems.contains(where: { $0.name == "quickAdd" && $0.value == "1" }) {
-      self = .quickAdd(list)
+      self = .quickAdd(list, vaultID: vaultID)
     } else {
-      self = .list(list)
+      self = .list(list, vaultID: vaultID)
     }
   }
 
   public var list: TaskSmartList {
     switch self {
-    case .list(let list), .quickAdd(let list), .task(_, let list): list
+    case .list(let list, _), .quickAdd(let list, _), .task(_, let list): list
     }
+  }
+
+  public var vaultID: VaultID {
+    switch self {
+    case .list(_, let vaultID), .quickAdd(_, let vaultID): vaultID
+    case .task(let identity, _): identity.vaultID
+    }
+  }
+
+  public static func url(
+    vaultID: VaultID,
+    list: TaskSmartList,
+    taskID: PageID? = nil,
+    quickAdd: Bool = false
+  ) -> URL? {
+    var components = URLComponents()
+    components.scheme = "enchiridion"
+    components.host = "tasks"
+    components.path = "/\(list.rawValue)"
+    var queryItems = [URLQueryItem(name: "vault", value: vaultID.rawValue)]
+    if let taskID { queryItems.append(URLQueryItem(name: "task", value: taskID.rawValue)) }
+    if quickAdd { queryItems.append(URLQueryItem(name: "quickAdd", value: "1")) }
+    components.queryItems = queryItems
+    return components.url
   }
 
   /// Prevents stale or forged task identifiers from opening an unusable detail screen.
   public func validated(against pages: [PageSnapshot]) -> Self {
-    guard case .task(let pageID, let list) = self else { return self }
+    guard case .task(let identity, let list) = self else { return self }
     let isAvailableTask = pages.contains {
-      $0.id == pageID && $0.deletedAt == nil && $0.taskData != nil
+      $0.id == identity.nodeID && $0.deletedAt == nil && $0.taskData != nil
     }
-    return isAvailableTask ? self : .list(list)
+    return isAvailableTask ? self : .list(list, vaultID: identity.vaultID)
   }
 }

--- a/apps/enchiridion/Sources/EnchiridionCore/TaskModels.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/TaskModels.swift
@@ -378,8 +378,7 @@ public struct TaskData: Codable, Hashable, Sendable {
   }
 
   public static func normalizedPageIDs(_ pageIDs: [PageID]) -> [PageID] {
-    var seen: Set<PageID> = []
-    return pageIDs.filter { seen.insert($0).inserted }
+    Array(Set(pageIDs)).sorted { $0.rawValue < $1.rawValue }
   }
 
   public mutating func setScheduleEnabled(

--- a/apps/enchiridion/Sources/EnchiridionCore/TaskMutationCoordinator.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/TaskMutationCoordinator.swift
@@ -305,23 +305,26 @@ struct TaskSystemEffectAdapters: Sendable {
     self.removeSpotlight = removeSpotlight
   }
 
-  static let live = Self(
+  static func live(vaultID: VaultID) -> Self {
+    Self(
     scheduleReminder: { page, requestingAuthorization in
       await TaskReminderScheduler.shared.schedule(
         page,
+        vaultID: vaultID,
         requestingAuthorization: requestingAuthorization
       )
     },
     cancelReminder: { pageID in
-      await TaskReminderScheduler.shared.cancel(pageID)
+      await TaskReminderScheduler.shared.cancel(.init(vaultID: vaultID, nodeID: pageID))
     },
     indexSpotlight: { page in
-      await TaskSystemSpotlight.index(page)
+      await TaskSystemSpotlight.index(page, vaultID: vaultID)
     },
     removeSpotlight: { pageID in
-      await TaskSystemSpotlight.remove(pageID)
+      await TaskSystemSpotlight.remove(.init(vaultID: vaultID, nodeID: pageID))
     }
-  )
+    )
+  }
 }
 
 public struct TaskMutationEffectExecutor: Sendable {
@@ -340,13 +343,15 @@ public struct TaskMutationEffectExecutor: Sendable {
 
   public static func live(
     surface: TaskMutationSurface,
+    vaultID: VaultID = .standalone,
     reload: (@MainActor @Sendable () async -> TaskMutationEffectDisposition)? = nil,
     sync: (@MainActor @Sendable (PageID) async -> TaskMutationEffectDisposition)? = nil,
     purgeSync: (@MainActor @Sendable (PageID) async -> TaskMutationEffectDisposition)? = nil
   ) -> Self {
     live(
       surface: surface,
-      systemEffects: .live,
+      vaultID: vaultID,
+      systemEffects: .live(vaultID: vaultID),
       reload: reload,
       sync: sync,
       purgeSync: purgeSync
@@ -355,6 +360,7 @@ public struct TaskMutationEffectExecutor: Sendable {
 
   static func live(
     surface: TaskMutationSurface,
+    vaultID: VaultID = .standalone,
     systemEffects: TaskSystemEffectAdapters,
     reload: (@MainActor @Sendable () async -> TaskMutationEffectDisposition)? = nil,
     sync: (@MainActor @Sendable (PageID) async -> TaskMutationEffectDisposition)? = nil,

--- a/apps/enchiridion/Sources/EnchiridionCore/TaskMutationWarningPresentation.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/TaskMutationWarningPresentation.swift
@@ -7,10 +7,11 @@ public enum TaskMutationWarningRecovery: Equatable, Sendable {
 
 /// A small, deterministic policy for turning side-effect failures from one persisted
 /// task change (or one outbox drain) into a single user-facing warning.
-public struct TaskMutationWarningPresentation: Equatable, Sendable {
+public struct TaskMutationWarningPresentation: Equatable, Sendable, Identifiable {
   public let title: String
   public let message: String
   public let recovery: TaskMutationWarningRecovery?
+  public var id: String { "\(title)\u{0}\(message)" }
 
   public init(
     title: String,

--- a/apps/enchiridion/Sources/EnchiridionCore/TaskReminderScheduler.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/TaskReminderScheduler.swift
@@ -33,19 +33,19 @@ public enum TaskReminderAction: String, CaseIterable, Equatable, Sendable {
 }
 
 public struct TaskReminderNotificationRoute: Equatable, Sendable {
-  public let pageID: PageID
+  public let identity: VaultScopedNodeID
   public let action: TaskReminderAction
 
-  public init(pageID: PageID, action: TaskReminderAction) {
-    self.pageID = pageID
+  public init(identity: VaultScopedNodeID, action: TaskReminderAction) {
+    self.identity = identity
     self.action = action
   }
 }
 
 public enum TaskReminderActionPlan: Equatable, Sendable {
-  case complete(PageID)
-  case snooze(PageID, until: Date)
-  case open(PageID)
+  case complete(VaultScopedNodeID)
+  case snooze(VaultScopedNodeID, until: Date)
+  case open(VaultScopedNodeID)
 
   public static func make(
     route: TaskReminderNotificationRoute,
@@ -53,9 +53,9 @@ public enum TaskReminderActionPlan: Equatable, Sendable {
     snoozeInterval: TimeInterval = 60 * 60
   ) -> Self {
     switch route.action {
-    case .complete: .complete(route.pageID)
-    case .snooze: .snooze(route.pageID, until: now.addingTimeInterval(snoozeInterval))
-    case .open: .open(route.pageID)
+    case .complete: .complete(route.identity)
+    case .snooze: .snooze(route.identity, until: now.addingTimeInterval(snoozeInterval))
+    case .open: .open(route.identity)
     }
   }
 }
@@ -65,6 +65,7 @@ public actor TaskReminderScheduler {
 
   public nonisolated static let notificationCategoryIdentifier = "ENCHIRIDION_TASK"
   public nonisolated static let pageIDUserInfoKey = "pageID"
+  public nonisolated static let vaultIDUserInfoKey = "vaultID"
 
   private let identifierPrefix = "dev.rawkode.enchiridion.task."
 
@@ -118,6 +119,7 @@ public actor TaskReminderScheduler {
   @discardableResult
   public func schedule(
     _ task: PageSnapshot,
+    vaultID: VaultID,
     requestingAuthorization: Bool = false,
     now: Date = Date(),
     calendar: Calendar = .current
@@ -127,7 +129,7 @@ public actor TaskReminderScheduler {
     guard let data = task.taskData, data.state == .active,
       let reminder = data.reminder, reminder > now
     else {
-      return cancel(task.id)
+      return cancel(.init(vaultID: vaultID, nodeID: task.id))
     }
 
     var settings = await center.notificationSettings()
@@ -158,16 +160,19 @@ public actor TaskReminderScheduler {
     content.title = task.displayTitle
     content.body = notificationBody(for: data)
     content.sound = .default
-    content.userInfo = [Self.pageIDUserInfoKey: task.id.rawValue]
+    content.userInfo = [
+      Self.pageIDUserInfoKey: task.id.rawValue,
+      Self.vaultIDUserInfoKey: vaultID.rawValue,
+    ]
     content.categoryIdentifier = Self.notificationCategoryIdentifier
-    content.targetContentIdentifier = task.id.rawValue
+    content.targetContentIdentifier = "\(vaultID.rawValue)/\(task.id.rawValue)"
 
     let components = calendar.dateComponents(
       [.calendar, .timeZone, .year, .month, .day, .hour, .minute],
       from: reminder
     )
     let request = UNNotificationRequest(
-      identifier: identifier(for: task.id),
+      identifier: identifier(for: .init(vaultID: vaultID, nodeID: task.id)),
       content: content,
       trigger: UNCalendarNotificationTrigger(dateMatching: components, repeats: false)
     )
@@ -179,7 +184,7 @@ public actor TaskReminderScheduler {
     }
   }
 
-  public func reconcile(_ tasks: [PageSnapshot]) async {
+  public func reconcile(_ tasks: [PageSnapshot], vaultID: VaultID) async {
     guard let center else { return }
     let settings = await center.notificationSettings()
     guard
@@ -192,21 +197,21 @@ public actor TaskReminderScheduler {
         guard let data = task.taskData, data.state == .active,
           data.reminder.map({ $0 > Date() }) == true
         else { return nil }
-        return identifier(for: task.id)
+        return identifier(for: .init(vaultID: vaultID, nodeID: task.id))
       })
     let pending = await center.pendingNotificationRequests()
     let stale = pending.map(\.identifier).filter {
-      $0.hasPrefix(identifierPrefix) && !activeIDs.contains($0)
+      $0.hasPrefix(identifierPrefix + vaultID.rawValue + ".") && !activeIDs.contains($0)
     }
     if !stale.isEmpty { center.removePendingNotificationRequests(withIdentifiers: stale) }
-    for task in tasks { await schedule(task) }
+    for task in tasks { await schedule(task, vaultID: vaultID) }
   }
 
   @discardableResult
-  public func cancel(_ pageID: PageID) -> TaskReminderEffectOutcome {
+  public func cancel(_ identity: VaultScopedNodeID) -> TaskReminderEffectOutcome {
     guard let center else { return .unavailable }
-    center.removePendingNotificationRequests(withIdentifiers: [identifier(for: pageID)])
-    center.removeDeliveredNotifications(withIdentifiers: [identifier(for: pageID)])
+    center.removePendingNotificationRequests(withIdentifiers: [identifier(for: identity)])
+    center.removeDeliveredNotifications(withIdentifiers: [identifier(for: identity)])
     return .applied
   }
 
@@ -216,7 +221,8 @@ public actor TaskReminderScheduler {
     defaultActionIdentifier: String? = nil
   ) -> TaskReminderNotificationRoute? {
     guard let rawPageID = userInfo[pageIDUserInfoKey] as? String,
-      !rawPageID.isEmpty
+      let rawVaultID = userInfo[vaultIDUserInfoKey] as? String,
+      !rawPageID.isEmpty, rawVaultID.hasPrefix("vault_")
     else { return nil }
 
     let action: TaskReminderAction?
@@ -228,20 +234,25 @@ public actor TaskReminderScheduler {
       }
     }
     guard let action else { return nil }
-    return TaskReminderNotificationRoute(pageID: PageID(rawValue: rawPageID), action: action)
+    return TaskReminderNotificationRoute(
+      identity: .init(
+        vaultID: .init(rawValue: rawVaultID),
+        nodeID: .init(rawValue: rawPageID)
+      ),
+      action: action
+    )
   }
 
-  public nonisolated static func taskURL(for pageID: PageID) -> URL? {
-    var components = URLComponents()
-    components.scheme = "enchiridion"
-    components.host = "tasks"
-    components.path = "/today"
-    components.queryItems = [URLQueryItem(name: "task", value: pageID.rawValue)]
-    return components.url
+  public nonisolated static func taskURL(for identity: VaultScopedNodeID) -> URL? {
+    TaskDeepLinkRoute.url(
+      vaultID: identity.vaultID,
+      list: .today,
+      taskID: identity.nodeID
+    )
   }
 
-  private func identifier(for pageID: PageID) -> String {
-    identifierPrefix + pageID.rawValue
+  private func identifier(for identity: VaultScopedNodeID) -> String {
+    identifierPrefix + identity.vaultID.rawValue + "." + identity.nodeID.rawValue
   }
 
   private func notificationBody(for data: TaskData) -> String {

--- a/apps/enchiridion/Sources/EnchiridionCore/TaskSystemCoordination.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/TaskSystemCoordination.swift
@@ -148,7 +148,8 @@ public actor TaskSystemReconciliationCoordinator {
   }
 
   private let operation: Operation
-  private var pendingSnapshot: (vaultID: VaultID, pages: [PageSnapshot])?
+  private var pendingSnapshots: [VaultID: [PageSnapshot]] = [:]
+  private var pendingVaultIDs: [VaultID] = []
   private var isDraining = false
   private var idleWaiters: [CheckedContinuation<Void, Never>] = []
 
@@ -157,23 +158,27 @@ public actor TaskSystemReconciliationCoordinator {
   }
 
   public func submit(vaultID: VaultID, pages: [PageSnapshot]) {
-    pendingSnapshot = (vaultID, pages)
+    if pendingSnapshots[vaultID] == nil {
+      pendingVaultIDs.append(vaultID)
+    }
+    pendingSnapshots[vaultID] = pages
     guard !isDraining else { return }
     isDraining = true
     Task { await drain() }
   }
 
   func waitUntilIdle() async {
-    guard isDraining || pendingSnapshot != nil else { return }
+    guard isDraining || !pendingVaultIDs.isEmpty else { return }
     await withCheckedContinuation { continuation in
       idleWaiters.append(continuation)
     }
   }
 
   private func drain() async {
-    while let snapshot = pendingSnapshot {
-      pendingSnapshot = nil
-      await operation(snapshot.vaultID, snapshot.pages)
+    while let vaultID = pendingVaultIDs.first {
+      pendingVaultIDs.removeFirst()
+      guard let pages = pendingSnapshots.removeValue(forKey: vaultID) else { continue }
+      await operation(vaultID, pages)
     }
     isDraining = false
     let waiters = idleWaiters

--- a/apps/enchiridion/Sources/EnchiridionCore/TaskSystemCoordination.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/TaskSystemCoordination.swift
@@ -137,17 +137,18 @@ actor TaskSystemExclusiveOperationLane {
 /// changes while a reconciliation is running, only the newest queued snapshot
 /// runs next and therefore becomes the final Spotlight and notification state.
 public actor TaskSystemReconciliationCoordinator {
-  public typealias Operation = @Sendable ([PageSnapshot]) async -> Void
+  public typealias Operation = @Sendable (VaultID, [PageSnapshot]) async -> Void
 
-  public static let shared = TaskSystemReconciliationCoordinator { pages in
-    await TaskSystemSpotlight.reconcile(pages)
+  public static let shared = TaskSystemReconciliationCoordinator { vaultID, pages in
+    await TaskSystemSpotlight.reconcile(pages, vaultID: vaultID)
     await TaskReminderScheduler.shared.reconcile(
-      pages.filter { $0.hasSupertag(BuiltInSupertags.task) }
+      pages.filter { $0.hasSupertag(BuiltInSupertags.task) },
+      vaultID: vaultID
     )
   }
 
   private let operation: Operation
-  private var pendingPages: [PageSnapshot]?
+  private var pendingSnapshot: (vaultID: VaultID, pages: [PageSnapshot])?
   private var isDraining = false
   private var idleWaiters: [CheckedContinuation<Void, Never>] = []
 
@@ -155,24 +156,24 @@ public actor TaskSystemReconciliationCoordinator {
     self.operation = operation
   }
 
-  public func submit(_ pages: [PageSnapshot]) {
-    pendingPages = pages
+  public func submit(vaultID: VaultID, pages: [PageSnapshot]) {
+    pendingSnapshot = (vaultID, pages)
     guard !isDraining else { return }
     isDraining = true
     Task { await drain() }
   }
 
   func waitUntilIdle() async {
-    guard isDraining || pendingPages != nil else { return }
+    guard isDraining || pendingSnapshot != nil else { return }
     await withCheckedContinuation { continuation in
       idleWaiters.append(continuation)
     }
   }
 
   private func drain() async {
-    while let pages = pendingPages {
-      pendingPages = nil
-      await operation(pages)
+    while let snapshot = pendingSnapshot {
+      pendingSnapshot = nil
+      await operation(snapshot.vaultID, snapshot.pages)
     }
     isDraining = false
     let waiters = idleWaiters

--- a/apps/enchiridion/Sources/EnchiridionCore/TaskSystemSpotlight.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/TaskSystemSpotlight.swift
@@ -16,23 +16,26 @@ public enum TaskSpotlightEffectOutcome: Equatable, Sendable {
 }
 
 public enum TaskSystemSpotlight {
-  private static let domainIdentifier = "dev.rawkode.enchiridion.tasks"
+  private static let domainIdentifierPrefix = "dev.rawkode.enchiridion.tasks."
   private static let operationLane = TaskSystemExclusiveOperationLane()
 
-  static func searchableIdentifier(for pageID: PageID) -> String { pageID.rawValue }
+  static func searchableIdentifier(for identity: VaultScopedNodeID) -> String { identity.id }
 
-  static func contentURL(for pageID: PageID) -> URL? {
-    TaskReminderScheduler.taskURL(for: pageID)
+  static func contentURL(for identity: VaultScopedNodeID) -> URL? {
+    TaskReminderScheduler.taskURL(for: identity)
   }
 
   @discardableResult
-  public static func index(_ page: PageSnapshot) async -> TaskSpotlightEffectOutcome {
+  public static func index(
+    _ page: PageSnapshot,
+    vaultID: VaultID
+  ) async -> TaskSpotlightEffectOutcome {
     #if canImport(CoreSpotlight)
       do {
         return try await operationLane.perform {
           try await withCrossProcessLock {
-            guard let item = searchableItem(for: page) else {
-              return await removeWithoutLock(page.id)
+            guard let item = searchableItem(for: page, vaultID: vaultID) else {
+              return await removeWithoutLock(.init(vaultID: vaultID, nodeID: page.id))
             }
             do {
               try await CSSearchableIndex.default().indexSearchableItems([item])
@@ -51,12 +54,12 @@ public enum TaskSystemSpotlight {
   }
 
   @discardableResult
-  public static func remove(_ pageID: PageID) async -> TaskSpotlightEffectOutcome {
+  public static func remove(_ identity: VaultScopedNodeID) async -> TaskSpotlightEffectOutcome {
     #if canImport(CoreSpotlight)
       do {
         return try await operationLane.perform {
           try await withCrossProcessLock {
-            await removeWithoutLock(pageID)
+            await removeWithoutLock(identity)
           }
         }
       } catch {
@@ -70,19 +73,22 @@ public enum TaskSystemSpotlight {
   /// Rebuilds the task domain from repository state. This is the single
   /// canonical indexing path used at app startup and after local reloads.
   @discardableResult
-  public static func reconcile(_ pages: [PageSnapshot]) async -> TaskSpotlightEffectOutcome {
+  public static func reconcile(
+    _ pages: [PageSnapshot],
+    vaultID: VaultID
+  ) async -> TaskSpotlightEffectOutcome {
     #if canImport(CoreSpotlight)
       do {
         return try await operationLane.perform {
           try await withCrossProcessLock {
             do {
               try await CSSearchableIndex.default().deleteSearchableItems(
-                withDomainIdentifiers: [domainIdentifier]
+                withDomainIdentifiers: [domainIdentifier(for: vaultID)]
               )
             } catch {
               return .removalFailed(error.localizedDescription)
             }
-            let activeItems = pages.compactMap(searchableItem(for:))
+            let activeItems = pages.compactMap { searchableItem(for: $0, vaultID: vaultID) }
             guard !activeItems.isEmpty else { return .applied }
             do {
               try await CSSearchableIndex.default().indexSearchableItems(activeItems)
@@ -101,7 +107,10 @@ public enum TaskSystemSpotlight {
   }
 
   #if canImport(CoreSpotlight)
-    private static func searchableItem(for page: PageSnapshot) -> CSSearchableItem? {
+    private static func searchableItem(
+      for page: PageSnapshot,
+      vaultID: VaultID
+    ) -> CSSearchableItem? {
       guard page.deletedAt == nil, let task = page.taskData, task.state == .active else {
         return nil
       }
@@ -111,18 +120,21 @@ public enum TaskSystemSpotlight {
       attributes.dueDate = task.deadline
       attributes.keywords =
         task.tags + (task.priority == .none ? [] : [task.priority.rawValue])
-      attributes.contentURL = contentURL(for: page.id)
+      let identity = VaultScopedNodeID(vaultID: vaultID, nodeID: page.id)
+      attributes.contentURL = contentURL(for: identity)
       return CSSearchableItem(
-        uniqueIdentifier: searchableIdentifier(for: page.id),
-        domainIdentifier: domainIdentifier,
+        uniqueIdentifier: searchableIdentifier(for: identity),
+        domainIdentifier: domainIdentifier(for: vaultID),
         attributeSet: attributes
       )
     }
 
-    private static func removeWithoutLock(_ pageID: PageID) async -> TaskSpotlightEffectOutcome {
+    private static func removeWithoutLock(
+      _ identity: VaultScopedNodeID
+    ) async -> TaskSpotlightEffectOutcome {
       do {
         try await CSSearchableIndex.default().deleteSearchableItems(
-          withIdentifiers: [pageID.rawValue]
+          withIdentifiers: [searchableIdentifier(for: identity)]
         )
         return .applied
       } catch {
@@ -133,7 +145,7 @@ public enum TaskSystemSpotlight {
     private static func withCrossProcessLock<Value: Sendable>(
       _ operation: @escaping @Sendable () async -> Value
     ) async throws -> Value {
-      let lockPath = try LibraryRepository.defaultLocalPath() + ".spotlight.lock"
+      let lockPath = try VaultRegistry.defaultCatalogPath() + ".spotlight.lock"
       let descriptor = open(lockPath, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)
       guard descriptor >= 0 else { throw posixError() }
       defer { close(descriptor) }
@@ -146,4 +158,8 @@ public enum TaskSystemSpotlight {
       NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
     }
   #endif
+
+  private static func domainIdentifier(for vaultID: VaultID) -> String {
+    domainIdentifierPrefix + vaultID.rawValue
+  }
 }

--- a/apps/enchiridion/Sources/EnchiridionCore/VaultRegistry.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/VaultRegistry.swift
@@ -28,7 +28,7 @@ public struct VaultDescriptor: Codable, Hashable, Sendable, Identifiable {
     self.deletedAt = deletedAt
   }
 
-  public var cloudZoneName: String { "EnchiridionGraph-\(id.rawValue)" }
+  public var cloudZoneName: String { id.cloudZoneName }
 }
 
 public struct VaultRegistrySnapshot: Equatable, Sendable {
@@ -256,7 +256,7 @@ public final class VaultRegistry: @unchecked Sendable {
   private func bootstrapIfNeeded() throws {
     try database.write { db in
       if try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM vaults WHERE deleted_at IS NULL") == 0 {
-        let personal = VaultDescriptor(name: Self.personalVaultName)
+        let personal = VaultDescriptor(id: .personal, name: Self.personalVaultName)
         try Self.insert(personal, db: db)
         try Self.setPreference(db, key: "selected-vault-id", value: personal.id.rawValue)
         try Self.setPreference(db, key: "default-capture-vault-id", value: personal.id.rawValue)

--- a/apps/enchiridion/Sources/EnchiridionCore/VaultRegistry.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/VaultRegistry.swift
@@ -99,13 +99,20 @@ public final class VaultRegistry: @unchecked Sendable {
 
   public static func defaultCatalogPath() throws -> String {
     let manager = FileManager.default
+    let catalogURL: URL
     #if os(iOS) || os(macOS)
     if let container = manager.containerURL(
       forSecurityApplicationGroupIdentifier: LibraryRepository.applicationGroupIdentifier
     ) {
       let directory = container.appendingPathComponent("vaults", isDirectory: true)
       try manager.createDirectory(at: directory, withIntermediateDirectories: true)
-      return directory.appendingPathComponent("catalog.sqlite").path
+      catalogURL = directory.appendingPathComponent("catalog.sqlite")
+      try migrateLegacyPersonalVaultIfNeeded(
+        catalogPath: catalogURL.path,
+        legacyDatabaseURLs: LibraryRepository.legacyDefaultDatabaseURLs(manager: manager),
+        manager: manager
+      )
+      return catalogURL.path
     }
     #endif
     let base = try manager.url(
@@ -118,7 +125,34 @@ public final class VaultRegistry: @unchecked Sendable {
       .appendingPathComponent("dev.rawkode.enchiridion", isDirectory: true)
       .appendingPathComponent("vaults", isDirectory: true)
     try manager.createDirectory(at: directory, withIntermediateDirectories: true)
-    return directory.appendingPathComponent("catalog.sqlite").path
+    catalogURL = directory.appendingPathComponent("catalog.sqlite")
+    try migrateLegacyPersonalVaultIfNeeded(
+      catalogPath: catalogURL.path,
+      legacyDatabaseURLs: LibraryRepository.legacyDefaultDatabaseURLs(manager: manager),
+      manager: manager
+    )
+    return catalogURL.path
+  }
+
+  static func migrateLegacyPersonalVaultIfNeeded(
+    catalogPath: String,
+    legacyDatabaseURLs: [URL],
+    manager: FileManager = .default
+  ) throws {
+    let destinationDirectory = URL(fileURLWithPath: catalogPath)
+      .deletingLastPathComponent()
+      .appendingPathComponent(VaultID.personal.rawValue, isDirectory: true)
+    try manager.createDirectory(at: destinationDirectory, withIntermediateDirectories: true)
+    let destinationDatabase = destinationDirectory.appendingPathComponent("graph.sqlite")
+
+    for sourceDatabase in legacyDatabaseURLs {
+      guard !manager.fileExists(atPath: destinationDatabase.path) else { return }
+      try LibraryRepository.migrateSQLiteDatabaseIfNeeded(
+        from: sourceDatabase,
+        to: destinationDatabase,
+        manager: manager
+      )
+    }
   }
 
   public static func defaultGraphPath(

--- a/apps/enchiridion/Sources/EnchiridionCore/VaultRegistry.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/VaultRegistry.swift
@@ -238,6 +238,7 @@ public final class VaultRegistry: @unchecked Sendable {
   /// repository before removing the returned SQLite files.
   @discardableResult
   public func deleteVault(_ id: VaultID, now: Date = Date()) throws -> String {
+    let graphPath = try graphPathWithoutCreating(for: id)
     try database.write { db in
       let active = try Self.fetchActiveVaults(db)
       guard active.contains(where: { $0.id == id }) else {
@@ -254,8 +255,8 @@ public final class VaultRegistry: @unchecked Sendable {
           try Self.setPreference(db, key: key, value: fallback.rawValue)
         }
       }
-      return try graphPath(for: id)
     }
+    return graphPath
   }
 
   public func graphPath(selection: VaultSelection) throws -> String {
@@ -273,10 +274,8 @@ public final class VaultRegistry: @unchecked Sendable {
   }
 
   public func graphPath(for id: VaultID) throws -> String {
-    guard Self.isSafe(id) else { throw VaultRegistryError.invalidIdentifier }
-    let catalogURL = URL(fileURLWithPath: path)
-    let directory = catalogURL.deletingLastPathComponent()
-      .appendingPathComponent(id.rawValue, isDirectory: true)
+    let graphPath = try graphPathWithoutCreating(for: id)
+    let directory = URL(fileURLWithPath: graphPath).deletingLastPathComponent()
     try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
     #if os(iOS)
     try FileManager.default.setAttributes(
@@ -284,6 +283,14 @@ public final class VaultRegistry: @unchecked Sendable {
       ofItemAtPath: directory.path
     )
     #endif
+    return graphPath
+  }
+
+  func graphPathWithoutCreating(for id: VaultID) throws -> String {
+    guard Self.isSafe(id) else { throw VaultRegistryError.invalidIdentifier }
+    let catalogURL = URL(fileURLWithPath: path)
+    let directory = catalogURL.deletingLastPathComponent()
+      .appendingPathComponent(id.rawValue, isDirectory: true)
     return directory.appendingPathComponent("graph.sqlite").path
   }
 

--- a/apps/enchiridion/Sources/EnchiridionCore/VaultRegistry.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/VaultRegistry.swift
@@ -1,0 +1,370 @@
+import Foundation
+import GRDB
+
+public struct VaultDescriptor: Codable, Hashable, Sendable, Identifiable {
+  public var id: VaultID
+  public var name: String
+  public var createdAt: Date
+  public var modifiedAt: Date
+  public var sortOrder: Int
+  public var isDownloaded: Bool
+  public var deletedAt: Date?
+
+  public init(
+    id: VaultID = .random(),
+    name: String,
+    createdAt: Date = Date(),
+    modifiedAt: Date? = nil,
+    sortOrder: Int = 0,
+    isDownloaded: Bool = true,
+    deletedAt: Date? = nil
+  ) {
+    self.id = id
+    self.name = name
+    self.createdAt = createdAt
+    self.modifiedAt = modifiedAt ?? createdAt
+    self.sortOrder = sortOrder
+    self.isDownloaded = isDownloaded
+    self.deletedAt = deletedAt
+  }
+
+  public var cloudZoneName: String { "EnchiridionGraph-\(id.rawValue)" }
+}
+
+public struct VaultRegistrySnapshot: Equatable, Sendable {
+  public var vaults: [VaultDescriptor]
+  public var selectedVaultID: VaultID
+  public var defaultCaptureVaultID: VaultID
+
+  public init(
+    vaults: [VaultDescriptor],
+    selectedVaultID: VaultID,
+    defaultCaptureVaultID: VaultID
+  ) {
+    self.vaults = vaults
+    self.selectedVaultID = selectedVaultID
+    self.defaultCaptureVaultID = defaultCaptureVaultID
+  }
+}
+
+public enum VaultSelection: Sendable {
+  case selected
+  case defaultCapture
+  case vault(VaultID)
+}
+
+public enum VaultRegistryError: Error, LocalizedError, Equatable {
+  case invalidName
+  case invalidIdentifier
+  case vaultNotFound
+  case cannotDeleteOnlyVault
+
+  public var errorDescription: String? {
+    switch self {
+    case .invalidName: "Enter a vault name."
+    case .invalidIdentifier: "The vault identifier is invalid."
+    case .vaultNotFound: "The vault is no longer available."
+    case .cannotDeleteOnlyVault: "Create another vault before deleting this one."
+    }
+  }
+}
+
+/// The small app-group catalog is the only process-wide authority for locating vault databases.
+/// Graph data never crosses this boundary: each descriptor maps to one independent SQLite file.
+public final class VaultRegistry: @unchecked Sendable {
+  public static let catalogZoneName = "EnchiridionGraphCatalog"
+  public static let personalVaultName = "Personal"
+
+  public let path: String
+  private let database: DatabasePool
+
+  public init(path: String) throws {
+    self.path = path
+    let url = URL(fileURLWithPath: path)
+    try FileManager.default.createDirectory(
+      at: url.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    var configuration = Configuration()
+    configuration.busyMode = .timeout(5)
+    configuration.journalMode = .wal
+    configuration.prepareDatabase { db in
+      try db.execute(sql: "PRAGMA foreign_keys = ON")
+      try db.execute(sql: "PRAGMA synchronous = FULL")
+    }
+    database = try DatabasePool(path: path, configuration: configuration)
+    try Self.migrator.migrate(database)
+    try bootstrapIfNeeded()
+  }
+
+  public static func defaultCatalogPath() throws -> String {
+    let manager = FileManager.default
+    #if os(iOS) || os(macOS)
+    if let container = manager.containerURL(
+      forSecurityApplicationGroupIdentifier: LibraryRepository.applicationGroupIdentifier
+    ) {
+      let directory = container.appendingPathComponent("vaults", isDirectory: true)
+      try manager.createDirectory(at: directory, withIntermediateDirectories: true)
+      return directory.appendingPathComponent("catalog.sqlite").path
+    }
+    #endif
+    let base = try manager.url(
+      for: .applicationSupportDirectory,
+      in: .userDomainMask,
+      appropriateFor: nil,
+      create: true
+    )
+    let directory = base
+      .appendingPathComponent("dev.rawkode.enchiridion", isDirectory: true)
+      .appendingPathComponent("vaults", isDirectory: true)
+    try manager.createDirectory(at: directory, withIntermediateDirectories: true)
+    return directory.appendingPathComponent("catalog.sqlite").path
+  }
+
+  public static func defaultGraphPath(
+    selection: VaultSelection = .selected
+  ) throws -> String {
+    let registry = try VaultRegistry(path: defaultCatalogPath())
+    return try registry.graphPath(selection: selection)
+  }
+
+  public func snapshot() throws -> VaultRegistrySnapshot {
+    try database.read { db in
+      let vaults = try Self.fetchActiveVaults(db)
+      guard let first = vaults.first else { throw VaultRegistryError.vaultNotFound }
+      let selected = try Self.preference(db, key: "selected-vault-id")
+        .map(VaultID.init(rawValue:))
+        .flatMap { id in vaults.contains(where: { $0.id == id }) ? id : nil }
+        ?? first.id
+      let capture = try Self.preference(db, key: "default-capture-vault-id")
+        .map(VaultID.init(rawValue:))
+        .flatMap { id in vaults.contains(where: { $0.id == id }) ? id : nil }
+        ?? selected
+      return .init(
+        vaults: vaults,
+        selectedVaultID: selected,
+        defaultCaptureVaultID: capture
+      )
+    }
+  }
+
+  @discardableResult
+  public func createVault(name: String, now: Date = Date()) throws -> VaultDescriptor {
+    let normalizedName = try Self.normalizedName(name)
+    return try database.write { db in
+      let sortOrder = try Int.fetchOne(
+        db,
+        sql: "SELECT COALESCE(MAX(sort_order), -1) + 1 FROM vaults WHERE deleted_at IS NULL"
+      ) ?? 0
+      let descriptor = VaultDescriptor(
+        name: normalizedName,
+        createdAt: now,
+        sortOrder: sortOrder
+      )
+      try Self.insert(descriptor, db: db)
+      return descriptor
+    }
+  }
+
+  public func renameVault(_ id: VaultID, name: String, now: Date = Date()) throws {
+    let normalizedName = try Self.normalizedName(name)
+    try database.write { db in
+      try db.execute(
+        sql: "UPDATE vaults SET name = ?, modified_at = ? WHERE id = ? AND deleted_at IS NULL",
+        arguments: [normalizedName, now.timeIntervalSince1970, id.rawValue]
+      )
+      guard db.changesCount == 1 else { throw VaultRegistryError.vaultNotFound }
+    }
+  }
+
+  public func setSelectedVault(_ id: VaultID) throws {
+    try setPreference("selected-vault-id", id: id)
+  }
+
+  public func setDefaultCaptureVault(_ id: VaultID) throws {
+    try setPreference("default-capture-vault-id", id: id)
+  }
+
+  public func reorderVaults(_ ids: [VaultID], now: Date = Date()) throws {
+    try database.write { db in
+      let active = try Self.fetchActiveVaults(db)
+      guard Set(ids) == Set(active.map(\.id)), ids.count == active.count else {
+        throw VaultRegistryError.vaultNotFound
+      }
+      for (index, id) in ids.enumerated() {
+        try db.execute(
+          sql: "UPDATE vaults SET sort_order = ?, modified_at = ? WHERE id = ?",
+          arguments: [index, now.timeIntervalSince1970, id.rawValue]
+        )
+      }
+    }
+  }
+
+  /// Marks the catalog entry deleted and returns the graph path. The caller must close every open
+  /// repository before removing the returned SQLite files.
+  @discardableResult
+  public func deleteVault(_ id: VaultID, now: Date = Date()) throws -> String {
+    try database.write { db in
+      let active = try Self.fetchActiveVaults(db)
+      guard active.contains(where: { $0.id == id }) else {
+        throw VaultRegistryError.vaultNotFound
+      }
+      guard active.count > 1 else { throw VaultRegistryError.cannotDeleteOnlyVault }
+      try db.execute(
+        sql: "UPDATE vaults SET deleted_at = ?, modified_at = ? WHERE id = ?",
+        arguments: [now.timeIntervalSince1970, now.timeIntervalSince1970, id.rawValue]
+      )
+      let fallback = active.first(where: { $0.id != id })!.id
+      for key in ["selected-vault-id", "default-capture-vault-id"] {
+        if try Self.preference(db, key: key) == id.rawValue {
+          try Self.setPreference(db, key: key, value: fallback.rawValue)
+        }
+      }
+      return try graphPath(for: id)
+    }
+  }
+
+  public func graphPath(selection: VaultSelection) throws -> String {
+    let id: VaultID
+    switch selection {
+    case .selected: id = try snapshot().selectedVaultID
+    case .defaultCapture: id = try snapshot().defaultCaptureVaultID
+    case .vault(let requested):
+      guard try snapshot().vaults.contains(where: { $0.id == requested }) else {
+        throw VaultRegistryError.vaultNotFound
+      }
+      id = requested
+    }
+    return try graphPath(for: id)
+  }
+
+  public func graphPath(for id: VaultID) throws -> String {
+    guard Self.isSafe(id) else { throw VaultRegistryError.invalidIdentifier }
+    let catalogURL = URL(fileURLWithPath: path)
+    let directory = catalogURL.deletingLastPathComponent()
+      .appendingPathComponent(id.rawValue, isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    #if os(iOS)
+    try FileManager.default.setAttributes(
+      [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication],
+      ofItemAtPath: directory.path
+    )
+    #endif
+    return directory.appendingPathComponent("graph.sqlite").path
+  }
+
+  private func bootstrapIfNeeded() throws {
+    try database.write { db in
+      if try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM vaults WHERE deleted_at IS NULL") == 0 {
+        let personal = VaultDescriptor(name: Self.personalVaultName)
+        try Self.insert(personal, db: db)
+        try Self.setPreference(db, key: "selected-vault-id", value: personal.id.rawValue)
+        try Self.setPreference(db, key: "default-capture-vault-id", value: personal.id.rawValue)
+      }
+    }
+  }
+
+  private func setPreference(_ key: String, id: VaultID) throws {
+    try database.write { db in
+      guard try Bool.fetchOne(
+        db,
+        sql: "SELECT EXISTS(SELECT 1 FROM vaults WHERE id = ? AND deleted_at IS NULL)",
+        arguments: [id.rawValue]
+      ) == true else { throw VaultRegistryError.vaultNotFound }
+      try Self.setPreference(db, key: key, value: id.rawValue)
+    }
+  }
+
+  private static func normalizedName(_ value: String) throws -> String {
+    let result = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !result.isEmpty, result.count <= 80 else { throw VaultRegistryError.invalidName }
+    return result
+  }
+
+  private static func isSafe(_ id: VaultID) -> Bool {
+    guard id.rawValue.hasPrefix("vault_"), id.rawValue.count <= 80 else { return false }
+    return id.rawValue.unicodeScalars.allSatisfy {
+      CharacterSet.alphanumerics.contains($0) || $0 == "_" || $0 == "-"
+    }
+  }
+
+  private static func fetchActiveVaults(_ db: Database) throws -> [VaultDescriptor] {
+    try Row.fetchAll(
+      db,
+      sql: "SELECT * FROM vaults WHERE deleted_at IS NULL ORDER BY sort_order, name COLLATE NOCASE"
+    ).compactMap(decode)
+  }
+
+  private static func decode(_ row: Row) -> VaultDescriptor? {
+    guard let id: String = row["id"],
+      let name: String = row["name"],
+      let createdAt: Double = row["created_at"],
+      let modifiedAt: Double = row["modified_at"],
+      let sortOrder: Int = row["sort_order"]
+    else { return nil }
+    return .init(
+      id: .init(rawValue: id),
+      name: name,
+      createdAt: Date(timeIntervalSince1970: createdAt),
+      modifiedAt: Date(timeIntervalSince1970: modifiedAt),
+      sortOrder: sortOrder,
+      isDownloaded: row["is_downloaded"] ?? true,
+      deletedAt: (row["deleted_at"] as Double?).map(Date.init(timeIntervalSince1970:))
+    )
+  }
+
+  private static func insert(_ descriptor: VaultDescriptor, db: Database) throws {
+    try db.execute(
+      sql: """
+        INSERT INTO vaults
+          (id,name,created_at,modified_at,sort_order,is_downloaded,deleted_at)
+        VALUES (?,?,?,?,?,?,?)
+        """,
+      arguments: [
+        descriptor.id.rawValue,
+        descriptor.name,
+        descriptor.createdAt.timeIntervalSince1970,
+        descriptor.modifiedAt.timeIntervalSince1970,
+        descriptor.sortOrder,
+        descriptor.isDownloaded,
+        descriptor.deletedAt?.timeIntervalSince1970,
+      ]
+    )
+  }
+
+  private static func preference(_ db: Database, key: String) throws -> String? {
+    try String.fetchOne(db, sql: "SELECT value FROM preferences WHERE key = ?", arguments: [key])
+  }
+
+  private static func setPreference(_ db: Database, key: String, value: String) throws {
+    try db.execute(
+      sql: "INSERT OR REPLACE INTO preferences (key,value) VALUES (?,?)",
+      arguments: [key, value]
+    )
+  }
+
+  private static let migrator: DatabaseMigrator = {
+    var migrator = DatabaseMigrator()
+    migrator.registerMigration("v1-vault-catalog") { db in
+      try db.create(table: "vaults") { table in
+        table.column("id", .text).primaryKey()
+        table.column("name", .text).notNull()
+        table.column("created_at", .double).notNull()
+        table.column("modified_at", .double).notNull()
+        table.column("sort_order", .integer).notNull()
+        table.column("is_downloaded", .boolean).notNull().defaults(to: true)
+        table.column("deleted_at", .double)
+      }
+      try db.create(index: "vaults_on_sort_order", on: "vaults", columns: ["sort_order"])
+      try db.create(table: "preferences") { table in
+        table.column("key", .text).primaryKey()
+        table.column("value", .text).notNull()
+      }
+      try db.create(table: "cloud_catalog_state") { table in
+        table.column("key", .text).primaryKey()
+        table.column("value", .blob).notNull()
+      }
+    }
+    return migrator
+  }()
+}

--- a/apps/enchiridion/Sources/EnchiridionCore/VaultRepositoryContext.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/VaultRepositoryContext.swift
@@ -29,7 +29,7 @@ public struct VaultRepositoryContext: Sendable {
 
   public static func openAll() throws -> [Self] {
     let registry = try VaultRegistry(path: VaultRegistry.defaultCatalogPath())
-    return try registry.snapshot().vaults.map { vault in
+    return try registry.snapshot().vaults.filter(\.isDownloaded).map { vault in
       try .init(
         vault: vault,
         repository: LibraryRepository(path: registry.graphPath(for: vault.id))

--- a/apps/enchiridion/Sources/EnchiridionCore/VaultRepositoryContext.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/VaultRepositoryContext.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Opens a repository together with the vault identity that gives its node IDs meaning.
+public struct VaultRepositoryContext: Sendable {
+  public let vault: VaultDescriptor
+  public let repository: LibraryRepository
+
+  public init(vault: VaultDescriptor, repository: LibraryRepository) {
+    self.vault = vault
+    self.repository = repository
+  }
+
+  public static func open(_ selection: VaultSelection) throws -> Self {
+    let registry = try VaultRegistry(path: VaultRegistry.defaultCatalogPath())
+    let snapshot = try registry.snapshot()
+    let vaultID = switch selection {
+    case .selected: snapshot.selectedVaultID
+    case .defaultCapture: snapshot.defaultCaptureVaultID
+    case .vault(let id): id
+    }
+    guard let vault = snapshot.vaults.first(where: { $0.id == vaultID }) else {
+      throw VaultRegistryError.vaultNotFound
+    }
+    return try .init(
+      vault: vault,
+      repository: LibraryRepository(path: registry.graphPath(for: vaultID))
+    )
+  }
+
+  public static func openAll() throws -> [Self] {
+    let registry = try VaultRegistry(path: VaultRegistry.defaultCatalogPath())
+    return try registry.snapshot().vaults.map { vault in
+      try .init(
+        vault: vault,
+        repository: LibraryRepository(path: registry.graphPath(for: vault.id))
+      )
+    }
+  }
+}

--- a/apps/enchiridion/Sources/EnchiridionCore/VaultSearch.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/VaultSearch.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+public struct VaultSearchResult: Codable, Hashable, Sendable, Identifiable {
+  public var scopedNodeID: VaultScopedNodeID
+  public var vaultName: String
+  public var title: String
+  public var excerpt: String
+  public var score: Double
+  public var id: String { scopedNodeID.id }
+
+  public init(
+    scopedNodeID: VaultScopedNodeID,
+    vaultName: String,
+    title: String,
+    excerpt: String,
+    score: Double
+  ) {
+    self.scopedNodeID = scopedNodeID
+    self.vaultName = vaultName
+    self.title = title
+    self.excerpt = excerpt
+    self.score = score
+  }
+}
+
+/// Fans a text search out across downloaded vaults while preserving vault-scoped identities.
+/// Query execution itself remains local to each vault's public SQLite graph surface.
+public struct VaultSearch: Sendable {
+  private let registry: VaultRegistry
+
+  public init(registry: VaultRegistry) {
+    self.registry = registry
+  }
+
+  public init() throws {
+    registry = try VaultRegistry(path: VaultRegistry.defaultCatalogPath())
+  }
+
+  public func search(
+    _ text: String,
+    limit: Int = 50
+  ) async throws -> [VaultSearchResult] {
+    let expression = Self.matchExpression(text)
+    guard !expression.isEmpty else { return [] }
+    let boundedLimit = min(max(limit, 1), 200)
+    let snapshot = try registry.snapshot()
+    var results: [VaultSearchResult] = []
+
+    for vault in snapshot.vaults where vault.isDownloaded {
+      let repository = try LibraryRepository(path: registry.graphPath(for: vault.id))
+      let queryResult = try repository.runGraphSQL(
+        """
+        SELECT node_id,
+               title,
+               snippet(graph_text_search, 2, '', '', ' … ', 18) AS excerpt,
+               bm25(graph_text_search) AS score
+        FROM graph_text_search
+        WHERE graph_text_search MATCH :query
+        ORDER BY score, title COLLATE NOCASE
+        LIMIT \(boundedLimit)
+        """,
+        arguments: ["query": .text(expression)],
+        limits: .init(maximumRows: boundedLimit)
+      )
+      for row in queryResult.rows {
+        guard case .text(let nodeID) = queryResult.value(column: "node_id", in: row),
+          case .text(let title) = queryResult.value(column: "title", in: row)
+        else { continue }
+        let excerpt: String
+        if case .text(let value) = queryResult.value(column: "excerpt", in: row) {
+          excerpt = value
+        } else {
+          excerpt = ""
+        }
+        let score: Double
+        switch queryResult.value(column: "score", in: row) {
+        case .real(let value): score = value
+        case .integer(let value): score = Double(value)
+        default: score = 0
+        }
+        results.append(
+          .init(
+            scopedNodeID: .init(vaultID: vault.id, nodeID: .init(rawValue: nodeID)),
+            vaultName: vault.name,
+            title: title,
+            excerpt: excerpt,
+            score: score
+          )
+        )
+      }
+    }
+
+    return Array(results.sorted {
+      if $0.score != $1.score { return $0.score < $1.score }
+      if $0.vaultName != $1.vaultName {
+        return $0.vaultName.localizedStandardCompare($1.vaultName) == .orderedAscending
+      }
+      return $0.title.localizedStandardCompare($1.title) == .orderedAscending
+    }.prefix(boundedLimit))
+  }
+
+  private static func matchExpression(_ text: String) -> String {
+    text
+      .split(whereSeparator: { $0.isWhitespace })
+      .prefix(12)
+      .map { token in
+        let escaped = token.replacingOccurrences(of: "\"", with: "\"\"")
+        return "\"\(escaped)\""
+      }
+      .joined(separator: " AND ")
+  }
+}

--- a/apps/enchiridion/Sources/EnchiridionCore/VaultSearch.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/VaultSearch.swift
@@ -44,50 +44,26 @@ public struct VaultSearch: Sendable {
     guard !expression.isEmpty else { return [] }
     let boundedLimit = min(max(limit, 1), 200)
     let snapshot = try registry.snapshot()
-    var results: [VaultSearchResult] = []
-
-    for vault in snapshot.vaults where vault.isDownloaded {
-      let repository = try LibraryRepository(path: registry.graphPath(for: vault.id))
-      let queryResult = try repository.runGraphSQL(
-        """
-        SELECT node_id,
-               title,
-               snippet(graph_text_search, 2, '', '', ' … ', 18) AS excerpt,
-               bm25(graph_text_search) AS score
-        FROM graph_text_search
-        WHERE graph_text_search MATCH :query
-        ORDER BY score, title COLLATE NOCASE
-        LIMIT \(boundedLimit)
-        """,
-        arguments: ["query": .text(expression)],
-        limits: .init(maximumRows: boundedLimit)
-      )
-      for row in queryResult.rows {
-        guard case .text(let nodeID) = queryResult.value(column: "node_id", in: row),
-          case .text(let title) = queryResult.value(column: "title", in: row)
-        else { continue }
-        let excerpt: String
-        if case .text(let value) = queryResult.value(column: "excerpt", in: row) {
-          excerpt = value
-        } else {
-          excerpt = ""
-        }
-        let score: Double
-        switch queryResult.value(column: "score", in: row) {
-        case .real(let value): score = value
-        case .integer(let value): score = Double(value)
-        default: score = 0
-        }
-        results.append(
-          .init(
-            scopedNodeID: .init(vaultID: vault.id, nodeID: .init(rawValue: nodeID)),
-            vaultName: vault.name,
-            title: title,
-            excerpt: excerpt,
-            score: score
+    let downloadedVaults = snapshot.vaults.filter(\.isDownloaded)
+    let results = try await withThrowingTaskGroup(
+      of: [VaultSearchResult].self,
+      returning: [VaultSearchResult].self
+    ) { group in
+      for vault in downloadedVaults {
+        group.addTask {
+          try Self.search(
+            vault: vault,
+            registry: registry,
+            expression: expression,
+            limit: boundedLimit
           )
-        )
+        }
       }
+      var combined: [VaultSearchResult] = []
+      for try await vaultResults in group {
+        combined.append(contentsOf: vaultResults)
+      }
+      return combined
     }
 
     return Array(results.sorted {
@@ -102,11 +78,67 @@ public struct VaultSearch: Sendable {
   private static func matchExpression(_ text: String) -> String {
     text
       .split(whereSeparator: { $0.isWhitespace })
+      .filter { token in token.contains { $0.isLetter || $0.isNumber } }
       .prefix(12)
       .map { token in
         let escaped = token.replacingOccurrences(of: "\"", with: "\"\"")
         return "\"\(escaped)\""
       }
       .joined(separator: " AND ")
+  }
+
+  private static func search(
+    vault: VaultDescriptor,
+    registry: VaultRegistry,
+    expression: String,
+    limit: Int
+  ) throws -> [VaultSearchResult] {
+    let repository = try LibraryRepository(path: registry.graphPath(for: vault.id))
+    let queryResult = try repository.runGraphSQL(
+      """
+      SELECT node_id,
+             title,
+             snippet(graph_text_search, 2, '', '', ' … ', 18) AS excerpt,
+             bm25(graph_text_search) AS score
+      FROM graph_text_search
+      WHERE graph_text_search MATCH :query
+      ORDER BY score, title COLLATE NOCASE
+      LIMIT \(limit)
+      """,
+      arguments: ["query": .text(expression)],
+      limits: .init(maximumRows: limit)
+    )
+    var results: [VaultSearchResult] = []
+    for row in queryResult.rows {
+      guard case .text(let nodeID) = queryResult.value(column: "node_id", in: row),
+        case .text(let title) = queryResult.value(column: "title", in: row)
+      else { continue }
+
+      let excerpt: String
+      if case .text(let value) = queryResult.value(column: "excerpt", in: row) {
+        excerpt = value
+      } else {
+        excerpt = ""
+      }
+
+      let score: Double
+      switch queryResult.value(column: "score", in: row) {
+      case .real(let value):
+        score = value
+      case .integer(let value):
+        score = Double(value)
+      default:
+        score = 0
+      }
+
+      results.append(.init(
+        scopedNodeID: .init(vaultID: vault.id, nodeID: .init(rawValue: nodeID)),
+        vaultName: vault.name,
+        title: title,
+        excerpt: excerpt,
+        score: score
+      ))
+    }
+    return results
   }
 }

--- a/apps/enchiridion/Sources/EnchiridionCore/VaultSession.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/VaultSession.swift
@@ -1,0 +1,178 @@
+import Foundation
+import Observation
+
+public enum VaultSessionError: Error, LocalizedError, Equatable {
+  case unavailable(String)
+  case couldNotRemoveLocalData(String)
+
+  public var errorDescription: String? {
+    switch self {
+    case .unavailable(let message): message
+    case .couldNotRemoveLocalData(let name):
+      "The \(name) vault was removed from the catalog, but its local files could not be deleted."
+    }
+  }
+}
+
+/// Owns the currently selected vault workspace. A switch replaces the repository and store as one
+/// unit so node identifiers, queries, assistant access, and sync never cross vault boundaries.
+@MainActor
+@Observable
+public final class VaultSession {
+  public private(set) var snapshot: VaultRegistrySnapshot
+  public private(set) var selectedVault: VaultDescriptor
+  public private(set) var repository: LibraryRepository
+  public private(set) var store: LibraryStore
+  public private(set) var errorMessage: String?
+
+  @ObservationIgnored private let registry: VaultRegistry
+  @ObservationIgnored private let calendar: Calendar
+  @ObservationIgnored private let contactResolver: (any DeviceContactResolving)?
+  @ObservationIgnored private let startsStoresImmediately: Bool
+
+  public convenience init(
+    calendar: Calendar = .current,
+    contactResolver: (any DeviceContactResolving)? = nil,
+    startImmediately: Bool = true
+  ) throws {
+    try self.init(
+      registry: VaultRegistry(path: VaultRegistry.defaultCatalogPath()),
+      calendar: calendar,
+      contactResolver: contactResolver,
+      startImmediately: startImmediately
+    )
+  }
+
+  public init(
+    registry: VaultRegistry,
+    calendar: Calendar = .current,
+    contactResolver: (any DeviceContactResolving)? = nil,
+    startImmediately: Bool = true
+  ) throws {
+    let snapshot = try registry.snapshot()
+    guard let descriptor = snapshot.vaults.first(where: { $0.id == snapshot.selectedVaultID }) else {
+      throw VaultRegistryError.vaultNotFound
+    }
+    let repository = try LibraryRepository(path: registry.graphPath(for: descriptor.id))
+    self.registry = registry
+    self.calendar = calendar
+    self.contactResolver = contactResolver
+    startsStoresImmediately = startImmediately
+    self.snapshot = snapshot
+    selectedVault = descriptor
+    self.repository = repository
+    store = LibraryStore(
+      repository: repository,
+      calendar: calendar,
+      contactResolver: contactResolver,
+      startImmediately: startImmediately
+    )
+  }
+
+  public func refreshCatalog() throws {
+    let refreshed = try registry.snapshot()
+    snapshot = refreshed
+    guard refreshed.vaults.contains(where: { $0.id == selectedVault.id }) else {
+      try replaceWorkspace(with: refreshed.selectedVaultID, snapshot: refreshed)
+      return
+    }
+    selectedVault = refreshed.vaults.first(where: { $0.id == selectedVault.id })!
+  }
+
+  public func selectVault(_ id: VaultID) throws {
+    guard id != selectedVault.id else { return }
+    try registry.setSelectedVault(id)
+    let refreshed = try registry.snapshot()
+    do {
+      try replaceWorkspace(with: id, snapshot: refreshed)
+      errorMessage = nil
+    } catch {
+      try? registry.setSelectedVault(selectedVault.id)
+      throw error
+    }
+  }
+
+  @discardableResult
+  public func createVault(name: String, select: Bool = true) throws -> VaultDescriptor {
+    let descriptor = try registry.createVault(name: name)
+    if select {
+      do {
+        try selectVault(descriptor.id)
+      } catch {
+        _ = try? registry.deleteVault(descriptor.id)
+        throw error
+      }
+    } else {
+      snapshot = try registry.snapshot()
+    }
+    return descriptor
+  }
+
+  public func renameVault(_ id: VaultID, name: String) throws {
+    try registry.renameVault(id, name: name)
+    try refreshCatalog()
+  }
+
+  public func setDefaultCaptureVault(_ id: VaultID) throws {
+    try registry.setDefaultCaptureVault(id)
+    snapshot = try registry.snapshot()
+  }
+
+  public func reorderVaults(_ ids: [VaultID]) throws {
+    try registry.reorderVaults(ids)
+    snapshot = try registry.snapshot()
+  }
+
+  public func deleteVault(_ id: VaultID) throws {
+    let name = snapshot.vaults.first(where: { $0.id == id })?.name ?? "selected"
+    let path = try registry.deleteVault(id)
+    let refreshed = try registry.snapshot()
+    if id == selectedVault.id {
+      try replaceWorkspace(with: refreshed.selectedVaultID, snapshot: refreshed)
+    } else {
+      snapshot = refreshed
+    }
+
+    let directory = URL(fileURLWithPath: path).deletingLastPathComponent()
+    guard FileManager.default.fileExists(atPath: directory.path) else { return }
+    do {
+      try FileManager.default.removeItem(at: directory)
+    } catch {
+      let sessionError = VaultSessionError.couldNotRemoveLocalData(name)
+      errorMessage = sessionError.localizedDescription
+      throw sessionError
+    }
+  }
+
+  public func clearError() {
+    errorMessage = nil
+  }
+
+  private func replaceWorkspace(
+    with id: VaultID,
+    snapshot: VaultRegistrySnapshot
+  ) throws {
+    guard let descriptor = snapshot.vaults.first(where: { $0.id == id }) else {
+      throw VaultRegistryError.vaultNotFound
+    }
+    do {
+      let repository = try LibraryRepository(path: registry.graphPath(for: id))
+      let store = LibraryStore(
+        repository: repository,
+        calendar: calendar,
+        contactResolver: contactResolver,
+        startImmediately: startsStoresImmediately
+      )
+      self.snapshot = snapshot
+      selectedVault = descriptor
+      self.repository = repository
+      self.store = store
+    } catch {
+      let wrapped = VaultSessionError.unavailable(
+        "The \(descriptor.name) vault could not be opened: \(error.localizedDescription)"
+      )
+      errorMessage = wrapped.localizedDescription
+      throw wrapped
+    }
+  }
+}

--- a/apps/enchiridion/Sources/EnchiridionCore/VaultSession.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/VaultSession.swift
@@ -62,6 +62,7 @@ public final class VaultSession {
     selectedVault = descriptor
     self.repository = repository
     store = LibraryStore(
+      vaultID: descriptor.id,
       repository: repository,
       calendar: calendar,
       contactResolver: contactResolver,
@@ -158,6 +159,7 @@ public final class VaultSession {
     do {
       let repository = try LibraryRepository(path: registry.graphPath(for: id))
       let store = LibraryStore(
+        vaultID: descriptor.id,
         repository: repository,
         calendar: calendar,
         contactResolver: contactResolver,

--- a/apps/enchiridion/Sources/EnchiridionCore/VaultSession.swift
+++ b/apps/enchiridion/Sources/EnchiridionCore/VaultSession.swift
@@ -29,6 +29,7 @@ public final class VaultSession {
   @ObservationIgnored private let calendar: Calendar
   @ObservationIgnored private let contactResolver: (any DeviceContactResolving)?
   @ObservationIgnored private let startsStoresImmediately: Bool
+  @ObservationIgnored private var backgroundStores: [VaultID: LibraryStore] = [:]
 
   public convenience init(
     calendar: Calendar = .current,
@@ -124,8 +125,10 @@ public final class VaultSession {
     snapshot = try registry.snapshot()
   }
 
-  public func deleteVault(_ id: VaultID) throws {
+  public func deleteVault(_ id: VaultID) async throws {
     let name = snapshot.vaults.first(where: { $0.id == id })?.name ?? "selected"
+    let removedStore = id == selectedVault.id ? store : backgroundStores.removeValue(forKey: id)
+    let removedRepository = removedStore?.repository
     let path = try registry.deleteVault(id)
     let refreshed = try registry.snapshot()
     if id == selectedVault.id {
@@ -133,6 +136,8 @@ public final class VaultSession {
     } else {
       snapshot = refreshed
     }
+    await removedStore?.stop()
+    try await removedRepository?.closeDatabase()
 
     let directory = URL(fileURLWithPath: path).deletingLastPathComponent()
     guard FileManager.default.fileExists(atPath: directory.path) else { return }
@@ -149,6 +154,39 @@ public final class VaultSession {
     errorMessage = nil
   }
 
+  public func store(
+    forVault id: VaultID,
+    selectingWith select: @MainActor (VaultID) throws -> Void
+  ) throws -> LibraryStore {
+    if selectedVault.id != id {
+      try select(id)
+    }
+    return store
+  }
+
+  public func backgroundStore(forVault id: VaultID) async throws -> LibraryStore {
+    if selectedVault.id == id { return store }
+    if let existing = backgroundStores[id] { return existing }
+    guard let descriptor = snapshot.vaults.first(where: {
+      $0.id == id && $0.isDownloaded && $0.deletedAt == nil
+    }) else {
+      throw VaultRegistryError.vaultNotFound
+    }
+    let path = try registry.graphPath(for: id)
+    let repository = try await Task.detached(priority: .userInitiated) {
+      try LibraryRepository(path: path)
+    }.value
+    let store = LibraryStore(
+      vaultID: descriptor.id,
+      repository: repository,
+      calendar: calendar,
+      contactResolver: contactResolver,
+      startImmediately: false
+    )
+    backgroundStores[id] = store
+    return store
+  }
+
   private func replaceWorkspace(
     with id: VaultID,
     snapshot: VaultRegistrySnapshot
@@ -157,14 +195,24 @@ public final class VaultSession {
       throw VaultRegistryError.vaultNotFound
     }
     do {
-      let repository = try LibraryRepository(path: registry.graphPath(for: id))
-      let store = LibraryStore(
-        vaultID: descriptor.id,
-        repository: repository,
-        calendar: calendar,
-        contactResolver: contactResolver,
-        startImmediately: startsStoresImmediately
-      )
+      let repository: LibraryRepository
+      let store: LibraryStore
+      if let cachedStore = backgroundStores.removeValue(forKey: id),
+        let cachedRepository = cachedStore.repository
+      {
+        repository = cachedRepository
+        store = cachedStore
+        if startsStoresImmediately { Task { await store.start() } }
+      } else {
+        repository = try LibraryRepository(path: registry.graphPath(for: id))
+        store = LibraryStore(
+          vaultID: descriptor.id,
+          repository: repository,
+          calendar: calendar,
+          contactResolver: contactResolver,
+          startImmediately: startsStoresImmediately
+        )
+      }
       self.snapshot = snapshot
       selectedVault = descriptor
       self.repository = repository

--- a/apps/enchiridion/Sources/SharedUI/AssistantAppIntents.swift
+++ b/apps/enchiridion/Sources/SharedUI/AssistantAppIntents.swift
@@ -23,7 +23,7 @@ struct AskEnchiridionIntent: AppIntent {
     let normalizedQuestion = question.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !normalizedQuestion.isEmpty else { throw AskEnchiridionIntentError.emptyQuestion }
 
-    let repository = try LibraryRepository(path: LibraryRepository.defaultLocalPath())
+    let repository = try VaultRepositoryContext.open(.selected).repository
     let assistant = FoundationModelAssistant(repository: repository)
     let response = await assistant.respond(to: normalizedQuestion)
     return .result(dialog: IntentDialog(stringLiteral: response.answer))

--- a/apps/enchiridion/Sources/SharedUI/EntryEditorView.swift
+++ b/apps/enchiridion/Sources/SharedUI/EntryEditorView.swift
@@ -85,6 +85,7 @@ struct PageDestinationView: View {
 
 private enum EntityDetailSection: String, CaseIterable, Identifiable {
   case properties = "Properties"
+  case relationships = "Relationships"
   case notes = "Notes"
 
   var id: Self { self }
@@ -134,6 +135,12 @@ struct EntityDetailView: View {
       switch selectedSection {
       case .properties:
         PagePropertiesView(store: store, pageID: page.id)
+      case .relationships:
+        GraphRelationshipsView(
+          store: store,
+          pageID: page.id,
+          onOpenPage: onOpenPage
+        )
       case .notes:
         PageEditorView(
           store: store,

--- a/apps/enchiridion/Sources/SharedUI/GraphQueryWorkspace.swift
+++ b/apps/enchiridion/Sources/SharedUI/GraphQueryWorkspace.swift
@@ -1,0 +1,203 @@
+import EnchiridionCore
+import SwiftUI
+
+struct GraphQueryWorkspace: View {
+  let store: LibraryStore
+  let onOpenPage: ((PageID) -> Void)?
+
+  @State private var mode = GraphQueryEditorMode.visual
+  @State private var selectedTagID: TagID?
+  @State private var traversalRelationID: RelationID?
+  @State private var targetTagID: TagID?
+  @State private var maximumDepth = 1
+  @State private var sql = "SELECT node_id, title, kind FROM graph_nodes WHERE deleted_at IS NULL ORDER BY modified_at DESC LIMIT 100"
+  @State private var relations: [RelationDefinition] = []
+  @State private var result: GraphQueryResult?
+  @State private var errorMessage: String?
+
+  var body: some View {
+    VStack(spacing: 0) {
+      Picker("Query editor", selection: $mode) {
+        ForEach(GraphQueryEditorMode.allCases) { mode in Text(mode.title).tag(mode) }
+      }
+      .pickerStyle(.segmented)
+      .frame(maxWidth: 320)
+      .padding()
+
+      Divider()
+
+      if mode == .visual {
+        visualEditor
+      } else {
+        sqlEditor
+      }
+
+      Divider()
+      resultView
+    }
+    .navigationTitle("Graph Query")
+    .task {
+      relations = (try? await store.graphRelationDefinitions()) ?? []
+    }
+    .alert("Query Error", isPresented: errorBinding) {
+      Button("OK", role: .cancel) {}
+    } message: {
+      Text(errorMessage ?? "The query could not be run.")
+    }
+  }
+
+  private var visualEditor: some View {
+    Form {
+      Section("Match") {
+        Picker("Type", selection: $selectedTagID) {
+          Text("Any type").tag(nil as TagID?)
+          ForEach(store.supertags) { tag in Text(tag.name).tag(tag.id as TagID?) }
+        }
+      }
+      Section("Traverse") {
+        Picker("Relationship", selection: $traversalRelationID) {
+          Text("No traversal").tag(nil as RelationID?)
+          ForEach(relations) { relation in
+            Text(relation.forwardName).tag(relation.id as RelationID?)
+          }
+        }
+        if traversalRelationID != nil {
+          Picker("Target type", selection: $targetTagID) {
+            Text("Any type").tag(nil as TagID?)
+            ForEach(store.supertags) { tag in Text(tag.name).tag(tag.id as TagID?) }
+          }
+          Stepper("Maximum depth: \(maximumDepth)", value: $maximumDepth, in: 1...8)
+        }
+      }
+      Section {
+        Button("Run Query", systemImage: "play.fill", action: runVisualQuery)
+      }
+    }
+    .formStyle(.grouped)
+    .frame(maxHeight: 300)
+  }
+
+  private var sqlEditor: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      TextEditor(text: $sql)
+        .font(.system(.body, design: .monospaced))
+        .frame(minHeight: 150)
+        .accessibilityLabel("Read-only graph SQL")
+      HStack {
+        Text("Queries can read the stable graph_* views only.")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+        Spacer()
+        Button("Run SQL", systemImage: "play.fill", action: runSQL)
+          .keyboardShortcut(.return, modifiers: [.command])
+      }
+    }
+    .padding()
+    .frame(maxHeight: 300)
+  }
+
+  @ViewBuilder
+  private var resultView: some View {
+    if let result {
+      if result.rows.isEmpty {
+        ContentUnavailableView(
+          "No matches",
+          systemImage: "line.3.horizontal.decrease.circle",
+          description: Text("Adjust the query and run it again.")
+        )
+      } else {
+        List(result.rows) { row in
+          let nodeID = textValue("node_id", row: row).map(NodeID.init(rawValue:))
+          Button {
+            if let nodeID { onOpenPage?(nodeID) }
+          } label: {
+            VStack(alignment: .leading, spacing: 3) {
+              Text(textValue("title", row: row) ?? rowSummary(row, result: result))
+                .foregroundStyle(.primary)
+              if let nodeID {
+                Text(nodeID.rawValue)
+                  .font(.caption.monospaced())
+                  .foregroundStyle(.secondary)
+              }
+            }
+          }
+          .buttonStyle(.plain)
+        }
+      }
+    } else {
+      ContentUnavailableView(
+        "Run a query",
+        systemImage: "point.3.connected.trianglepath.dotted",
+        description: Text("Build a graph traversal visually or write read-only SQLite SQL.")
+      )
+    }
+  }
+
+  private func runVisualQuery() {
+    var expressions: [GraphExpression] = []
+    if let selectedTagID { expressions.append(.tag(selectedTagID)) }
+    if traversalRelationID != nil || targetTagID != nil {
+      expressions.append(.traversal(.init(
+        relationID: traversalRelationID,
+        maximumDepth: maximumDepth,
+        targetTagID: targetTagID
+      )))
+    }
+    let expression: GraphExpression? = switch expressions.count {
+    case 0: nil
+    case 1: expressions[0]
+    default: .and(expressions)
+    }
+    perform { try store.runGraphQuery(.init(expression: expression)) }
+  }
+
+  private func runSQL() {
+    perform { try store.runGraphSQL(sql) }
+  }
+
+  private func perform(_ query: () throws -> GraphQueryResult) {
+    do {
+      result = try query()
+      errorMessage = nil
+    } catch {
+      errorMessage = error.localizedDescription
+    }
+  }
+
+  private func textValue(_ column: String, row: GraphQueryRow) -> String? {
+    guard let result, case .text(let value) = result.value(column: column, in: row) else {
+      return nil
+    }
+    return value
+  }
+
+  private func rowSummary(_ row: GraphQueryRow, result: GraphQueryResult) -> String {
+    zip(result.columns, row.values).map { column, value in
+      "\(column.name): \(display(value))"
+    }.joined(separator: " · ")
+  }
+
+  private func display(_ value: GraphSQLValue) -> String {
+    switch value {
+    case .null: "—"
+    case .integer(let value): value.formatted()
+    case .real(let value): value.formatted()
+    case .text(let value): value
+    case .blob(let value): "\(value.count) bytes"
+    }
+  }
+
+  private var errorBinding: Binding<Bool> {
+    Binding(
+      get: { errorMessage != nil },
+      set: { if !$0 { errorMessage = nil } }
+    )
+  }
+}
+
+private enum GraphQueryEditorMode: String, CaseIterable, Identifiable {
+  case visual
+  case sql
+  var id: Self { self }
+  var title: String { self == .visual ? "Visual" : "SQL" }
+}

--- a/apps/enchiridion/Sources/SharedUI/GraphQueryWorkspace.swift
+++ b/apps/enchiridion/Sources/SharedUI/GraphQueryWorkspace.swift
@@ -63,7 +63,7 @@ struct GraphQueryWorkspace: View {
       Text("Saved queries belong to this vault and retain their visual or SQL definition.")
     }
     .alert("Query Error", isPresented: errorBinding) {
-      Button("OK", role: .cancel) {}
+      Button("Dismiss Error", role: .cancel) {}
     } message: {
       Text(errorMessage ?? "The query could not be run.")
     }

--- a/apps/enchiridion/Sources/SharedUI/GraphQueryWorkspace.swift
+++ b/apps/enchiridion/Sources/SharedUI/GraphQueryWorkspace.swift
@@ -18,6 +18,7 @@ struct GraphQueryWorkspace: View {
   @State private var errorMessage: String?
   @State private var showsSaveQuery = false
   @State private var queryName = ""
+  @State private var isRunning = false
 
   var body: some View {
     VStack(spacing: 0) {
@@ -57,7 +58,11 @@ struct GraphQueryWorkspace: View {
     .alert("Save Graph Query", isPresented: $showsSaveQuery) {
       TextField("Name", text: $queryName)
       Button("Cancel", role: .cancel) {}
-      Button("Save") { Task { await saveCurrentQuery() } }
+      Button("Save") {
+        let name = queryName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else { return }
+        Task { await saveCurrentQuery(name: name) }
+      }
         .disabled(queryName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
     } message: {
       Text("Saved queries belong to this vault and retain their visual or SQL definition.")
@@ -77,7 +82,7 @@ struct GraphQueryWorkspace: View {
         ForEach(savedQueries) { query in
           Button {
             selectedSavedQueryID = query.id
-            perform { try store.runGraphQuery(query) }
+            Task { await perform { try await store.runGraphQueryAsync(query) } }
           } label: {
             Label(query.name, systemImage: query.source.systemImage)
           }
@@ -116,6 +121,9 @@ struct GraphQueryWorkspace: View {
             Text(relation.forwardName).tag(relation.id as RelationID?)
           }
         }
+        .onChange(of: traversalRelationID) { _, relationID in
+          if relationID == nil { targetTagID = nil }
+        }
         if traversalRelationID != nil {
           Picker("Target type", selection: $targetTagID) {
             Text("Any type").tag(nil as TagID?)
@@ -125,7 +133,10 @@ struct GraphQueryWorkspace: View {
         }
       }
       Section {
-        Button("Run Query", systemImage: "play.fill", action: runVisualQuery)
+        Button("Run Query", systemImage: "play.fill") {
+          Task { await runVisualQuery() }
+        }
+        .disabled(isRunning)
       }
     }
     .formStyle(.grouped)
@@ -143,7 +154,10 @@ struct GraphQueryWorkspace: View {
           .font(.caption)
           .foregroundStyle(.secondary)
         Spacer()
-        Button("Run SQL", systemImage: "play.fill", action: runSQL)
+        Button("Run SQL", systemImage: "play.fill") {
+          Task { await runSQL() }
+        }
+          .disabled(isRunning)
           .keyboardShortcut(.return, modifiers: [.command])
       }
     }
@@ -188,14 +202,15 @@ struct GraphQueryWorkspace: View {
     }
   }
 
-  private func runVisualQuery() {
-    perform { try store.runGraphQuery(currentVisualDefinition) }
+  private func runVisualQuery() async {
+    let definition = currentVisualDefinition
+    await perform { try await store.runGraphQueryAsync(definition) }
   }
 
   private var currentVisualDefinition: GraphQueryDefinition {
     var expressions: [GraphExpression] = []
     if let selectedTagID { expressions.append(.tag(selectedTagID)) }
-    if traversalRelationID != nil || targetTagID != nil {
+    if traversalRelationID != nil {
       expressions.append(.traversal(.init(
         relationID: traversalRelationID,
         maximumDepth: maximumDepth,
@@ -210,26 +225,30 @@ struct GraphQueryWorkspace: View {
     return .init(expression: expression)
   }
 
-  private func runSQL() {
-    perform { try store.runGraphSQL(sql) }
+  private func runSQL() async {
+    let sql = sql
+    await perform { try await store.runGraphSQLAsync(sql) }
   }
 
-  private func perform(_ query: () throws -> GraphQueryResult) {
+  private func perform(_ query: () async throws -> GraphQueryResult) async {
+    guard !isRunning else { return }
+    isRunning = true
+    defer { isRunning = false }
     do {
-      result = try query()
+      result = try await query()
       errorMessage = nil
     } catch {
       errorMessage = error.localizedDescription
     }
   }
 
-  private func saveCurrentQuery() async {
+  private func saveCurrentQuery(name: String) async {
     let source: SavedGraphQuery.Source = switch mode {
     case .visual: .builder(currentVisualDefinition)
     case .sql: .sql(sql)
     }
     let query = SavedGraphQuery(
-      name: queryName.trimmingCharacters(in: .whitespacesAndNewlines),
+      name: name,
       source: source,
       presentation: .init(kind: mode == .visual ? .list : .table)
     )
@@ -237,7 +256,7 @@ struct GraphQueryWorkspace: View {
       try await store.saveGraphQuery(query)
       selectedSavedQueryID = query.id
       await reloadSavedQueries()
-      perform { try store.runGraphQuery(query) }
+      await perform { try await store.runGraphQueryAsync(query) }
     } catch {
       errorMessage = error.localizedDescription
     }

--- a/apps/enchiridion/Sources/SharedUI/GraphQueryWorkspace.swift
+++ b/apps/enchiridion/Sources/SharedUI/GraphQueryWorkspace.swift
@@ -12,16 +12,30 @@ struct GraphQueryWorkspace: View {
   @State private var maximumDepth = 1
   @State private var sql = "SELECT node_id, title, kind FROM graph_nodes WHERE deleted_at IS NULL ORDER BY modified_at DESC LIMIT 100"
   @State private var relations: [RelationDefinition] = []
+  @State private var savedQueries: [SavedGraphQuery] = []
+  @State private var selectedSavedQueryID: GraphQueryID?
   @State private var result: GraphQueryResult?
   @State private var errorMessage: String?
+  @State private var showsSaveQuery = false
+  @State private var queryName = ""
 
   var body: some View {
     VStack(spacing: 0) {
-      Picker("Query editor", selection: $mode) {
-        ForEach(GraphQueryEditorMode.allCases) { mode in Text(mode.title).tag(mode) }
+      HStack(spacing: 12) {
+        Picker("Query editor", selection: $mode) {
+          ForEach(GraphQueryEditorMode.allCases) { mode in Text(mode.title).tag(mode) }
+        }
+        .pickerStyle(.segmented)
+        .frame(maxWidth: 320)
+
+        savedQueryMenu
+
+        Button("Save", systemImage: "square.and.arrow.down") {
+          queryName = ""
+          showsSaveQuery = true
+        }
+        .disabled(mode == .sql && sql.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
       }
-      .pickerStyle(.segmented)
-      .frame(maxWidth: 320)
       .padding()
 
       Divider()
@@ -38,11 +52,52 @@ struct GraphQueryWorkspace: View {
     .navigationTitle("Graph Query")
     .task {
       relations = (try? await store.graphRelationDefinitions()) ?? []
+      await reloadSavedQueries()
+    }
+    .alert("Save Graph Query", isPresented: $showsSaveQuery) {
+      TextField("Name", text: $queryName)
+      Button("Cancel", role: .cancel) {}
+      Button("Save") { Task { await saveCurrentQuery() } }
+        .disabled(queryName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    } message: {
+      Text("Saved queries belong to this vault and retain their visual or SQL definition.")
     }
     .alert("Query Error", isPresented: errorBinding) {
       Button("OK", role: .cancel) {}
     } message: {
       Text(errorMessage ?? "The query could not be run.")
+    }
+  }
+
+  private var savedQueryMenu: some View {
+    Menu {
+      if savedQueries.isEmpty {
+        Text("No saved queries")
+      } else {
+        ForEach(savedQueries) { query in
+          Button {
+            selectedSavedQueryID = query.id
+            perform { try store.runGraphQuery(query) }
+          } label: {
+            Label(query.name, systemImage: query.source.systemImage)
+          }
+        }
+        if let selectedSavedQueryID,
+          let selected = savedQueries.first(where: { $0.id == selectedSavedQueryID })
+        {
+          Divider()
+          Button("Delete \(selected.name)", systemImage: "trash", role: .destructive) {
+            Task { await deleteSavedQuery(selected) }
+          }
+        }
+      }
+    } label: {
+      Label(
+        selectedSavedQueryID.flatMap { id in
+          savedQueries.first(where: { $0.id == id })?.name
+        } ?? "Saved Queries",
+        systemImage: "tray.full"
+      )
     }
   }
 
@@ -134,6 +189,10 @@ struct GraphQueryWorkspace: View {
   }
 
   private func runVisualQuery() {
+    perform { try store.runGraphQuery(currentVisualDefinition) }
+  }
+
+  private var currentVisualDefinition: GraphQueryDefinition {
     var expressions: [GraphExpression] = []
     if let selectedTagID { expressions.append(.tag(selectedTagID)) }
     if traversalRelationID != nil || targetTagID != nil {
@@ -148,7 +207,7 @@ struct GraphQueryWorkspace: View {
     case 1: expressions[0]
     default: .and(expressions)
     }
-    perform { try store.runGraphQuery(.init(expression: expression)) }
+    return .init(expression: expression)
   }
 
   private func runSQL() {
@@ -159,6 +218,44 @@ struct GraphQueryWorkspace: View {
     do {
       result = try query()
       errorMessage = nil
+    } catch {
+      errorMessage = error.localizedDescription
+    }
+  }
+
+  private func saveCurrentQuery() async {
+    let source: SavedGraphQuery.Source = switch mode {
+    case .visual: .builder(currentVisualDefinition)
+    case .sql: .sql(sql)
+    }
+    let query = SavedGraphQuery(
+      name: queryName.trimmingCharacters(in: .whitespacesAndNewlines),
+      source: source,
+      presentation: .init(kind: mode == .visual ? .list : .table)
+    )
+    do {
+      try await store.saveGraphQuery(query)
+      selectedSavedQueryID = query.id
+      await reloadSavedQueries()
+      perform { try store.runGraphQuery(query) }
+    } catch {
+      errorMessage = error.localizedDescription
+    }
+  }
+
+  private func deleteSavedQuery(_ query: SavedGraphQuery) async {
+    do {
+      try await store.deleteGraphQuery(query.id)
+      if selectedSavedQueryID == query.id { selectedSavedQueryID = nil }
+      await reloadSavedQueries()
+    } catch {
+      errorMessage = error.localizedDescription
+    }
+  }
+
+  private func reloadSavedQueries() async {
+    do {
+      savedQueries = try await store.savedGraphQueries()
     } catch {
       errorMessage = error.localizedDescription
     }
@@ -192,6 +289,15 @@ struct GraphQueryWorkspace: View {
       get: { errorMessage != nil },
       set: { if !$0 { errorMessage = nil } }
     )
+  }
+}
+
+private extension SavedGraphQuery.Source {
+  var systemImage: String {
+    switch self {
+    case .builder: "point.3.connected.trianglepath.dotted"
+    case .sql: "text.page"
+    }
   }
 }
 

--- a/apps/enchiridion/Sources/SharedUI/GraphRelationDefinitionsView.swift
+++ b/apps/enchiridion/Sources/SharedUI/GraphRelationDefinitionsView.swift
@@ -21,6 +21,11 @@ struct GraphRelationDefinitionsView: View {
         Section("Custom") {
           ForEach(customDefinitions) { definition in
             definitionButton(definition)
+              .contextMenu {
+                Button("Delete Relationship Type", systemImage: "trash", role: .destructive) {
+                  definitionPendingDeletion = definition
+                }
+              }
               .swipeActions {
                 Button("Delete", systemImage: "trash", role: .destructive) {
                   definitionPendingDeletion = definition
@@ -120,9 +125,9 @@ struct GraphRelationDefinitionsView: View {
 
   private func deletePendingDefinition() async {
     guard let definition = definitionPendingDeletion else { return }
+    defer { definitionPendingDeletion = nil }
     do {
       try await store.deleteGraphRelationDefinition(definition.id)
-      definitionPendingDeletion = nil
       await load()
     } catch {
       errorMessage = error.localizedDescription

--- a/apps/enchiridion/Sources/SharedUI/GraphRelationDefinitionsView.swift
+++ b/apps/enchiridion/Sources/SharedUI/GraphRelationDefinitionsView.swift
@@ -1,0 +1,323 @@
+import EnchiridionCore
+import SwiftUI
+
+struct GraphRelationDefinitionsView: View {
+  let store: LibraryStore
+
+  @State private var definitions: [RelationDefinition] = []
+  @State private var editingDefinition: RelationDefinition?
+  @State private var definitionPendingDeletion: RelationDefinition?
+  @State private var errorMessage: String?
+
+  var body: some View {
+    List {
+      Section {
+        Text("Relationships are directed in storage and named in both directions. Endpoint types and cardinality are enforced for every edit.")
+          .font(.subheadline)
+          .foregroundStyle(.secondary)
+      }
+
+      if !customDefinitions.isEmpty {
+        Section("Custom") {
+          ForEach(customDefinitions) { definition in
+            definitionButton(definition)
+              .swipeActions {
+                Button("Delete", systemImage: "trash", role: .destructive) {
+                  definitionPendingDeletion = definition
+                }
+              }
+          }
+        }
+      }
+
+      Section("Base Relationships") {
+        ForEach(systemDefinitions) { definition in
+          definitionButton(definition)
+        }
+      }
+    }
+    .navigationTitle("Relationship Types")
+    .toolbar {
+      ToolbarItem(placement: .primaryAction) {
+        Button {
+          editingDefinition = .draft
+        } label: {
+          Label("New Relationship Type", systemImage: "plus")
+        }
+      }
+    }
+    .task { await load() }
+    .refreshable { await load() }
+    .sheet(item: $editingDefinition, onDismiss: { Task { await load() } }) { definition in
+      GraphRelationDefinitionEditor(
+        store: store,
+        definition: definition,
+        isNew: !definitions.contains { $0.id == definition.id }
+      )
+    }
+    .confirmationDialog(
+      "Delete \(definitionPendingDeletion?.forwardName ?? "relationship")?",
+      isPresented: deletionBinding,
+      titleVisibility: .visible
+    ) {
+      Button("Delete Relationship Type", role: .destructive) {
+        Task { await deletePendingDefinition() }
+      }
+      Button("Cancel", role: .cancel) {}
+    } message: {
+      Text("The custom definition will no longer be available for new relationships.")
+    }
+    .alert("Relationship Type Error", isPresented: errorBinding) {
+      Button("OK", role: .cancel) {}
+    } message: {
+      Text(errorMessage ?? "The relationship type could not be changed.")
+    }
+  }
+
+  private var customDefinitions: [RelationDefinition] {
+    definitions.filter { !$0.isSystem }
+  }
+
+  private var systemDefinitions: [RelationDefinition] {
+    definitions.filter(\.isSystem)
+  }
+
+  private func definitionButton(_ definition: RelationDefinition) -> some View {
+    Button {
+      editingDefinition = definition
+    } label: {
+      HStack(spacing: 12) {
+        Image(systemName: definition.isSystem ? "lock" : "arrow.left.arrow.right")
+          .foregroundStyle(.secondary)
+          .frame(width: 20)
+          .accessibilityHidden(true)
+        VStack(alignment: .leading, spacing: 3) {
+          Text("\(definition.forwardName) / \(definition.inverseName)")
+            .foregroundStyle(.primary)
+          Text(definition.summary(using: store.supertags))
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+        Spacer()
+        Image(systemName: "chevron.right")
+          .font(.caption.weight(.semibold))
+          .foregroundStyle(.tertiary)
+          .accessibilityHidden(true)
+      }
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+  }
+
+  private func load() async {
+    do {
+      definitions = try await store.graphRelationDefinitions()
+      errorMessage = nil
+    } catch {
+      errorMessage = error.localizedDescription
+    }
+  }
+
+  private func deletePendingDefinition() async {
+    guard let definition = definitionPendingDeletion else { return }
+    do {
+      try await store.deleteGraphRelationDefinition(definition.id)
+      definitionPendingDeletion = nil
+      await load()
+    } catch {
+      errorMessage = error.localizedDescription
+    }
+  }
+
+  private var deletionBinding: Binding<Bool> {
+    Binding(
+      get: { definitionPendingDeletion != nil },
+      set: { if !$0 { definitionPendingDeletion = nil } }
+    )
+  }
+
+  private var errorBinding: Binding<Bool> {
+    Binding(
+      get: { errorMessage != nil },
+      set: { if !$0 { errorMessage = nil } }
+    )
+  }
+}
+
+private struct GraphRelationDefinitionEditor: View {
+  let store: LibraryStore
+  let definition: RelationDefinition
+  let isNew: Bool
+
+  @Environment(\.dismiss) private var dismiss
+  @State private var draft: RelationDefinition
+  @State private var isSaving = false
+  @State private var errorMessage: String?
+
+  init(store: LibraryStore, definition: RelationDefinition, isNew: Bool) {
+    self.store = store
+    self.definition = definition
+    self.isNew = isNew
+    _draft = State(initialValue: definition)
+  }
+
+  var body: some View {
+    NavigationStack {
+      Form {
+        Section("Names") {
+          TextField("Forward name", text: $draft.forwardName)
+          TextField("Backlink name", text: $draft.inverseName)
+          Text("For example, Person “works at” Company appears on the Company as “people”.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+
+        Section("Endpoints") {
+          typePicker("Source types", selection: $draft.sourceTagIDs)
+          typePicker("Target types", selection: $draft.targetTagIDs)
+          Text("Leaving an endpoint unrestricted allows any page type. Inherited types are accepted.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+
+        Section("Cardinality") {
+          Picker("Targets per source", selection: $draft.cardinality.targetsPerSource) {
+            ForEach(EndpointMaximum.allCases, id: \.self) { maximum in
+              Text(maximum.title).tag(maximum)
+            }
+          }
+          Picker("Sources per target", selection: $draft.cardinality.sourcesPerTarget) {
+            ForEach(EndpointMaximum.allCases, id: \.self) { maximum in
+              Text(maximum.title).tag(maximum)
+            }
+          }
+          LabeledContent("Shape", value: draft.cardinality.title)
+        }
+
+        if definition.isSystem {
+          Section {
+            Text("This relationship is part of Enchiridion’s Base Tag ontology and cannot be changed.")
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+        }
+      }
+      .formStyle(.grouped)
+      .disabled(definition.isSystem || isSaving)
+      .navigationTitle(navigationTitle)
+      .toolbar {
+        ToolbarItem(placement: .cancellationAction) {
+          Button(definition.isSystem ? "Done" : "Cancel") { dismiss() }
+            .disabled(false)
+        }
+        if !definition.isSystem {
+          ToolbarItem(placement: .confirmationAction) {
+            Button("Save") { Task { await save() } }
+              .disabled(!canSave || isSaving)
+          }
+        }
+      }
+      .alert("Cannot Save Relationship", isPresented: errorBinding) {
+        Button("OK", role: .cancel) {}
+      } message: {
+        Text(errorMessage ?? "Check the relationship definition and try again.")
+      }
+    }
+    #if os(macOS)
+    .frame(minWidth: 500, minHeight: 520)
+    #endif
+  }
+
+  private var navigationTitle: String {
+    if definition.isSystem { return "Base Relationship" }
+    return isNew ? "New Relationship" : "Edit Relationship"
+  }
+
+  private var canSave: Bool {
+    !draft.forwardName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+      && !draft.inverseName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+  }
+
+  private func typePicker(_ title: String, selection: Binding<[TagID]>) -> some View {
+    Menu {
+      ForEach(store.supertags) { tag in
+        Toggle(tag.name, isOn: Binding(
+          get: { selection.wrappedValue.contains(tag.id) },
+          set: { enabled in
+            if enabled {
+              if !selection.wrappedValue.contains(tag.id) {
+                selection.wrappedValue.append(tag.id)
+              }
+            } else {
+              selection.wrappedValue.removeAll { $0 == tag.id }
+            }
+          }
+        ))
+      }
+    } label: {
+      LabeledContent(title, value: typeNames(selection.wrappedValue))
+    }
+  }
+
+  private func typeNames(_ ids: [TagID]) -> String {
+    guard !ids.isEmpty else { return "Any type" }
+    return ids.compactMap { id in
+      store.supertags.first(where: { $0.id == id })?.name
+    }.joined(separator: ", ")
+  }
+
+  private func save() async {
+    isSaving = true
+    defer { isSaving = false }
+    do {
+      try await store.saveGraphRelationDefinition(draft)
+      dismiss()
+    } catch {
+      errorMessage = error.localizedDescription
+    }
+  }
+
+  private var errorBinding: Binding<Bool> {
+    Binding(
+      get: { errorMessage != nil },
+      set: { if !$0 { errorMessage = nil } }
+    )
+  }
+}
+
+private extension RelationDefinition {
+  static var draft: Self {
+    .init(
+      id: .random(),
+      forwardName: "relates to",
+      inverseName: "related from"
+    )
+  }
+
+  func summary(using tags: [SupertagDefinition]) -> String {
+    let sources = endpointNames(sourceTagIDs, tags: tags)
+    let targets = endpointNames(targetTagIDs, tags: tags)
+    return "\(sources) → \(targets) · \(cardinality.title)"
+  }
+
+  private func endpointNames(_ ids: [TagID], tags: [SupertagDefinition]) -> String {
+    guard !ids.isEmpty else { return "Any page" }
+    return ids.compactMap { id in tags.first(where: { $0.id == id })?.name }
+      .joined(separator: ", ")
+  }
+}
+
+private extension RelationCardinality {
+  var title: String {
+    switch (targetsPerSource, sourcesPerTarget) {
+    case (.one, .one): "One to one"
+    case (.many, .one): "One to many"
+    case (.one, .many): "Many to one"
+    case (.many, .many): "Many to many"
+    }
+  }
+}
+
+private extension EndpointMaximum {
+  var title: String { self == .one ? "One" : "Many" }
+}

--- a/apps/enchiridion/Sources/SharedUI/GraphRelationDefinitionsView.swift
+++ b/apps/enchiridion/Sources/SharedUI/GraphRelationDefinitionsView.swift
@@ -68,7 +68,7 @@ struct GraphRelationDefinitionsView: View {
       Text("The custom definition will no longer be available for new relationships.")
     }
     .alert("Relationship Type Error", isPresented: errorBinding) {
-      Button("OK", role: .cancel) {}
+      Button("Dismiss Error", role: .cancel) {}
     } message: {
       Text(errorMessage ?? "The relationship type could not be changed.")
     }

--- a/apps/enchiridion/Sources/SharedUI/GraphRelationshipViews.swift
+++ b/apps/enchiridion/Sources/SharedUI/GraphRelationshipViews.swift
@@ -89,9 +89,10 @@ struct GraphRelationshipsView: View {
   private var availableRelations: [RelationDefinition] {
     guard let page = store.page(id: pageID) else { return [] }
     let directTags = Set(page.objectMetadata.supertagIDs)
-    let effectiveTags = store.supertags.reduce(into: directTags) { result, tag in
-      if directTags.contains(tag.id) { result.formUnion(ancestors(of: tag.id)) }
-    }
+    let effectiveTags = SupertagInheritance.effectiveTagIDs(
+      for: directTags,
+      definitions: store.supertags
+    )
     return relations.filter {
       $0.sourceTagIDs.isEmpty || !effectiveTags.isDisjoint(with: $0.sourceTagIDs)
     }
@@ -99,13 +100,6 @@ struct GraphRelationshipsView: View {
 
   private var pageIssues: [GraphIssue] {
     issues.filter { $0.nodeID == pageID }
-  }
-
-  private func ancestors(of tagID: TagID) -> Set<TagID> {
-    guard let tag = store.supertags.first(where: { $0.id == tagID }) else { return [] }
-    return tag.parentIDs.reduce(into: Set(tag.parentIDs)) { result, parent in
-      result.formUnion(ancestors(of: parent))
-    }
   }
 
   @ViewBuilder
@@ -257,19 +251,11 @@ private struct GraphRelationshipTargetPicker: View {
 
   private func isCompatibleTarget(_ page: PageSnapshot) -> Bool {
     guard !relation.targetTagIDs.isEmpty else { return true }
-    let effectiveTags = page.objectMetadata.supertagIDs.reduce(into: Set<TagID>()) {
-      result, tagID in
-      result.insert(tagID)
-      result.formUnion(ancestors(of: tagID))
-    }
+    let effectiveTags = SupertagInheritance.effectiveTagIDs(
+      for: Set(page.objectMetadata.supertagIDs),
+      definitions: store.supertags
+    )
     return !effectiveTags.isDisjoint(with: relation.targetTagIDs)
-  }
-
-  private func ancestors(of tagID: TagID) -> Set<TagID> {
-    guard let tag = store.supertags.first(where: { $0.id == tagID }) else { return [] }
-    return tag.parentIDs.reduce(into: Set(tag.parentIDs)) { result, parent in
-      result.formUnion(ancestors(of: parent))
-    }
   }
 
   private func typeNames(for page: PageSnapshot) -> String {

--- a/apps/enchiridion/Sources/SharedUI/GraphRelationshipViews.swift
+++ b/apps/enchiridion/Sources/SharedUI/GraphRelationshipViews.swift
@@ -80,7 +80,7 @@ struct GraphRelationshipsView: View {
       }
     }
     .alert("Relationship Error", isPresented: errorBinding) {
-      Button("OK", role: .cancel) {}
+      Button("Dismiss Error", role: .cancel) {}
     } message: {
       Text(errorMessage ?? "The relationship could not be changed.")
     }

--- a/apps/enchiridion/Sources/SharedUI/GraphRelationshipViews.swift
+++ b/apps/enchiridion/Sources/SharedUI/GraphRelationshipViews.swift
@@ -1,0 +1,359 @@
+import EnchiridionCore
+import SwiftUI
+
+struct GraphRelationshipsView: View {
+  let store: LibraryStore
+  let pageID: NodeID
+  let onOpenPage: ((PageID) -> Void)?
+
+  @State private var relations: [RelationDefinition] = []
+  @State private var outgoing: [KnowledgeEdge] = []
+  @State private var backlinks: [GraphBacklink] = []
+  @State private var issues: [GraphIssue] = []
+  @State private var selectedRelation: RelationDefinition?
+  @State private var errorMessage: String?
+
+  var body: some View {
+    List {
+      if !pageIssues.isEmpty {
+        Section("Needs Attention") {
+          ForEach(pageIssues) { issue in
+            Label(issue.message, systemImage: "exclamationmark.triangle")
+              .foregroundStyle(.orange)
+          }
+        }
+      }
+
+      Section("Relationships") {
+        if outgoing.isEmpty {
+          Text("No relationships yet")
+            .foregroundStyle(.secondary)
+        }
+        ForEach(outgoing) { edge in
+          relationshipRow(edge)
+        }
+        Menu("Add Relationship", systemImage: "plus") {
+          ForEach(availableRelations) { relation in
+            Button(relation.forwardName) { selectedRelation = relation }
+          }
+        }
+        .disabled(availableRelations.isEmpty)
+      }
+
+      Section("Backlinks") {
+        if backlinks.isEmpty {
+          Text("No pages point here")
+            .foregroundStyle(.secondary)
+        }
+        ForEach(backlinks) { backlink in
+          Button {
+            onOpenPage?(backlink.edge.sourceNodeID)
+          } label: {
+            HStack {
+              VStack(alignment: .leading, spacing: 2) {
+                Text(backlink.sourceTitle)
+                  .foregroundStyle(.primary)
+                Text(backlink.relation.inverseName)
+                  .font(.caption)
+                  .foregroundStyle(.secondary)
+              }
+              Spacer()
+              Image(systemName: "arrow.up.left")
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+            }
+          }
+          .buttonStyle(.plain)
+        }
+      }
+    }
+    .formStyle(.grouped)
+    .task(id: pageID) { await load() }
+    .sheet(item: $selectedRelation) { relation in
+      GraphRelationshipTargetPicker(
+        store: store,
+        sourceID: pageID,
+        relation: relation
+      ) {
+        selectedRelation = nil
+        Task { await load() }
+      }
+    }
+    .alert("Relationship Error", isPresented: errorBinding) {
+      Button("OK", role: .cancel) {}
+    } message: {
+      Text(errorMessage ?? "The relationship could not be changed.")
+    }
+  }
+
+  private var availableRelations: [RelationDefinition] {
+    guard let page = store.page(id: pageID) else { return [] }
+    let directTags = Set(page.objectMetadata.supertagIDs)
+    let effectiveTags = store.supertags.reduce(into: directTags) { result, tag in
+      if directTags.contains(tag.id) { result.formUnion(ancestors(of: tag.id)) }
+    }
+    return relations.filter {
+      $0.sourceTagIDs.isEmpty || !effectiveTags.isDisjoint(with: $0.sourceTagIDs)
+    }
+  }
+
+  private var pageIssues: [GraphIssue] {
+    issues.filter { $0.nodeID == pageID }
+  }
+
+  private func ancestors(of tagID: TagID) -> Set<TagID> {
+    guard let tag = store.supertags.first(where: { $0.id == tagID }) else { return [] }
+    return tag.parentIDs.reduce(into: Set(tag.parentIDs)) { result, parent in
+      result.formUnion(ancestors(of: parent))
+    }
+  }
+
+  @ViewBuilder
+  private func relationshipRow(_ edge: KnowledgeEdge) -> some View {
+    let relation = relations.first(where: { $0.id == edge.relationID })
+    let target = store.page(id: edge.targetNodeID)
+    HStack {
+      Button {
+        onOpenPage?(edge.targetNodeID)
+      } label: {
+        VStack(alignment: .leading, spacing: 2) {
+          Text(target?.displayTitle ?? "Unavailable page")
+            .foregroundStyle(target == nil ? .secondary : .primary)
+          Text(relation?.forwardName ?? edge.relationID.rawValue)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+      }
+      .buttonStyle(.plain)
+      Spacer()
+      if hasCardinalityConflict(edge) {
+        Button("Keep This") {
+          Task { await resolveConflict(keeping: edge) }
+        }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.small)
+        .help("Keep this relationship and remove the other conflicting values")
+      }
+      if edge.origin == .user {
+        Button(role: .destructive) {
+          Task { await remove(edge) }
+        } label: {
+          Label("Remove Relationship", systemImage: "minus.circle")
+            .labelStyle(.iconOnly)
+        }
+        .buttonStyle(.borderless)
+      }
+    }
+  }
+
+  private func load() async {
+    do {
+      async let loadedRelations = store.graphRelationDefinitions()
+      async let loadedOutgoing = store.graphOutgoingEdges(from: pageID)
+      async let loadedBacklinks = store.graphBacklinks(to: pageID)
+      async let loadedIssues = store.graphIssues()
+      relations = try await loadedRelations
+      outgoing = try await loadedOutgoing
+      backlinks = try await loadedBacklinks
+      issues = try await loadedIssues
+      errorMessage = nil
+    } catch {
+      errorMessage = error.localizedDescription
+    }
+  }
+
+  private func remove(_ edge: KnowledgeEdge) async {
+    do {
+      try await store.removeGraphEdge(edge.id)
+      await load()
+    } catch {
+      errorMessage = error.localizedDescription
+    }
+  }
+
+  private func hasCardinalityConflict(_ edge: KnowledgeEdge) -> Bool {
+    pageIssues.contains {
+      $0.kind == .cardinalityViolation && $0.edgeID == edge.id
+        && $0.relationID == edge.relationID
+    }
+  }
+
+  private func resolveConflict(keeping edge: KnowledgeEdge) async {
+    do {
+      try await store.resolveGraphCardinalityConflict(
+        relationID: edge.relationID,
+        keeping: edge.id
+      )
+      await load()
+    } catch {
+      errorMessage = error.localizedDescription
+    }
+  }
+
+  private var errorBinding: Binding<Bool> {
+    Binding(
+      get: { errorMessage != nil },
+      set: { if !$0 { errorMessage = nil } }
+    )
+  }
+}
+
+private struct GraphRelationshipTargetPicker: View {
+  let store: LibraryStore
+  let sourceID: NodeID
+  let relation: RelationDefinition
+  let didCreate: () -> Void
+
+  @Environment(\.dismiss) private var dismiss
+  @State private var query = ""
+  @State private var errorMessage: String?
+
+  var body: some View {
+    NavigationStack {
+      List(candidates) { page in
+        Button {
+          Task { await create(targetID: page.id) }
+        } label: {
+          VStack(alignment: .leading, spacing: 2) {
+            Text(page.displayTitle)
+              .foregroundStyle(.primary)
+            Text(typeNames(for: page))
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+        }
+        .buttonStyle(.plain)
+      }
+      .overlay {
+        if candidates.isEmpty {
+          ContentUnavailableView.search(text: query)
+        }
+      }
+      .navigationTitle("Add \(relation.forwardName)")
+      .searchable(text: $query, prompt: "Find a page")
+      .toolbar {
+        ToolbarItem(placement: .cancellationAction) {
+          Button("Cancel") { dismiss() }
+        }
+      }
+      .alert("Cannot Add Relationship", isPresented: errorBinding) {
+        Button("OK", role: .cancel) {}
+      } message: {
+        Text(errorMessage ?? "Choose a compatible page.")
+      }
+    }
+    #if os(macOS)
+    .frame(minWidth: 420, minHeight: 480)
+    #endif
+  }
+
+  private var candidates: [PageSnapshot] {
+    store.pages.filter {
+      $0.id != sourceID && $0.deletedAt == nil
+        && (query.isEmpty || $0.displayTitle.localizedStandardContains(query))
+        && isCompatibleTarget($0)
+    }
+  }
+
+  private func isCompatibleTarget(_ page: PageSnapshot) -> Bool {
+    guard !relation.targetTagIDs.isEmpty else { return true }
+    let effectiveTags = page.objectMetadata.supertagIDs.reduce(into: Set<TagID>()) {
+      result, tagID in
+      result.insert(tagID)
+      result.formUnion(ancestors(of: tagID))
+    }
+    return !effectiveTags.isDisjoint(with: relation.targetTagIDs)
+  }
+
+  private func ancestors(of tagID: TagID) -> Set<TagID> {
+    guard let tag = store.supertags.first(where: { $0.id == tagID }) else { return [] }
+    return tag.parentIDs.reduce(into: Set(tag.parentIDs)) { result, parent in
+      result.formUnion(ancestors(of: parent))
+    }
+  }
+
+  private func typeNames(for page: PageSnapshot) -> String {
+    let names = page.objectMetadata.supertagIDs.compactMap { id in
+      store.supertags.first(where: { $0.id == id })?.name
+    }
+    return names.isEmpty ? "Page" : names.joined(separator: " · ")
+  }
+
+  private func create(targetID: NodeID) async {
+    do {
+      _ = try await store.createGraphEdge(
+        relationID: relation.id,
+        from: sourceID,
+        to: targetID
+      )
+      dismiss()
+      didCreate()
+    } catch {
+      errorMessage = error.localizedDescription
+    }
+  }
+
+  private var errorBinding: Binding<Bool> {
+    Binding(
+      get: { errorMessage != nil },
+      set: { if !$0 { errorMessage = nil } }
+    )
+  }
+}
+
+struct GraphIssuesView: View {
+  let store: LibraryStore
+  let onOpenPage: ((PageID) -> Void)?
+  @State private var issues: [GraphIssue] = []
+  @State private var errorMessage: String?
+
+  var body: some View {
+    List(issues) { issue in
+      Button {
+        onOpenPage?(issue.nodeID)
+      } label: {
+        VStack(alignment: .leading, spacing: 4) {
+          Text(store.page(id: issue.nodeID)?.displayTitle ?? "Unavailable page")
+            .foregroundStyle(.primary)
+          Text(issue.message)
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+        }
+      }
+      .buttonStyle(.plain)
+    }
+    .overlay {
+      if issues.isEmpty, errorMessage == nil {
+        ContentUnavailableView(
+          "Graph is consistent",
+          systemImage: "checkmark.circle",
+          description: Text("Relationship conflicts and unresolved targets appear here.")
+        )
+      }
+    }
+    .navigationTitle("Needs Attention")
+    .task { await load() }
+    .refreshable { await load() }
+    .alert("Cannot Load Graph Issues", isPresented: errorBinding) {
+      Button("OK", role: .cancel) {}
+    } message: {
+      Text(errorMessage ?? "Graph issues could not be loaded.")
+    }
+  }
+
+  private func load() async {
+    do {
+      issues = try await store.graphIssues()
+      errorMessage = nil
+    } catch {
+      errorMessage = error.localizedDescription
+    }
+  }
+
+  private var errorBinding: Binding<Bool> {
+    Binding(
+      get: { errorMessage != nil },
+      set: { if !$0 { errorMessage = nil } }
+    )
+  }
+}

--- a/apps/enchiridion/Sources/SharedUI/SupertagPropertiesView.swift
+++ b/apps/enchiridion/Sources/SharedUI/SupertagPropertiesView.swift
@@ -31,10 +31,8 @@ struct SupertagPropertiesView: View {
           )
         }
 
-        ForEach(page.objectMetadata.supertagIDs) { tagID in
-          if let definition = store.supertags.first(where: { $0.id == tagID }),
-            !visibleFields(in: definition, on: page).isEmpty
-          {
+        ForEach(visibleDefinitions(on: page)) { definition in
+          if !visibleFields(in: definition, on: page).isEmpty {
             Section(definition.name) {
               ForEach(visibleFields(in: definition, on: page)) { field in
                 SupertagFieldEditor(
@@ -121,6 +119,20 @@ struct SupertagPropertiesView: View {
         return lhsRank == rhsRank ? lhs.offset < rhs.offset : lhsRank < rhsRank
       }
       .map(\.element)
+  }
+
+  private func visibleDefinitions(on page: PageSnapshot) -> [SupertagDefinition] {
+    var ordered: [SupertagDefinition] = []
+    var visited: Set<TagID> = []
+    func append(_ id: TagID) {
+      guard visited.insert(id).inserted,
+        let definition = store.supertags.first(where: { $0.id == id })
+      else { return }
+      for parentID in definition.parentIDs { append(parentID) }
+      ordered.append(definition)
+    }
+    for tagID in page.objectMetadata.supertagIDs { append(tagID) }
+    return ordered
   }
 
   private func fieldRank(

--- a/apps/enchiridion/Sources/SharedUI/SupertagSchemaEditor.swift
+++ b/apps/enchiridion/Sources/SharedUI/SupertagSchemaEditor.swift
@@ -158,7 +158,7 @@ struct SupertagSchemaEditor: View {
       }
       .disabled(isSaving)
       .alert("Cannot Save Supertag", isPresented: errorBinding) {
-        Button("OK", role: .cancel) {}
+        Button("Dismiss Error", role: .cancel) {}
       } message: {
         Text(errorMessage ?? "Check the inheritance and field definitions, then try again.")
       }

--- a/apps/enchiridion/Sources/SharedUI/SupertagSchemaEditor.swift
+++ b/apps/enchiridion/Sources/SharedUI/SupertagSchemaEditor.swift
@@ -6,6 +6,8 @@ struct SupertagSchemaEditor: View {
   let definition: SupertagDefinition
   @Environment(\.dismiss) private var dismiss
   @State private var draft: SupertagDefinition
+  @State private var isSaving = false
+  @State private var errorMessage: String?
 
   init(store: LibraryStore, definition: SupertagDefinition) {
     self.store = store
@@ -19,6 +21,58 @@ struct SupertagSchemaEditor: View {
         Section("Supertag") {
           TextField("Name", text: $draft.name)
           TextField("Symbol", text: $draft.symbol)
+        }
+
+        Section("Inheritance") {
+          if definition.isBuiltIn {
+            if draft.parentIDs.isEmpty {
+              Text("Base Tag")
+                .foregroundStyle(.secondary)
+            } else {
+              ForEach(draft.parentIDs) { parentID in
+                Label(parentName(parentID), systemImage: "arrow.up.right")
+              }
+            }
+            Text("Base Tag inheritance is fixed by Enchiridion.")
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          } else {
+            Menu("Inherits From", systemImage: "arrow.triangle.branch") {
+              ForEach(store.supertags.filter { $0.id != draft.id }) { candidate in
+                Toggle(
+                  candidate.name,
+                  isOn: Binding(
+                    get: { draft.parentIDs.contains(candidate.id) },
+                    set: { enabled in
+                      if enabled { draft.parentIDs.append(candidate.id) }
+                      else { draft.parentIDs.removeAll { $0 == candidate.id } }
+                    }
+                  )
+                )
+              }
+            }
+            if draft.parentIDs.isEmpty {
+              Text("This type does not inherit properties from another type.")
+                .foregroundStyle(.secondary)
+            } else {
+              ForEach(draft.parentIDs) { parentID in
+                HStack {
+                  Label(parentName(parentID), systemImage: "arrow.up.right")
+                  Spacer()
+                  Button(role: .destructive) {
+                    draft.parentIDs.removeAll { $0 == parentID }
+                  } label: {
+                    Label("Remove Parent", systemImage: "minus.circle")
+                      .labelStyle(.iconOnly)
+                  }
+                  .buttonStyle(.borderless)
+                }
+              }
+            }
+            Text("Multiple inheritance is allowed. Cycles are rejected when you save.")
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
         }
 
         Section("Fields") {
@@ -95,11 +149,18 @@ struct SupertagSchemaEditor: View {
         ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
         ToolbarItem(placement: .confirmationAction) {
           Button("Save") {
-            store.saveSupertag(draft)
-            dismiss()
+            Task { await save() }
           }
-          .disabled(draft.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+          .disabled(
+            draft.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSaving
+          )
         }
+      }
+      .disabled(isSaving)
+      .alert("Cannot Save Supertag", isPresented: errorBinding) {
+        Button("OK", role: .cancel) {}
+      } message: {
+        Text(errorMessage ?? "Check the inheritance and field definitions, then try again.")
       }
     }
     #if os(macOS)
@@ -113,5 +174,27 @@ struct SupertagSchemaEditor: View {
   private func valueCount(for fieldID: SupertagFieldID) -> Int {
     let key = SupertagPropertyKey(supertagID: definition.id, fieldID: fieldID)
     return taggedPages.reduce(0) { $0 + ($1.objectMetadata.properties[key]?.count ?? 0) }
+  }
+
+  private func parentName(_ id: TagID) -> String {
+    store.supertags.first(where: { $0.id == id })?.name ?? id.rawValue
+  }
+
+  private func save() async {
+    isSaving = true
+    defer { isSaving = false }
+    do {
+      try await store.saveSupertag(draft)
+      dismiss()
+    } catch {
+      errorMessage = error.localizedDescription
+    }
+  }
+
+  private var errorBinding: Binding<Bool> {
+    Binding(
+      get: { errorMessage != nil },
+      set: { if !$0 { errorMessage = nil } }
+    )
   }
 }

--- a/apps/enchiridion/Sources/SharedUI/TaskAppIntents.swift
+++ b/apps/enchiridion/Sources/SharedUI/TaskAppIntents.swift
@@ -52,11 +52,8 @@ struct EnchiridionTaskEntity: AppEntity {
 
 struct EnchiridionTaskEntityQuery: EntityStringQuery, EnumerableEntityQuery {
   func entities(for identifiers: [String]) async throws -> [EnchiridionTaskEntity] {
-    let requested = Set(identifiers)
-    return try await intentTaskPages(in: .active).compactMap { item in
-      let entity = EnchiridionTaskEntity(page: item.page, vault: item.vault)
-      return requested.contains(entity.id) ? entity : nil
-    }
+    try await intentTaskPages(for: identifiers, in: .active)
+      .map { EnchiridionTaskEntity(page: $0.page, vault: $0.vault) }
   }
 
   func entities(matching string: String) async throws -> [EnchiridionTaskEntity] {
@@ -117,11 +114,8 @@ struct ClosedEnchiridionTaskEntity: AppEntity {
 
 struct ClosedEnchiridionTaskEntityQuery: EntityStringQuery, EnumerableEntityQuery {
   func entities(for identifiers: [String]) async throws -> [ClosedEnchiridionTaskEntity] {
-    let requested = Set(identifiers)
-    return try await intentTaskPages(in: .closed).compactMap { item in
-      let entity = ClosedEnchiridionTaskEntity(page: item.page, vault: item.vault)
-      return requested.contains(entity.id) ? entity : nil
-    }
+    try await intentTaskPages(for: identifiers, in: .closed)
+      .map { ClosedEnchiridionTaskEntity(page: $0.page, vault: $0.vault) }
   }
 
   func entities(matching string: String) async throws -> [ClosedEnchiridionTaskEntity] {
@@ -469,12 +463,13 @@ struct FindEnchiridionTasksIntent: AppIntent {
     & ProvidesDialog
   {
     let contexts = try VaultRepositoryContext.openAll()
-    let tasks = try await contexts.asyncFlatMap { context in
+    let taskPages = try await contexts.asyncFlatMap { context in
       let pages = try await context.repository.pages(with: BuiltInSupertags.task)
       return TaskQuery.items(from: pages, selection: .smart(list.smartList))
-        .map { EnchiridionTaskEntity(page: $0.page, vault: context.vault) }
+        .map { IntentTaskPage(vault: context.vault, page: $0.page) }
     }
-    await TaskSpotlightIndex.index(tasks)
+    let tasks = taskPages.map { EnchiridionTaskEntity(page: $0.page, vault: $0.vault) }
+    await TaskSpotlightIndex.index(taskPages)
     return .result(
       value: tasks,
       dialog: tasks.isEmpty
@@ -496,7 +491,9 @@ struct OpenEnchiridionTaskListIntent: AppIntent {
 
   func perform() async throws -> some IntentResult & OpensIntent {
     let context = try VaultRepositoryContext.open(.selected)
-    let url = TaskDeepLinkRoute.url(vaultID: context.vault.id, list: list.smartList)!
+    guard let url = TaskDeepLinkRoute.url(vaultID: context.vault.id, list: list.smartList) else {
+      throw EnchiridionTaskIntentError.taskNotActive
+    }
     return .result(opensIntent: OpenURLIntent(url))
   }
 }
@@ -623,6 +620,26 @@ private func intentTaskPages(in lifecycle: TaskLifecycleScope) async throws -> [
   }
 }
 
+private func intentTaskPages(
+  for identifiers: [String],
+  in lifecycle: TaskLifecycleScope
+) async throws -> [IntentTaskPage] {
+  let identities = identifiers.compactMap(VaultScopedNodeID.init(serialized:))
+  let identitiesByVault = Dictionary(grouping: identities, by: \.vaultID)
+  var pagesByIdentity: [VaultScopedNodeID: IntentTaskPage] = [:]
+  for (vaultID, vaultIdentities) in identitiesByVault {
+    let context = try VaultRepositoryContext.open(.vault(vaultID))
+    for identity in vaultIdentities {
+      guard let page = try await context.repository.page(id: identity.nodeID),
+        let state = page.taskData?.state,
+        lifecycle.contains(state)
+      else { continue }
+      pagesByIdentity[identity] = .init(vault: context.vault, page: page)
+    }
+  }
+  return identities.compactMap { pagesByIdentity[$0] }
+}
+
 private func intentCreationContext(_ selection: VaultSelection) throws -> IntentCreationContext {
   let context = try VaultRepositoryContext.open(selection)
   return .init(
@@ -664,13 +681,9 @@ private func intentMutationValue<Value: Sendable>(
 }
 
 private enum TaskSpotlightIndex {
-  static func index(_ entities: [EnchiridionTaskEntity]) async {
-    for entity in entities {
-      guard let identity = VaultScopedNodeID(serialized: entity.id),
-        let context = try? VaultRepositoryContext.open(.vault(identity.vaultID)),
-        let page = try? await context.repository.page(id: identity.nodeID)
-      else { continue }
-      await TaskSystemSpotlight.index(page, vaultID: identity.vaultID)
+  static func index(_ items: [IntentTaskPage]) async {
+    for item in items {
+      await TaskSystemSpotlight.index(item.page, vaultID: item.vault.id)
     }
   }
 }

--- a/apps/enchiridion/Sources/SharedUI/TaskAppIntents.swift
+++ b/apps/enchiridion/Sources/SharedUI/TaskAppIntents.swift
@@ -23,62 +23,68 @@ struct EnchiridionTaskEntity: AppEntity {
   @Property(title: "Tags")
   var tags: [String]
 
+  @Property(title: "Vault")
+  var vaultName: String
+
   var displayRepresentation: DisplayRepresentation {
     if isCompleted {
-      return DisplayRepresentation(title: "\(title)", subtitle: "Completed")
+      return DisplayRepresentation(title: "\(title)", subtitle: "Completed · \(vaultName)")
     }
     if let deadline {
       return DisplayRepresentation(
         title: "\(title)",
-        subtitle: "Due \(deadline.formatted(date: .abbreviated, time: .omitted))"
+        subtitle: "Due \(deadline.formatted(date: .abbreviated, time: .omitted)) · \(vaultName)"
       )
     }
-    return DisplayRepresentation(title: "\(title)")
+    return DisplayRepresentation(title: "\(title)", subtitle: "\(vaultName)")
   }
 
-  init(page: PageSnapshot) {
-    id = page.id.rawValue
+  init(page: PageSnapshot, vault: VaultDescriptor) {
+    id = VaultScopedNodeID(vaultID: vault.id, nodeID: page.id).id
     title = page.displayTitle
     isCompleted = page.taskData?.state == .completed
     deadline = page.taskData?.deadline
     priority = page.taskData?.priority.rawValue ?? TaskPriority.none.rawValue
     tags = page.taskData?.tags ?? []
+    vaultName = vault.name
   }
 }
 
 struct EnchiridionTaskEntityQuery: EntityStringQuery, EnumerableEntityQuery {
   func entities(for identifiers: [String]) async throws -> [EnchiridionTaskEntity] {
-    let repository = try intentRepository()
-    let pagesByID = Dictionary(
-      uniqueKeysWithValues: try await repository.tasks(in: .active).map { ($0.id.rawValue, $0) }
-    )
-    return identifiers.compactMap { pagesByID[$0].map(EnchiridionTaskEntity.init(page:)) }
+    let requested = Set(identifiers)
+    return try await intentTaskPages(in: .active).compactMap { item in
+      let entity = EnchiridionTaskEntity(page: item.page, vault: item.vault)
+      return requested.contains(entity.id) ? entity : nil
+    }
   }
 
   func entities(matching string: String) async throws -> [EnchiridionTaskEntity] {
-    let repository = try intentRepository()
-    return try await repository.tasks(in: .active)
+    return try await intentTaskPages(in: .active)
       .filter {
-        $0.displayTitle.localizedStandardContains(string)
-          || $0.plainText.localizedStandardContains(string)
+        $0.page.displayTitle.localizedStandardContains(string)
+          || $0.page.plainText.localizedStandardContains(string)
       }
       .prefix(30)
-      .map(EnchiridionTaskEntity.init(page:))
+      .map { EnchiridionTaskEntity(page: $0.page, vault: $0.vault) }
   }
 
   func suggestedEntities() async throws -> [EnchiridionTaskEntity] {
-    let repository = try intentRepository()
-    let pages = try await repository.tasks(in: .active)
-    return TaskQuery.items(from: pages, selection: .smart(.today))
-      .map(\.page)
+    let contexts = try VaultRepositoryContext.openAll()
+    let items = try await contexts.asyncFlatMap { context in
+      let pages = try await context.repository.tasks(in: .active)
+      return TaskQuery.items(from: pages, selection: .smart(.today)).map {
+        IntentTaskPage(vault: context.vault, page: $0.page)
+      }
+    }
+    return items
       .prefix(20)
-      .map(EnchiridionTaskEntity.init(page:))
+      .map { EnchiridionTaskEntity(page: $0.page, vault: $0.vault) }
   }
 
   func allEntities() async throws -> [EnchiridionTaskEntity] {
-    let repository = try intentRepository()
-    return try await repository.tasks(in: .active)
-      .map(EnchiridionTaskEntity.init(page:))
+    try await intentTaskPages(in: .active)
+      .map { EnchiridionTaskEntity(page: $0.page, vault: $0.vault) }
   }
 }
 
@@ -94,50 +100,56 @@ struct ClosedEnchiridionTaskEntity: AppEntity {
   @Property(title: "Status")
   var status: String
 
+  @Property(title: "Vault")
+  var vaultName: String
+
   var displayRepresentation: DisplayRepresentation {
-    DisplayRepresentation(title: "\(title)", subtitle: "\(status)")
+    DisplayRepresentation(title: "\(title)", subtitle: "\(status) · \(vaultName)")
   }
 
-  init(page: PageSnapshot) {
-    id = page.id.rawValue
+  init(page: PageSnapshot, vault: VaultDescriptor) {
+    id = VaultScopedNodeID(vaultID: vault.id, nodeID: page.id).id
     title = page.displayTitle
     status = page.taskData?.state == .completed ? "Completed" : "Canceled"
+    vaultName = vault.name
   }
 }
 
 struct ClosedEnchiridionTaskEntityQuery: EntityStringQuery, EnumerableEntityQuery {
   func entities(for identifiers: [String]) async throws -> [ClosedEnchiridionTaskEntity] {
-    let repository = try intentRepository()
-    let pagesByID = Dictionary(
-      uniqueKeysWithValues: try await repository.tasks(in: .closed).map { ($0.id.rawValue, $0) }
-    )
-    return identifiers.compactMap { pagesByID[$0].map(ClosedEnchiridionTaskEntity.init(page:)) }
+    let requested = Set(identifiers)
+    return try await intentTaskPages(in: .closed).compactMap { item in
+      let entity = ClosedEnchiridionTaskEntity(page: item.page, vault: item.vault)
+      return requested.contains(entity.id) ? entity : nil
+    }
   }
 
   func entities(matching string: String) async throws -> [ClosedEnchiridionTaskEntity] {
-    let repository = try intentRepository()
-    return try await repository.tasks(in: .closed)
+    return try await intentTaskPages(in: .closed)
       .filter {
-        $0.displayTitle.localizedStandardContains(string)
-          || $0.plainText.localizedStandardContains(string)
+        $0.page.displayTitle.localizedStandardContains(string)
+          || $0.page.plainText.localizedStandardContains(string)
       }
       .prefix(30)
-      .map(ClosedEnchiridionTaskEntity.init(page:))
+      .map { ClosedEnchiridionTaskEntity(page: $0.page, vault: $0.vault) }
   }
 
   func suggestedEntities() async throws -> [ClosedEnchiridionTaskEntity] {
-    let repository = try intentRepository()
-    let pages = try await repository.tasks(in: .closed)
-    return TaskQuery.items(from: pages, selection: .smart(.logbook))
-      .map(\.page)
+    let contexts = try VaultRepositoryContext.openAll()
+    let items = try await contexts.asyncFlatMap { context in
+      let pages = try await context.repository.tasks(in: .closed)
+      return TaskQuery.items(from: pages, selection: .smart(.logbook)).map {
+        IntentTaskPage(vault: context.vault, page: $0.page)
+      }
+    }
+    return items
       .prefix(20)
-      .map(ClosedEnchiridionTaskEntity.init(page:))
+      .map { ClosedEnchiridionTaskEntity(page: $0.page, vault: $0.vault) }
   }
 
   func allEntities() async throws -> [ClosedEnchiridionTaskEntity] {
-    let repository = try intentRepository()
-    return try await repository.tasks(in: .closed)
-      .map(ClosedEnchiridionTaskEntity.init(page:))
+    try await intentTaskPages(in: .closed)
+      .map { ClosedEnchiridionTaskEntity(page: $0.page, vault: $0.vault) }
   }
 }
 
@@ -226,9 +238,9 @@ struct AddEnchiridionTaskIntent: AppIntent {
     guard !normalizedTitle.isEmpty else {
       throw EnchiridionTaskIntentError.invalidTitle
     }
-    let mutations = try intentTaskMutations()
+    let context = try intentCreationContext(.defaultCapture)
     let page = try intentMutationValue(
-      await mutations.create(
+      await context.mutations.create(
         TaskDraft(
           title: normalizedTitle,
           notes: notes ?? "",
@@ -244,7 +256,7 @@ struct AddEnchiridionTaskIntent: AppIntent {
       )
     )
     return .result(
-      value: EnchiridionTaskEntity(page: page),
+      value: EnchiridionTaskEntity(page: page, vault: context.vault),
       dialog: "Added \(page.displayTitle) to Enchiridion."
     )
   }
@@ -272,11 +284,11 @@ struct QuickAddEnchiridionTaskIntent: AppIntent {
   {
     let normalizedCapture = capture.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !normalizedCapture.isEmpty else { throw EnchiridionTaskIntentError.invalidTitle }
-    let mutations = try intentTaskMutations()
+    let context = try intentCreationContext(.defaultCapture)
     let parsed = QuickTaskParser.parse(normalizedCapture)
-    let page = try intentMutationValue(await mutations.create(parsed.draft))
+    let page = try intentMutationValue(await context.mutations.create(parsed.draft))
     return .result(
-      value: EnchiridionTaskEntity(page: page),
+      value: EnchiridionTaskEntity(page: page, vault: context.vault),
       dialog: "Captured \(page.displayTitle)."
     )
   }
@@ -297,12 +309,12 @@ struct CompleteEnchiridionTaskIntent: AppIntent {
   func perform() async throws -> some IntentResult & ReturnsValue<EnchiridionTaskEntity>
     & ProvidesDialog
   {
-    let mutations = try intentTaskMutations()
+    let context = try intentMutationContext(for: task.id)
     let result = try intentMutationValue(
-      await mutations.complete(PageID(rawValue: task.id))
+      await context.mutations.complete(context.identity.nodeID)
     )
     return .result(
-      value: EnchiridionTaskEntity(page: result.completed),
+      value: EnchiridionTaskEntity(page: result.completed, vault: context.vault),
       dialog: "Completed \(result.completed.displayTitle)."
     )
   }
@@ -323,12 +335,12 @@ struct ReopenEnchiridionTaskIntent: AppIntent {
   func perform() async throws -> some IntentResult & ReturnsValue<EnchiridionTaskEntity>
     & ProvidesDialog
   {
-    let mutations = try intentTaskMutations()
+    let context = try intentMutationContext(for: task.id)
     let page = try intentMutationValue(
-      await mutations.reopen(PageID(rawValue: task.id))
+      await context.mutations.reopen(context.identity.nodeID)
     )
     return .result(
-      value: EnchiridionTaskEntity(page: page),
+      value: EnchiridionTaskEntity(page: page, vault: context.vault),
       dialog: "Reopened \(page.displayTitle)."
     )
   }
@@ -361,10 +373,10 @@ struct ScheduleEnchiridionTaskIntent: AppIntent {
     let schedule: TaskSchedulePatch =
       includesTime
       ? .dateTime(scheduledAt) : .dateOnly(Calendar.current.startOfDay(for: scheduledAt))
-    let mutations = try intentTaskMutations()
+    let context = try intentMutationContext(for: task.id)
     let result = try intentMutationValue(
-      await mutations.patchTasks(
-        [PageID(rawValue: task.id)],
+      await context.mutations.patchTasks(
+        [context.identity.nodeID],
         patch: TaskMetadataPatch(schedule: schedule, placement: .anytime)
       )
     )
@@ -374,7 +386,7 @@ struct ScheduleEnchiridionTaskIntent: AppIntent {
       time: includesTime ? .shortened : .omitted
     )
     return .result(
-      value: EnchiridionTaskEntity(page: page),
+      value: EnchiridionTaskEntity(page: page, vault: context.vault),
       dialog: "Scheduled \(page.displayTitle) for \(spokenDate)."
     )
   }
@@ -399,16 +411,16 @@ struct SetEnchiridionTaskDeadlineIntent: AppIntent {
     & ProvidesDialog
   {
     let normalizedDeadline = Calendar.current.startOfDay(for: deadline)
-    let mutations = try intentTaskMutations()
+    let context = try intentMutationContext(for: task.id)
     let result = try intentMutationValue(
-      await mutations.patchTasks(
-        [PageID(rawValue: task.id)],
+      await context.mutations.patchTasks(
+        [context.identity.nodeID],
         patch: TaskMetadataPatch(deadline: .set(normalizedDeadline))
       )
     )
     guard let page = result.tasks.first else { throw EnchiridionTaskIntentError.taskNotActive }
     return .result(
-      value: EnchiridionTaskEntity(page: page),
+      value: EnchiridionTaskEntity(page: page, vault: context.vault),
       dialog:
         "Set the deadline for \(page.displayTitle) to \(deadline.formatted(date: .abbreviated, time: .omitted))."
     )
@@ -431,12 +443,12 @@ struct CancelEnchiridionTaskIntent: AppIntent {
   func perform() async throws -> some IntentResult & ReturnsValue<ClosedEnchiridionTaskEntity>
     & ProvidesDialog
   {
-    let mutations = try intentTaskMutations()
+    let context = try intentMutationContext(for: task.id)
     let page = try intentMutationValue(
-      await mutations.cancel(PageID(rawValue: task.id))
+      await context.mutations.cancel(context.identity.nodeID)
     )
     return .result(
-      value: ClosedEnchiridionTaskEntity(page: page),
+      value: ClosedEnchiridionTaskEntity(page: page, vault: context.vault),
       dialog: "Canceled \(page.displayTitle)."
     )
   }
@@ -456,10 +468,12 @@ struct FindEnchiridionTasksIntent: AppIntent {
   func perform() async throws -> some IntentResult & ReturnsValue<[EnchiridionTaskEntity]>
     & ProvidesDialog
   {
-    let repository = try intentRepository()
-    let pages = try await repository.pages(with: BuiltInSupertags.task)
-    let tasks = TaskQuery.items(from: pages, selection: .smart(list.smartList))
-      .map { EnchiridionTaskEntity(page: $0.page) }
+    let contexts = try VaultRepositoryContext.openAll()
+    let tasks = try await contexts.asyncFlatMap { context in
+      let pages = try await context.repository.pages(with: BuiltInSupertags.task)
+      return TaskQuery.items(from: pages, selection: .smart(list.smartList))
+        .map { EnchiridionTaskEntity(page: $0.page, vault: context.vault) }
+    }
     await TaskSpotlightIndex.index(tasks)
     return .result(
       value: tasks,
@@ -481,7 +495,8 @@ struct OpenEnchiridionTaskListIntent: AppIntent {
   }
 
   func perform() async throws -> some IntentResult & OpensIntent {
-    let url = URL(string: "enchiridion://tasks/\(list.rawValue)")!
+    let context = try VaultRepositoryContext.open(.selected)
+    let url = TaskDeepLinkRoute.url(vaultID: context.vault.id, list: list.smartList)!
     return .result(opensIntent: OpenURLIntent(url))
   }
 }
@@ -584,14 +599,53 @@ private enum EnchiridionTaskIntentError: Error, CustomLocalizedStringResourceCon
   }
 }
 
-private func intentRepository() throws -> LibraryRepository {
-  try LibraryRepository(path: LibraryRepository.defaultLocalPath())
+private struct IntentTaskPage: Sendable {
+  let vault: VaultDescriptor
+  let page: PageSnapshot
 }
 
-private func intentTaskMutations() throws -> TaskMutationCoordinator {
-  TaskMutationCoordinator(
-    repository: try intentRepository(),
-    effects: .live(surface: .appIntent)
+private struct IntentMutationContext {
+  let vault: VaultDescriptor
+  let identity: VaultScopedNodeID
+  let mutations: TaskMutationCoordinator
+}
+
+private struct IntentCreationContext {
+  let vault: VaultDescriptor
+  let mutations: TaskMutationCoordinator
+}
+
+private func intentTaskPages(in lifecycle: TaskLifecycleScope) async throws -> [IntentTaskPage] {
+  try await VaultRepositoryContext.openAll().asyncFlatMap { context in
+    try await context.repository.tasks(in: lifecycle).map {
+      IntentTaskPage(vault: context.vault, page: $0)
+    }
+  }
+}
+
+private func intentCreationContext(_ selection: VaultSelection) throws -> IntentCreationContext {
+  let context = try VaultRepositoryContext.open(selection)
+  return .init(
+    vault: context.vault,
+    mutations: TaskMutationCoordinator(
+      repository: context.repository,
+      effects: .live(surface: .appIntent, vaultID: context.vault.id)
+    )
+  )
+}
+
+private func intentMutationContext(for serializedIdentity: String) throws -> IntentMutationContext {
+  guard let identity = VaultScopedNodeID(serialized: serializedIdentity) else {
+    throw EnchiridionTaskIntentError.taskNotActive
+  }
+  let context = try VaultRepositoryContext.open(.vault(identity.vaultID))
+  return .init(
+    vault: context.vault,
+    identity: identity,
+    mutations: TaskMutationCoordinator(
+      repository: context.repository,
+      effects: .live(surface: .appIntent, vaultID: identity.vaultID)
+    )
   )
 }
 
@@ -611,12 +665,22 @@ private func intentMutationValue<Value: Sendable>(
 
 private enum TaskSpotlightIndex {
   static func index(_ entities: [EnchiridionTaskEntity]) async {
-    guard !entities.isEmpty else { return }
-    let repository = try? intentRepository()
-    guard let repository else { return }
     for entity in entities {
-      guard let page = try? await repository.page(id: PageID(rawValue: entity.id)) else { continue }
-      await TaskSystemSpotlight.index(page)
+      guard let identity = VaultScopedNodeID(serialized: entity.id),
+        let context = try? VaultRepositoryContext.open(.vault(identity.vaultID)),
+        let page = try? await context.repository.page(id: identity.nodeID)
+      else { continue }
+      await TaskSystemSpotlight.index(page, vaultID: identity.vaultID)
     }
+  }
+}
+
+private extension Sequence {
+  func asyncFlatMap<Result>(
+    _ transform: (Element) async throws -> [Result]
+  ) async rethrows -> [Result] {
+    var result: [Result] = []
+    for element in self { result += try await transform(element) }
+    return result
   }
 }

--- a/apps/enchiridion/Sources/SharedUI/TaskMutationWarningModifier.swift
+++ b/apps/enchiridion/Sources/SharedUI/TaskMutationWarningModifier.swift
@@ -24,21 +24,27 @@ private struct TaskMutationWarningModifier: ViewModifier {
         guard next != presentedWarning else { return }
         presentedWarning = next
       }
-      .alert(
-        presentedWarning?.title ?? "Task Change Saved with Warnings",
-        item: warningBinding
-      ) { warning in
+      .alert(item: warningBinding) { warning in
         if let recovery = warning.recovery {
-          Button(recovery.title) {
+          return Alert(
+            title: Text(warning.title),
+            message: Text(warning.message),
+            primaryButton: .default(Text(recovery.title)) {
+              store.acknowledgeTaskMutationWarnings()
+              perform(recovery)
+            },
+            secondaryButton: .cancel(Text("OK")) {
+              store.acknowledgeTaskMutationWarnings()
+            }
+          )
+        }
+        return Alert(
+          title: Text(warning.title),
+          message: Text(warning.message),
+          dismissButton: .cancel(Text("OK")) {
             store.acknowledgeTaskMutationWarnings()
-            perform(recovery)
           }
-        }
-        Button("OK", role: .cancel) {
-          store.acknowledgeTaskMutationWarnings()
-        }
-      } message: { warning in
-        Text(warning.message)
+        )
       }
   }
 

--- a/apps/enchiridion/Sources/SharedUI/TaskReminderNotificationCoordinator.swift
+++ b/apps/enchiridion/Sources/SharedUI/TaskReminderNotificationCoordinator.swift
@@ -6,14 +6,17 @@ import Foundation
 final class TaskReminderNotificationCoordinator: NSObject, UNUserNotificationCenterDelegate {
   static let shared = TaskReminderNotificationCoordinator()
 
-  private var store: LibraryStore?
+  private var resolveStore: (@MainActor @Sendable (VaultID) throws -> LibraryStore?)?
   private var openURL: (@MainActor @Sendable (URL) -> Void)?
 
   func configure(
     store: LibraryStore,
+    resolveStore: (@MainActor @Sendable (VaultID) throws -> LibraryStore?)? = nil,
     openURL: @escaping @MainActor @Sendable (URL) -> Void
   ) {
-    self.store = store
+    self.resolveStore = resolveStore ?? { vaultID in
+      vaultID == store.vaultID ? store : nil
+    }
     self.openURL = openURL
     UNUserNotificationCenter.current().delegate = self
     Task { await TaskReminderScheduler.shared.registerNotificationCategory() }
@@ -40,22 +43,24 @@ final class TaskReminderNotificationCoordinator: NSObject, UNUserNotificationCen
   }
 
   private func handle(route: TaskReminderNotificationRoute) async {
-    guard let store, let task = await task(for: route.pageID, in: store),
+    guard let resolveStore,
+      let store = try? resolveStore(route.identity.vaultID),
+      let task = await task(for: route.identity.nodeID, in: store),
       let data = task.taskData
     else { return }
 
     let plan = TaskReminderActionPlan.make(route: route, now: Date())
     switch plan {
-    case .complete(let pageID):
+    case .complete(let identity):
       guard data.state == .active else { return }
-      await store.completeTask(pageID)
-    case .snooze(let pageID, let until):
+      await store.completeTask(identity.nodeID)
+    case .snooze(let identity, let until):
       guard data.state == .active else { return }
       var updatedData = data
       updatedData.reminder = until
-      await store.updateTask(pageID: pageID, data: updatedData)
-    case .open(let pageID):
-      openTask(pageID)
+      await store.updateTask(pageID: identity.nodeID, data: updatedData)
+    case .open(let identity):
+      openTask(identity)
     }
   }
 
@@ -65,8 +70,8 @@ final class TaskReminderNotificationCoordinator: NSObject, UNUserNotificationCen
     return store.page(id: pageID)
   }
 
-  private func openTask(_ pageID: PageID) {
-    guard let url = TaskReminderScheduler.taskURL(for: pageID) else { return }
+  private func openTask(_ identity: VaultScopedNodeID) {
+    guard let url = TaskReminderScheduler.taskURL(for: identity) else { return }
     openURL?(url)
   }
 }

--- a/apps/enchiridion/Sources/SharedUI/TaskReminderNotificationCoordinator.swift
+++ b/apps/enchiridion/Sources/SharedUI/TaskReminderNotificationCoordinator.swift
@@ -1,17 +1,22 @@
 import EnchiridionCore
 import Foundation
+import OSLog
 @preconcurrency import UserNotifications
 
 @MainActor
 final class TaskReminderNotificationCoordinator: NSObject, UNUserNotificationCenterDelegate {
   static let shared = TaskReminderNotificationCoordinator()
 
-  private var resolveStore: (@MainActor @Sendable (VaultID) throws -> LibraryStore?)?
+  private let logger = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "dev.rawkode.enchiridion",
+    category: "TaskReminders"
+  )
+  private var resolveStore: (@MainActor @Sendable (VaultID) async throws -> LibraryStore?)?
   private var openURL: (@MainActor @Sendable (URL) -> Void)?
 
   func configure(
     store: LibraryStore,
-    resolveStore: (@MainActor @Sendable (VaultID) throws -> LibraryStore?)? = nil,
+    resolveStore: (@MainActor @Sendable (VaultID) async throws -> LibraryStore?)? = nil,
     openURL: @escaping @MainActor @Sendable (URL) -> Void
   ) {
     self.resolveStore = resolveStore ?? { vaultID in
@@ -43,24 +48,37 @@ final class TaskReminderNotificationCoordinator: NSObject, UNUserNotificationCen
   }
 
   private func handle(route: TaskReminderNotificationRoute) async {
-    guard let resolveStore,
-      let store = try? resolveStore(route.identity.vaultID),
-      let task = await task(for: route.identity.nodeID, in: store),
-      let data = task.taskData
-    else { return }
-
     let plan = TaskReminderActionPlan.make(route: route, now: Date())
-    switch plan {
-    case .complete(let identity):
-      guard data.state == .active else { return }
-      await store.completeTask(identity.nodeID)
-    case .snooze(let identity, let until):
-      guard data.state == .active else { return }
-      var updatedData = data
-      updatedData.reminder = until
-      await store.updateTask(pageID: identity.nodeID, data: updatedData)
-    case .open(let identity):
+    if case .open(let identity) = plan {
       openTask(identity)
+      return
+    }
+
+    guard let resolveStore else { return }
+    do {
+      guard let store = try await resolveStore(route.identity.vaultID),
+        let task = await task(for: route.identity.nodeID, in: store),
+        let data = task.taskData
+      else {
+        logger.error("reminder_action_unavailable")
+        return
+      }
+
+      guard data.state == .active else { return }
+      let applied: Bool
+      switch plan {
+      case .complete(let identity):
+        applied = await store.completeTask(identity.nodeID) != nil
+      case .snooze(let identity, let until):
+        var updatedData = data
+        updatedData.reminder = until
+        applied = await store.updateTask(pageID: identity.nodeID, data: updatedData) != nil
+      case .open:
+        return
+      }
+      if !applied { logger.error("reminder_action_failed") }
+    } catch {
+      logger.error("reminder_store_resolution_failed: \(error.localizedDescription, privacy: .public)")
     }
   }
 

--- a/apps/enchiridion/Sources/SharedUI/TaskWorkbench.swift
+++ b/apps/enchiridion/Sources/SharedUI/TaskWorkbench.swift
@@ -198,7 +198,7 @@ struct TaskWorkbenchChrome: ViewModifier {
           }
         )
       ) {
-        Button("OK") { selection.errorMessage = nil }
+        Button("Dismiss Error") { selection.errorMessage = nil }
       } message: {
         Text(selection.errorMessage ?? "The selected tasks were not changed.")
       }

--- a/apps/enchiridion/Sources/SharedUI/VaultManagementView.swift
+++ b/apps/enchiridion/Sources/SharedUI/VaultManagementView.swift
@@ -73,6 +73,9 @@ struct VaultManagementView: View {
       }
       .navigationTitle("Vaults")
       .toolbar {
+        #if os(iOS)
+          ToolbarItem(placement: .topBarTrailing) { EditButton() }
+        #endif
         ToolbarItem(placement: .cancellationAction) {
           Button("Done") { dismiss() }
         }
@@ -110,7 +113,7 @@ struct VaultManagementView: View {
         Text("This permanently removes this vault's local graph. Other vaults are not affected.")
       }
       .alert("Vault Error", isPresented: errorBinding) {
-        Button("OK", role: .cancel) {}
+        Button("Dismiss Error", role: .cancel) {}
       } message: {
         Text(errorMessage ?? "The vault operation could not be completed.")
       }
@@ -181,9 +184,14 @@ struct VaultManagementView: View {
   private func deleteVault() {
     guard let vault = vaultToDelete else { return }
     let changedWorkspace = vault.id == session.selectedVault.id
-    perform {
-      try session.deleteVault(vault.id)
-      if changedWorkspace { workspaceDidChange() }
+    Task {
+      do {
+        try await session.deleteVault(vault.id)
+        if changedWorkspace { workspaceDidChange() }
+        errorMessage = nil
+      } catch {
+        errorMessage = error.localizedDescription
+      }
     }
     vaultToDelete = nil
   }

--- a/apps/enchiridion/Sources/SharedUI/VaultManagementView.swift
+++ b/apps/enchiridion/Sources/SharedUI/VaultManagementView.swift
@@ -1,0 +1,226 @@
+import EnchiridionCore
+import SwiftUI
+
+struct VaultSwitcherMenu: View {
+  let session: VaultSession
+  let selectVault: @MainActor (VaultID) throws -> Void
+  @State private var errorMessage: String?
+
+  var body: some View {
+    Menu {
+      ForEach(session.snapshot.vaults) { vault in
+        Button {
+          do {
+            try selectVault(vault.id)
+            errorMessage = nil
+          } catch {
+            errorMessage = error.localizedDescription
+          }
+        } label: {
+          if vault.id == session.selectedVault.id {
+            Label(vault.name, systemImage: "checkmark")
+          } else {
+            Text(vault.name)
+          }
+        }
+      }
+    } label: {
+      Label(session.selectedVault.name, systemImage: "archivebox")
+    }
+    .help("Switch vault")
+    .accessibilityHint("Chooses which independent knowledge graph is open.")
+    .alert("Vault Unavailable", isPresented: errorBinding) {
+      Button("OK", role: .cancel) {}
+    } message: {
+      Text(errorMessage ?? "The vault could not be opened.")
+    }
+  }
+
+  private var errorBinding: Binding<Bool> {
+    Binding(
+      get: { errorMessage != nil },
+      set: { if !$0 { errorMessage = nil } }
+    )
+  }
+}
+
+struct VaultManagementView: View {
+  let session: VaultSession
+  let selectVault: @MainActor (VaultID) throws -> Void
+  let workspaceDidChange: @MainActor () -> Void
+
+  @Environment(\.dismiss) private var dismiss
+  @State private var showsNewVaultPrompt = false
+  @State private var newVaultName = ""
+  @State private var vaultToRename: VaultDescriptor?
+  @State private var renamedVaultName = ""
+  @State private var vaultToDelete: VaultDescriptor?
+  @State private var errorMessage: String?
+
+  var body: some View {
+    NavigationStack {
+      List {
+        Section {
+          ForEach(session.snapshot.vaults) { vault in
+            vaultRow(vault)
+          }
+          .onMove(perform: moveVaults)
+        } header: {
+          Text("Vaults")
+        } footer: {
+          Text("Each vault is an independent knowledge graph. Links and assistant queries stay inside the open vault.")
+        }
+      }
+      .navigationTitle("Vaults")
+      .toolbar {
+        ToolbarItem(placement: .cancellationAction) {
+          Button("Done") { dismiss() }
+        }
+        ToolbarItem(placement: .primaryAction) {
+          Button {
+            newVaultName = ""
+            showsNewVaultPrompt = true
+          } label: {
+            Label("New Vault", systemImage: "plus")
+          }
+        }
+      }
+      .alert("New Vault", isPresented: $showsNewVaultPrompt) {
+        TextField("Name", text: $newVaultName)
+        Button("Cancel", role: .cancel) {}
+        Button("Create") { createVault() }
+          .disabled(newVaultName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+      } message: {
+        Text("A new local graph is created and opened immediately.")
+      }
+      .alert("Rename Vault", isPresented: renameBinding) {
+        TextField("Name", text: $renamedVaultName)
+        Button("Cancel", role: .cancel) { vaultToRename = nil }
+        Button("Rename") { renameVault() }
+          .disabled(renamedVaultName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+      }
+      .confirmationDialog(
+        "Delete \(vaultToDelete?.name ?? "Vault")?",
+        isPresented: deleteBinding,
+        titleVisibility: .visible
+      ) {
+        Button("Delete Vault and Local Data", role: .destructive) { deleteVault() }
+        Button("Cancel", role: .cancel) { vaultToDelete = nil }
+      } message: {
+        Text("This permanently removes this vault's local graph. Other vaults are not affected.")
+      }
+      .alert("Vault Error", isPresented: errorBinding) {
+        Button("OK", role: .cancel) {}
+      } message: {
+        Text(errorMessage ?? "The vault operation could not be completed.")
+      }
+    }
+  }
+
+  private func vaultRow(_ vault: VaultDescriptor) -> some View {
+    Button {
+      perform { try selectVault(vault.id) }
+    } label: {
+      HStack(spacing: 12) {
+        Image(systemName: vault.id == session.selectedVault.id ? "archivebox.fill" : "archivebox")
+          .foregroundStyle(vault.id == session.selectedVault.id ? Color.accentColor : .secondary)
+          .accessibilityHidden(true)
+        VStack(alignment: .leading, spacing: 2) {
+          Text(vault.name)
+            .foregroundStyle(.primary)
+          if vault.id == session.snapshot.defaultCaptureVaultID {
+            Text("Default capture")
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+        }
+        Spacer()
+        if vault.id == session.selectedVault.id {
+          Image(systemName: "checkmark")
+            .foregroundStyle(.tint)
+            .accessibilityLabel("Open vault")
+        }
+      }
+      .contentShape(.rect)
+    }
+    .buttonStyle(.plain)
+    .contextMenu {
+      Button("Open", systemImage: "arrow.right.circle") {
+        perform { try selectVault(vault.id) }
+      }
+      Button("Use for Capture", systemImage: "square.and.arrow.down") {
+        perform { try session.setDefaultCaptureVault(vault.id) }
+      }
+      Button("Rename", systemImage: "pencil") {
+        renamedVaultName = vault.name
+        vaultToRename = vault
+      }
+      Divider()
+      Button("Delete", systemImage: "trash", role: .destructive) {
+        vaultToDelete = vault
+      }
+      .disabled(session.snapshot.vaults.count == 1)
+    }
+    .accessibilityLabel(vault.name)
+    .accessibilityValue(vault.id == session.selectedVault.id ? "Open" : "")
+  }
+
+  private func createVault() {
+    perform {
+      _ = try session.createVault(name: newVaultName)
+      workspaceDidChange()
+    }
+  }
+
+  private func renameVault() {
+    guard let vault = vaultToRename else { return }
+    perform { try session.renameVault(vault.id, name: renamedVaultName) }
+    vaultToRename = nil
+  }
+
+  private func deleteVault() {
+    guard let vault = vaultToDelete else { return }
+    let changedWorkspace = vault.id == session.selectedVault.id
+    perform {
+      try session.deleteVault(vault.id)
+      if changedWorkspace { workspaceDidChange() }
+    }
+    vaultToDelete = nil
+  }
+
+  private func moveVaults(from offsets: IndexSet, to destination: Int) {
+    var vaults = session.snapshot.vaults
+    vaults.move(fromOffsets: offsets, toOffset: destination)
+    perform { try session.reorderVaults(vaults.map(\.id)) }
+  }
+
+  private func perform(_ operation: () throws -> Void) {
+    do {
+      try operation()
+      errorMessage = nil
+    } catch {
+      errorMessage = error.localizedDescription
+    }
+  }
+
+  private var renameBinding: Binding<Bool> {
+    Binding(
+      get: { vaultToRename != nil },
+      set: { if !$0 { vaultToRename = nil } }
+    )
+  }
+
+  private var deleteBinding: Binding<Bool> {
+    Binding(
+      get: { vaultToDelete != nil },
+      set: { if !$0 { vaultToDelete = nil } }
+    )
+  }
+
+  private var errorBinding: Binding<Bool> {
+    Binding(
+      get: { errorMessage != nil },
+      set: { if !$0 { errorMessage = nil } }
+    )
+  }
+}

--- a/apps/enchiridion/Sources/SharedUI/VaultManagementView.swift
+++ b/apps/enchiridion/Sources/SharedUI/VaultManagementView.swift
@@ -30,7 +30,7 @@ struct VaultSwitcherMenu: View {
     .help("Switch vault")
     .accessibilityHint("Chooses which independent knowledge graph is open.")
     .alert("Vault Unavailable", isPresented: errorBinding) {
-      Button("OK", role: .cancel) {}
+      Button("Dismiss Error", role: .cancel) {}
     } message: {
       Text(errorMessage ?? "The vault could not be opened.")
     }

--- a/apps/enchiridion/Sources/TaskShareExtension/ShareViewController.swift
+++ b/apps/enchiridion/Sources/TaskShareExtension/ShareViewController.swift
@@ -25,10 +25,10 @@ final class ShareViewController: SLComposeServiceViewController {
 
     Task { @MainActor in
       do {
-        let repository = try LibraryRepository(path: LibraryRepository.defaultLocalPath())
+        let context = try VaultRepositoryContext.open(.defaultCapture)
         let mutations = TaskMutationCoordinator(
-          repository: repository,
-          effects: .live(surface: .shareExtension)
+          repository: context.repository,
+          effects: .live(surface: .shareExtension, vaultID: context.vault.id)
         )
         switch await mutations.create(draft) {
         case .success:

--- a/apps/enchiridion/Sources/TodayTasksWidget/TodayTasksWidget.swift
+++ b/apps/enchiridion/Sources/TodayTasksWidget/TodayTasksWidget.swift
@@ -11,6 +11,7 @@ private struct TodayTaskSummary: Identifiable, Sendable {
 
 private struct TodayTasksEntry: TimelineEntry {
   var date: Date
+  var vaultID: VaultID?
   var tasks: [TodayTaskSummary]
   var errorMessage: String?
 }
@@ -19,6 +20,7 @@ private struct TodayTasksProvider: TimelineProvider {
   func placeholder(in context: Context) -> TodayTasksEntry {
     TodayTasksEntry(
       date: Date(),
+      vaultID: nil,
       tasks: [
         TodayTaskSummary(id: "one", title: "Review today", deadline: nil),
         TodayTaskSummary(id: "two", title: "Plan tomorrow", deadline: nil),
@@ -49,8 +51,8 @@ private struct TodayTasksProvider: TimelineProvider {
   private func loadEntry() async -> TodayTasksEntry {
     let actionFeedback = TaskWidgetActionFeedbackStore().current()?.message
     do {
-      let repository = try LibraryRepository(path: LibraryRepository.defaultLocalPath())
-      let pages = try await repository.pages(with: BuiltInSupertags.task)
+      let context = try VaultRepositoryContext.open(.defaultCapture)
+      let pages = try await context.repository.pages(with: BuiltInSupertags.task)
       let tasks = TaskQuery.items(from: pages, selection: .smart(.today))
         .prefix(8)
         .map {
@@ -62,12 +64,14 @@ private struct TodayTasksProvider: TimelineProvider {
         }
       return TodayTasksEntry(
         date: Date(),
+        vaultID: context.vault.id,
         tasks: tasks,
         errorMessage: actionFeedback
       )
     } catch {
       return TodayTasksEntry(
         date: Date(),
+        vaultID: nil,
         tasks: [],
         errorMessage: "Open Enchiridion to finish setup."
       )
@@ -83,17 +87,21 @@ struct CompleteTodayTaskWidgetIntent: AppIntent {
   @Parameter(title: "Task ID")
   var taskID: String
 
+  @Parameter(title: "Vault ID")
+  var vaultID: String
+
   init() {}
 
-  init(taskID: String) {
+  init(taskID: String, vaultID: VaultID) {
     self.taskID = taskID
+    self.vaultID = vaultID.rawValue
   }
 
   func perform() async throws -> some IntentResult {
-    let repository = try LibraryRepository(path: LibraryRepository.defaultLocalPath())
+    let context = try VaultRepositoryContext.open(.vault(.init(rawValue: vaultID)))
     let mutations = TaskMutationCoordinator(
-      repository: repository,
-      effects: .live(surface: .widgetExtension)
+      repository: context.repository,
+      effects: .live(surface: .widgetExtension, vaultID: context.vault.id)
     )
     switch await mutations.complete(PageID(rawValue: taskID)) {
     case .success:
@@ -124,11 +132,19 @@ private struct TodayTasksWidgetView: View {
         Label("Today", systemImage: "sun.max.fill")
           .font(.headline)
         Spacer()
-        Link(destination: URL(string: "enchiridion://tasks/inbox?quickAdd=1")!) {
-          Image(systemName: "plus.circle.fill")
-            .font(.title3)
+        if let vaultID = entry.vaultID,
+          let destination = TaskDeepLinkRoute.url(
+            vaultID: vaultID,
+            list: .inbox,
+            quickAdd: true
+          )
+        {
+          Link(destination: destination) {
+            Image(systemName: "plus.circle.fill")
+              .font(.title3)
+          }
+          .accessibilityLabel("Quick add task")
         }
-        .accessibilityLabel("Quick add task")
       }
 
       if let errorMessage = entry.errorMessage {
@@ -141,9 +157,9 @@ private struct TodayTasksWidgetView: View {
           .font(.caption)
           .foregroundStyle(.secondary)
         Spacer(minLength: 0)
-      } else {
+      } else if let vaultID = entry.vaultID {
         ForEach(visibleTasks) { task in
-          Button(intent: CompleteTodayTaskWidgetIntent(taskID: task.id)) {
+          Button(intent: CompleteTodayTaskWidgetIntent(taskID: task.id, vaultID: vaultID)) {
             HStack(spacing: 7) {
               Image(systemName: "circle")
                 .foregroundStyle(.secondary)
@@ -163,10 +179,16 @@ private struct TodayTasksWidgetView: View {
           .accessibilityLabel("Complete \(task.title)")
         }
         Spacer(minLength: 0)
+      } else {
+        ForEach(visibleTasks) { task in
+          Label(task.title, systemImage: "circle")
+            .lineLimit(1)
+        }
+        Spacer(minLength: 0)
       }
     }
     .containerBackground(.fill.tertiary, for: .widget)
-    .widgetURL(URL(string: "enchiridion://tasks/today"))
+    .widgetURL(entry.vaultID.flatMap { TaskDeepLinkRoute.url(vaultID: $0, list: .today) })
   }
 }
 

--- a/apps/enchiridion/Sources/iOS/CarPlayScene.swift
+++ b/apps/enchiridion/Sources/iOS/CarPlayScene.swift
@@ -8,6 +8,9 @@ final class EnchiridionAppDelegate: NSObject, UIApplicationDelegate {
   ) -> Bool {
     TaskReminderNotificationCoordinator.shared.configure(
       store: EnchiridionAppRuntime.shared.store,
+      resolveStore: { vaultID in
+        try EnchiridionAppRuntime.shared.store(for: vaultID)
+      },
       openURL: { url in
         UIApplication.shared.open(url)
       }

--- a/apps/enchiridion/Sources/iOS/CarPlayScene.swift
+++ b/apps/enchiridion/Sources/iOS/CarPlayScene.swift
@@ -9,7 +9,7 @@ final class EnchiridionAppDelegate: NSObject, UIApplicationDelegate {
     TaskReminderNotificationCoordinator.shared.configure(
       store: EnchiridionAppRuntime.shared.store,
       resolveStore: { vaultID in
-        try EnchiridionAppRuntime.shared.store(for: vaultID)
+        try await EnchiridionAppRuntime.shared.vaultSession?.backgroundStore(forVault: vaultID)
       },
       openURL: { url in
         UIApplication.shared.open(url)

--- a/apps/enchiridion/Sources/iOS/CarPlayVoiceCoordinator.swift
+++ b/apps/enchiridion/Sources/iOS/CarPlayVoiceCoordinator.swift
@@ -39,8 +39,8 @@ final class CarPlayVoiceCoordinator: NSObject {
     case setup
   }
 
-  private let session: AssistantConversationSession?
-  private let unavailableReason: @MainActor () -> String?
+  private var session: AssistantConversationSession?
+  private var unavailableReason: @MainActor () -> String?
   private let audioSession = AVAudioSession.sharedInstance()
   private let safetyObservers = CarPlayNotificationObserverBag()
   private let logger = Logger(
@@ -66,6 +66,19 @@ final class CarPlayVoiceCoordinator: NSObject {
     self.unavailableReason = unavailableReason
     super.init()
     observeSafetyEvents()
+  }
+
+  func update(
+    session: AssistantConversationSession?,
+    unavailableReason: @escaping @MainActor () -> String?
+  ) {
+    let connectedController = interfaceController
+    disconnect()
+    self.session = session
+    self.unavailableReason = unavailableReason
+    if let connectedController {
+      connect(to: connectedController)
+    }
   }
 
   func connect(to interfaceController: CPInterfaceController) {

--- a/apps/enchiridion/Sources/iOS/EnchiridioniOSApp.swift
+++ b/apps/enchiridion/Sources/iOS/EnchiridioniOSApp.swift
@@ -1,68 +1,99 @@
 import EnchiridionCore
+import Observation
 import SwiftUI
 import UIKit
 
 @main
 struct EnchiridioniOSApp: App {
   @UIApplicationDelegateAdaptor(EnchiridionAppDelegate.self) private var appDelegate
+  @State private var runtime = EnchiridionAppRuntime.shared
 
   var body: some Scene {
     WindowGroup {
       MobileRootView(
-        store: EnchiridionAppRuntime.shared.store,
-        contactsResolver: EnchiridionAppRuntime.shared.contactsResolver,
-        assistantSession: EnchiridionAppRuntime.shared.assistantSession,
-        assistantUnavailableReason: EnchiridionAppRuntime.shared.assistantUnavailableReason
+        store: runtime.store,
+        contactsResolver: runtime.contactsResolver,
+        vaultSession: runtime.vaultSession,
+        selectVault: runtime.selectVault,
+        workspaceDidChange: runtime.workspaceDidChange,
+        assistantSession: runtime.assistantSession,
+        assistantUnavailableReason: runtime.assistantUnavailableReason
       )
       .managesDeviceContacts(
-        store: EnchiridionAppRuntime.shared.store,
-        resolver: EnchiridionAppRuntime.shared.contactsResolver
+        store: runtime.store,
+        resolver: runtime.contactsResolver
       )
     }
   }
 }
 
 @MainActor
+@Observable
 final class EnchiridionAppRuntime {
   static let shared = EnchiridionAppRuntime()
 
-  let repository: LibraryRepository?
-  let store: LibraryStore
-  let assistant: FoundationModelAssistant?
-  lazy var carPlayAssistant = repository.map { FoundationModelAssistant(repository: $0) }
-  lazy var assistantSession = makeAssistantConversationSession(assistant: assistant)
-  lazy var carPlayAssistantSession = makeAssistantConversationSession(
-    assistant: carPlayAssistant,
-    surface: .carPlay
-  )
+  let vaultSession: VaultSession?
+  let contactsResolver = DeviceContactsResolver()
+  private let fallbackStore: LibraryStore
+  private(set) var assistant: FoundationModelAssistant?
+  private(set) var carPlayAssistant: FoundationModelAssistant?
+  private(set) var assistantSession: AssistantConversationSession?
+  private(set) var carPlayAssistantSession: AssistantConversationSession?
+  private(set) var carPlayVoice: CarPlayVoiceCoordinator!
+  private(set) var repositoryError: String?
+
+  var repository: LibraryRepository? { vaultSession?.repository }
+  var store: LibraryStore { vaultSession?.store ?? fallbackStore }
   var assistantUnavailableReason: String? {
     assistantUnavailabilityMessage(assistant: assistant, repositoryError: repositoryError)
   }
-  let repositoryError: String?
-  let contactsResolver = DeviceContactsResolver()
-  lazy var carPlayVoice = CarPlayVoiceCoordinator(
-    session: carPlayAssistantSession,
-    unavailableReason: { [weak self] in
-      guard let self else { return "Your local library is unavailable." }
-      return assistantUnavailabilityMessage(
-        assistant: self.carPlayAssistant,
-        repositoryError: self.repositoryError
-      )
-    }
-  )
 
   private init() {
     do {
-      let repository = try LibraryRepository(path: LibraryRepository.defaultLocalPath())
-      self.repository = repository
-      store = LibraryStore(repository: repository, contactResolver: contactsResolver)
-      assistant = FoundationModelAssistant(repository: repository)
-      repositoryError = nil
+      let session = try VaultSession(contactResolver: contactsResolver)
+      vaultSession = session
+      fallbackStore = session.store
     } catch {
-      repository = nil
-      store = LibraryStore(contactResolver: contactsResolver)
-      assistant = nil
+      vaultSession = nil
+      fallbackStore = LibraryStore(contactResolver: contactsResolver)
       repositoryError = error.localizedDescription
     }
+    rebuildWorkspaceDependents()
+  }
+
+  func selectVault(_ id: VaultID) throws {
+    guard let vaultSession else { throw VaultRegistryError.vaultNotFound }
+    try vaultSession.selectVault(id)
+    workspaceDidChange()
+  }
+
+  func workspaceDidChange() {
+    repositoryError = nil
+    rebuildWorkspaceDependents()
+    TaskReminderNotificationCoordinator.shared.configure(
+      store: store,
+      openURL: { url in UIApplication.shared.open(url) }
+    )
+  }
+
+  private func rebuildWorkspaceDependents() {
+    carPlayVoice?.disconnect()
+    assistant = repository.map { FoundationModelAssistant(repository: $0) }
+    carPlayAssistant = repository.map { FoundationModelAssistant(repository: $0) }
+    assistantSession = makeAssistantConversationSession(assistant: assistant)
+    carPlayAssistantSession = makeAssistantConversationSession(
+      assistant: carPlayAssistant,
+      surface: .carPlay
+    )
+    carPlayVoice = CarPlayVoiceCoordinator(
+      session: carPlayAssistantSession,
+      unavailableReason: { [weak self] in
+        guard let self else { return "Your local library is unavailable." }
+        return assistantUnavailabilityMessage(
+          assistant: self.carPlayAssistant,
+          repositoryError: self.repositoryError
+        )
+      }
+    )
   }
 }

--- a/apps/enchiridion/Sources/iOS/EnchiridioniOSApp.swift
+++ b/apps/enchiridion/Sources/iOS/EnchiridioniOSApp.swift
@@ -72,8 +72,21 @@ final class EnchiridionAppRuntime {
     rebuildWorkspaceDependents()
     TaskReminderNotificationCoordinator.shared.configure(
       store: store,
+      resolveStore: { vaultID in
+        try EnchiridionAppRuntime.shared.store(for: vaultID)
+      },
       openURL: { url in UIApplication.shared.open(url) }
     )
+  }
+
+  func store(for vaultID: VaultID) throws -> LibraryStore? {
+    guard let vaultSession else {
+      return store.vaultID == vaultID ? store : nil
+    }
+    if vaultSession.selectedVault.id != vaultID {
+      try selectVault(vaultID)
+    }
+    return vaultSession.store
   }
 
   private func rebuildWorkspaceDependents() {

--- a/apps/enchiridion/Sources/iOS/EnchiridioniOSApp.swift
+++ b/apps/enchiridion/Sources/iOS/EnchiridioniOSApp.swift
@@ -68,12 +68,12 @@ final class EnchiridionAppRuntime {
   }
 
   func workspaceDidChange() {
-    repositoryError = nil
+    if vaultSession != nil { repositoryError = nil }
     rebuildWorkspaceDependents()
     TaskReminderNotificationCoordinator.shared.configure(
       store: store,
       resolveStore: { vaultID in
-        try EnchiridionAppRuntime.shared.store(for: vaultID)
+        try await EnchiridionAppRuntime.shared.vaultSession?.backgroundStore(forVault: vaultID)
       },
       openURL: { url in UIApplication.shared.open(url) }
     )
@@ -83,14 +83,10 @@ final class EnchiridionAppRuntime {
     guard let vaultSession else {
       return store.vaultID == vaultID ? store : nil
     }
-    if vaultSession.selectedVault.id != vaultID {
-      try selectVault(vaultID)
-    }
-    return vaultSession.store
+    return try vaultSession.store(forVault: vaultID, selectingWith: selectVault)
   }
 
   private func rebuildWorkspaceDependents() {
-    carPlayVoice?.disconnect()
     assistant = repository.map { FoundationModelAssistant(repository: $0) }
     carPlayAssistant = repository.map { FoundationModelAssistant(repository: $0) }
     assistantSession = makeAssistantConversationSession(assistant: assistant)
@@ -98,15 +94,23 @@ final class EnchiridionAppRuntime {
       assistant: carPlayAssistant,
       surface: .carPlay
     )
-    carPlayVoice = CarPlayVoiceCoordinator(
-      session: carPlayAssistantSession,
-      unavailableReason: { [weak self] in
+    let unavailableReason: @MainActor () -> String? = { [weak self] in
         guard let self else { return "Your local library is unavailable." }
         return assistantUnavailabilityMessage(
           assistant: self.carPlayAssistant,
           repositoryError: self.repositoryError
         )
       }
-    )
+    if let carPlayVoice {
+      carPlayVoice.update(
+        session: carPlayAssistantSession,
+        unavailableReason: unavailableReason
+      )
+    } else {
+      carPlayVoice = CarPlayVoiceCoordinator(
+        session: carPlayAssistantSession,
+        unavailableReason: unavailableReason
+      )
+    }
   }
 }

--- a/apps/enchiridion/Sources/iOS/MobileLibraryScreen.swift
+++ b/apps/enchiridion/Sources/iOS/MobileLibraryScreen.swift
@@ -4,18 +4,36 @@ import SwiftUI
 struct MobileLibraryScreen: View {
   let store: LibraryStore
   let contactsResolver: DeviceContactsResolver
+  let vaultSession: VaultSession?
+  let selectVault: @MainActor (VaultID) throws -> Void
+  let workspaceDidChange: @MainActor () -> Void
   @State private var query = ""
   @State private var editingTag: SupertagDefinition?
   @State private var editingView: LiveQueryDefinition?
 
-  init(store: LibraryStore, contactsResolver: DeviceContactsResolver = DeviceContactsResolver()) {
+  init(
+    store: LibraryStore,
+    contactsResolver: DeviceContactsResolver = DeviceContactsResolver(),
+    vaultSession: VaultSession? = nil,
+    selectVault: @escaping @MainActor (VaultID) throws -> Void = { _ in },
+    workspaceDidChange: @escaping @MainActor () -> Void = {}
+  ) {
     self.store = store
     self.contactsResolver = contactsResolver
+    self.vaultSession = vaultSession
+    self.selectVault = selectVault
+    self.workspaceDidChange = workspaceDidChange
   }
 
   var body: some View {
     NavigationStack {
       List {
+        if let vaultSession {
+          Section("Vault") {
+            VaultSwitcherMenu(session: vaultSession, selectVault: selectVault)
+          }
+        }
+
         Section("Pages") {
           NavigationLink {
             PageListScreen(store: store, section: .allPages)
@@ -77,7 +95,13 @@ struct MobileLibraryScreen: View {
       .toolbar {
         ToolbarItem(placement: .primaryAction) {
           NavigationLink {
-            MobileSettingsView(store: store, contactsResolver: contactsResolver)
+            MobileSettingsView(
+              store: store,
+              contactsResolver: contactsResolver,
+              vaultSession: vaultSession,
+              selectVault: selectVault,
+              workspaceDidChange: workspaceDidChange
+            )
           } label: {
             Label("Settings", systemImage: "gearshape")
           }

--- a/apps/enchiridion/Sources/iOS/MobileLibraryScreen.swift
+++ b/apps/enchiridion/Sources/iOS/MobileLibraryScreen.swift
@@ -90,6 +90,24 @@ struct MobileLibraryScreen: View {
             Label("New View", systemImage: "plus")
           }
         }
+
+        Section("Graph") {
+          NavigationLink {
+            MobileGraphQueryDestination(store: store)
+          } label: {
+            Label("Query", systemImage: "point.3.connected.trianglepath.dotted")
+          }
+          NavigationLink {
+            GraphRelationDefinitionsView(store: store)
+          } label: {
+            Label("Relationship Types", systemImage: "arrow.left.arrow.right")
+          }
+          NavigationLink {
+            MobileGraphIssuesDestination(store: store)
+          } label: {
+            Label("Needs Attention", systemImage: "exclamationmark.triangle")
+          }
+        }
       }
       .navigationTitle("Library")
       .toolbar {
@@ -114,6 +132,30 @@ struct MobileLibraryScreen: View {
         LiveViewEditor(store: store, definition: view)
       }
     }
+  }
+}
+
+private struct MobileGraphQueryDestination: View {
+  let store: LibraryStore
+  @State private var openedPageID: PageID?
+
+  var body: some View {
+    GraphQueryWorkspace(store: store) { openedPageID = $0 }
+      .sheet(item: $openedPageID) { pageID in
+        NavigationStack { PageDestinationView(store: store, pageID: pageID) }
+      }
+  }
+}
+
+private struct MobileGraphIssuesDestination: View {
+  let store: LibraryStore
+  @State private var openedPageID: PageID?
+
+  var body: some View {
+    GraphIssuesView(store: store) { openedPageID = $0 }
+      .sheet(item: $openedPageID) { pageID in
+        NavigationStack { PageDestinationView(store: store, pageID: pageID) }
+      }
   }
 }
 

--- a/apps/enchiridion/Sources/iOS/MobileRootView.swift
+++ b/apps/enchiridion/Sources/iOS/MobileRootView.swift
@@ -112,8 +112,9 @@ struct MobileRootView: View {
   }
 
   private func receive(_ route: TaskDeepLinkRoute) async {
+    guard let workspaceStore = workspaceStore(for: route.vaultID) else { return }
     let outcome = await systemHandoffCoordinator.open(route) {
-      await store.reload()
+      await workspaceStore.reload()
     }
     guard let route = outcome?.route else { return }
     apply(route)
@@ -135,13 +136,25 @@ struct MobileRootView: View {
     case .list:
       requestedTaskID = nil
       showsQuickTaskCapture = false
-    case .task(let pageID, list: _):
+    case .task(let identity, list: _):
       showsQuickTaskCapture = false
-      requestedTaskID = pageID
-    case .quickAdd(let list):
+      requestedTaskID = identity.nodeID
+    case .quickAdd(let list, vaultID: _):
       requestedTaskID = nil
       quickTaskSelection = .smart(list)
       showsQuickTaskCapture = true
+    }
+  }
+
+  private func workspaceStore(for vaultID: VaultID) -> LibraryStore? {
+    guard let vaultSession else { return store.vaultID == vaultID ? store : nil }
+    do {
+      if vaultSession.selectedVault.id != vaultID {
+        try selectVault(vaultID)
+      }
+      return vaultSession.store
+    } catch {
+      return nil
     }
   }
 }

--- a/apps/enchiridion/Sources/iOS/MobileRootView.swift
+++ b/apps/enchiridion/Sources/iOS/MobileRootView.swift
@@ -6,7 +6,7 @@ import UIKit
 struct MobileRootView: View {
   @Environment(\.scenePhase) private var scenePhase
 
-  @State private var store: LibraryStore
+  let store: LibraryStore
   @State private var selectedTab: MobileTab = .today
   @State private var requestedTaskSelection: TaskListSelection?
   @State private var requestedTaskID: PageID?
@@ -16,17 +16,26 @@ struct MobileRootView: View {
   @State private var isEditorFocused = false
   @State private var isKeyboardVisible = false
   private let contactsResolver: DeviceContactsResolver
+  private let vaultSession: VaultSession?
+  private let selectVault: @MainActor (VaultID) throws -> Void
+  private let workspaceDidChange: @MainActor () -> Void
   private let assistantSession: AssistantConversationSession?
   private let assistantUnavailableReason: String?
 
   init(
     store: LibraryStore,
     contactsResolver: DeviceContactsResolver = DeviceContactsResolver(),
+    vaultSession: VaultSession? = nil,
+    selectVault: @escaping @MainActor (VaultID) throws -> Void = { _ in },
+    workspaceDidChange: @escaping @MainActor () -> Void = {},
     assistantSession: AssistantConversationSession? = nil,
     assistantUnavailableReason: String? = nil
   ) {
-    _store = State(initialValue: store)
+    self.store = store
     self.contactsResolver = contactsResolver
+    self.vaultSession = vaultSession
+    self.selectVault = selectVault
+    self.workspaceDidChange = workspaceDidChange
     self.assistantSession = assistantSession
     self.assistantUnavailableReason = assistantUnavailableReason
   }
@@ -57,7 +66,13 @@ struct MobileRootView: View {
         .tag(MobileTab.calendar)
         .toolbar(tabBarVisibility, for: .tabBar)
 
-      MobileLibraryScreen(store: store, contactsResolver: contactsResolver)
+      MobileLibraryScreen(
+        store: store,
+        contactsResolver: contactsResolver,
+        vaultSession: vaultSession,
+        selectVault: selectVault,
+        workspaceDidChange: workspaceDidChange
+      )
         .tabItem { Label("Library", systemImage: "books.vertical") }
         .tag(MobileTab.library)
         .toolbar(tabBarVisibility, for: .tabBar)

--- a/apps/enchiridion/Sources/iOS/MobileRootView.swift
+++ b/apps/enchiridion/Sources/iOS/MobileRootView.swift
@@ -10,6 +10,8 @@ struct MobileRootView: View {
   @State private var selectedTab: MobileTab = .today
   @State private var requestedTaskSelection: TaskListSelection?
   @State private var requestedTaskID: PageID?
+  @State private var routedTaskStore: LibraryStore?
+  @State private var routeErrorMessage: String?
   @State private var showsQuickTaskCapture = false
   @State private var quickTaskSelection: TaskListSelection = .smart(.inbox)
   @State private var systemHandoffCoordinator = TaskSystemHandoffCoordinator()
@@ -82,8 +84,13 @@ struct MobileRootView: View {
     }
     .sheet(item: $requestedTaskID) { pageID in
       NavigationStack {
-        TaskDetailScreen(store: store, pageID: pageID)
+        TaskDetailScreen(store: routedTaskStore ?? store, pageID: pageID)
       }
+    }
+    .alert("Unable to Open Task", isPresented: routeErrorBinding) {
+      Button("Dismiss Error", role: .cancel) {}
+    } message: {
+      Text(routeErrorMessage ?? "The linked vault could not be opened.")
     }
     .onOpenURL { url in
       guard let route = TaskDeepLinkRoute(url: url) else { return }
@@ -112,12 +119,17 @@ struct MobileRootView: View {
   }
 
   private func receive(_ route: TaskDeepLinkRoute) async {
-    guard let workspaceStore = workspaceStore(for: route.vaultID) else { return }
-    let outcome = await systemHandoffCoordinator.open(route) {
-      await workspaceStore.reload()
+    do {
+      let workspaceStore = try workspaceStore(for: route.vaultID)
+      let outcome = await systemHandoffCoordinator.open(route) {
+        await workspaceStore.reload()
+      }
+      guard let route = outcome?.route else { return }
+      routeErrorMessage = nil
+      apply(route, store: workspaceStore)
+    } catch {
+      routeErrorMessage = error.localizedDescription
     }
-    guard let route = outcome?.route else { return }
-    apply(route)
   }
 
   private func refreshForActivation() async {
@@ -125,37 +137,43 @@ struct MobileRootView: View {
       await store.reload()
     }
     guard let route = outcome?.route else { return }
-    apply(route)
+    apply(route, store: store)
   }
 
-  private func apply(_ route: TaskDeepLinkRoute) {
+  private func apply(_ route: TaskDeepLinkRoute, store: LibraryStore) {
     selectedTab = .tasks
     requestedTaskSelection = .smart(route.list)
 
     switch route {
     case .list:
       requestedTaskID = nil
+      routedTaskStore = nil
       showsQuickTaskCapture = false
     case .task(let identity, list: _):
       showsQuickTaskCapture = false
+      routedTaskStore = store
       requestedTaskID = identity.nodeID
     case .quickAdd(let list, vaultID: _):
       requestedTaskID = nil
+      routedTaskStore = nil
       quickTaskSelection = .smart(list)
       showsQuickTaskCapture = true
     }
   }
 
-  private func workspaceStore(for vaultID: VaultID) -> LibraryStore? {
-    guard let vaultSession else { return store.vaultID == vaultID ? store : nil }
-    do {
-      if vaultSession.selectedVault.id != vaultID {
-        try selectVault(vaultID)
-      }
-      return vaultSession.store
-    } catch {
-      return nil
+  private func workspaceStore(for vaultID: VaultID) throws -> LibraryStore {
+    guard let vaultSession else {
+      guard store.vaultID == vaultID else { throw VaultRegistryError.vaultNotFound }
+      return store
     }
+    return try vaultSession.store(forVault: vaultID, selectingWith: selectVault)
+  }
+
+  private var routeErrorBinding: Binding<Bool> {
+    Binding(
+      get: { routeErrorMessage != nil },
+      set: { if !$0 { routeErrorMessage = nil } }
+    )
   }
 }
 

--- a/apps/enchiridion/Sources/iOS/MobileSettingsView.swift
+++ b/apps/enchiridion/Sources/iOS/MobileSettingsView.swift
@@ -4,16 +4,38 @@ import SwiftUI
 struct MobileSettingsView: View {
   let store: LibraryStore
   let contactsResolver: DeviceContactsResolver
+  let vaultSession: VaultSession?
+  let selectVault: @MainActor (VaultID) throws -> Void
+  let workspaceDidChange: @MainActor () -> Void
+  @State private var showsVaultManager = false
   @AppStorage(CarPlayAssistantPrivacySettings.isEnabledKey)
   private var isCarPlayAssistantEnabled = true
 
-  init(store: LibraryStore, contactsResolver: DeviceContactsResolver = DeviceContactsResolver()) {
+  init(
+    store: LibraryStore,
+    contactsResolver: DeviceContactsResolver = DeviceContactsResolver(),
+    vaultSession: VaultSession? = nil,
+    selectVault: @escaping @MainActor (VaultID) throws -> Void = { _ in },
+    workspaceDidChange: @escaping @MainActor () -> Void = {}
+  ) {
     self.store = store
     self.contactsResolver = contactsResolver
+    self.vaultSession = vaultSession
+    self.selectVault = selectVault
+    self.workspaceDidChange = workspaceDidChange
   }
 
   var body: some View {
     Form {
+      if let vaultSession {
+        Section("Vault") {
+          VaultSwitcherMenu(session: vaultSession, selectVault: selectVault)
+          Button("Manage Vaults") { showsVaultManager = true }
+          Text("Captures can use a different default vault. Relationships never cross vault boundaries.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+      }
       Section("Calendar") {
         Button("Enable Local Calendars") { Task { await store.enableCalendar() } }
         Button("Connect Google Calendar") { Task { await store.enableGoogleCalendar() } }
@@ -54,6 +76,15 @@ struct MobileSettingsView: View {
       }
     }
     .navigationTitle("Settings")
+    .sheet(isPresented: $showsVaultManager) {
+      if let vaultSession {
+        VaultManagementView(
+          session: vaultSession,
+          selectVault: selectVault,
+          workspaceDidChange: workspaceDidChange
+        )
+      }
+    }
   }
 
   private var isSyncing: Bool {

--- a/apps/enchiridion/Sources/macOS/EnchiridionMacApp.swift
+++ b/apps/enchiridion/Sources/macOS/EnchiridionMacApp.swift
@@ -1,4 +1,6 @@
+import AppKit
 import EnchiridionCore
+import Observation
 import SwiftUI
 
 @main
@@ -8,14 +10,19 @@ struct EnchiridionMacApp: App {
   @FocusedValue(\.newTaskAction) private var newTaskAction
   @FocusedValue(\.openTaskListAction) private var openTaskListAction
   @Environment(\.openWindow) private var openWindow
+  @State private var runtime = EnchiridionMacRuntime.shared
 
   var body: some Scene {
     WindowGroup {
-      MacRootView(store: EnchiridionMacRuntime.shared.store)
+      MacRootView(
+        store: runtime.store,
+        vaultSession: runtime.vaultSession,
+        selectVault: runtime.selectVault
+      )
         .frame(minWidth: 820, minHeight: 520)
         .managesDeviceContacts(
-          store: EnchiridionMacRuntime.shared.store,
-          resolver: EnchiridionMacRuntime.shared.contactsResolver
+          store: runtime.store,
+          resolver: runtime.contactsResolver
         )
     }
     .commands {
@@ -56,8 +63,8 @@ struct EnchiridionMacApp: App {
 
     Window("Assistant", id: "assistant") {
       AssistantConversationView(
-        session: EnchiridionMacRuntime.shared.assistantSession,
-        unavailableReason: EnchiridionMacRuntime.shared.assistantUnavailableReason
+        session: runtime.assistantSession,
+        unavailableReason: runtime.assistantUnavailableReason
       )
       .frame(minWidth: 480, minHeight: 560)
     }
@@ -65,39 +72,63 @@ struct EnchiridionMacApp: App {
 
     Settings {
       MacSettingsView(
-        store: EnchiridionMacRuntime.shared.store,
-        contactsResolver: EnchiridionMacRuntime.shared.contactsResolver
+        store: runtime.store,
+        contactsResolver: runtime.contactsResolver,
+        vaultSession: runtime.vaultSession,
+        selectVault: runtime.selectVault,
+        workspaceDidChange: runtime.workspaceDidChange
       )
     }
   }
 }
 
 @MainActor
+@Observable
 final class EnchiridionMacRuntime {
   static let shared = EnchiridionMacRuntime()
 
-  let repository: LibraryRepository?
-  let store: LibraryStore
-  let assistant: FoundationModelAssistant?
-  lazy var assistantSession = makeAssistantConversationSession(assistant: assistant)
+  let vaultSession: VaultSession?
+  let contactsResolver = DeviceContactsResolver()
+  private let fallbackStore: LibraryStore
+  private(set) var assistant: FoundationModelAssistant?
+  private(set) var assistantSession: AssistantConversationSession?
+  private(set) var repositoryError: String?
+
+  var repository: LibraryRepository? { vaultSession?.repository }
+  var store: LibraryStore { vaultSession?.store ?? fallbackStore }
   var assistantUnavailableReason: String? {
     assistantUnavailabilityMessage(assistant: assistant, repositoryError: repositoryError)
   }
-  let repositoryError: String?
-  let contactsResolver = DeviceContactsResolver()
-
   private init() {
     do {
-      let repository = try LibraryRepository(path: LibraryRepository.defaultLocalPath())
-      self.repository = repository
-      store = LibraryStore(repository: repository, contactResolver: contactsResolver)
-      assistant = FoundationModelAssistant(repository: repository)
-      repositoryError = nil
+      let session = try VaultSession(contactResolver: contactsResolver)
+      vaultSession = session
+      fallbackStore = session.store
     } catch {
-      repository = nil
-      store = LibraryStore(contactResolver: contactsResolver)
-      assistant = nil
+      vaultSession = nil
+      fallbackStore = LibraryStore(contactResolver: contactsResolver)
       repositoryError = error.localizedDescription
     }
+    rebuildWorkspaceDependents()
+  }
+
+  func selectVault(_ id: VaultID) throws {
+    guard let vaultSession else { throw VaultRegistryError.vaultNotFound }
+    try vaultSession.selectVault(id)
+    workspaceDidChange()
+  }
+
+  func workspaceDidChange() {
+    repositoryError = nil
+    rebuildWorkspaceDependents()
+    TaskReminderNotificationCoordinator.shared.configure(
+      store: store,
+      openURL: { url in NSWorkspace.shared.open(url) }
+    )
+  }
+
+  private func rebuildWorkspaceDependents() {
+    assistant = repository.map { FoundationModelAssistant(repository: $0) }
+    assistantSession = makeAssistantConversationSession(assistant: assistant)
   }
 }

--- a/apps/enchiridion/Sources/macOS/EnchiridionMacApp.swift
+++ b/apps/enchiridion/Sources/macOS/EnchiridionMacApp.swift
@@ -74,9 +74,13 @@ struct EnchiridionMacApp: App {
       MacSettingsView(
         store: runtime.store,
         contactsResolver: runtime.contactsResolver,
-        vaultSession: runtime.vaultSession,
-        selectVault: runtime.selectVault,
-        workspaceDidChange: runtime.workspaceDidChange
+        vaultContext: runtime.vaultSession.map { session in
+          VaultSettingsContext(
+            session: session,
+            selectVault: runtime.selectVault,
+            workspaceDidChange: runtime.workspaceDidChange
+          )
+        }
       )
     }
   }
@@ -119,12 +123,12 @@ final class EnchiridionMacRuntime {
   }
 
   func workspaceDidChange() {
-    repositoryError = nil
+    if vaultSession != nil { repositoryError = nil }
     rebuildWorkspaceDependents()
     TaskReminderNotificationCoordinator.shared.configure(
       store: store,
       resolveStore: { vaultID in
-        try EnchiridionMacRuntime.shared.store(for: vaultID)
+        try await EnchiridionMacRuntime.shared.vaultSession?.backgroundStore(forVault: vaultID)
       },
       openURL: { url in NSWorkspace.shared.open(url) }
     )
@@ -134,10 +138,7 @@ final class EnchiridionMacRuntime {
     guard let vaultSession else {
       return store.vaultID == vaultID ? store : nil
     }
-    if vaultSession.selectedVault.id != vaultID {
-      try selectVault(vaultID)
-    }
-    return vaultSession.store
+    return try vaultSession.store(forVault: vaultID, selectingWith: selectVault)
   }
 
   private func rebuildWorkspaceDependents() {

--- a/apps/enchiridion/Sources/macOS/EnchiridionMacApp.swift
+++ b/apps/enchiridion/Sources/macOS/EnchiridionMacApp.swift
@@ -123,8 +123,21 @@ final class EnchiridionMacRuntime {
     rebuildWorkspaceDependents()
     TaskReminderNotificationCoordinator.shared.configure(
       store: store,
+      resolveStore: { vaultID in
+        try EnchiridionMacRuntime.shared.store(for: vaultID)
+      },
       openURL: { url in NSWorkspace.shared.open(url) }
     )
+  }
+
+  func store(for vaultID: VaultID) throws -> LibraryStore? {
+    guard let vaultSession else {
+      return store.vaultID == vaultID ? store : nil
+    }
+    if vaultSession.selectedVault.id != vaultID {
+      try selectVault(vaultID)
+    }
+    return vaultSession.store
   }
 
   private func rebuildWorkspaceDependents() {

--- a/apps/enchiridion/Sources/macOS/MacRootView.swift
+++ b/apps/enchiridion/Sources/macOS/MacRootView.swift
@@ -811,9 +811,10 @@ struct MacRootView: View {
   }
 
   private func receive(_ route: TaskDeepLinkRoute) async {
+    guard await editorFlushController.flush() else { return }
+    guard let workspaceStore = workspaceStore(for: route.vaultID) else { return }
     let outcome = await systemHandoffCoordinator.open(route) {
-      guard await editorFlushController.flush() else { return nil }
-      return await store.reload()
+      await workspaceStore.reload()
     }
     guard let route = outcome?.route else { return }
     apply(route)
@@ -836,12 +837,24 @@ struct MacRootView: View {
     case .list:
       showsQuickTaskCapture = false
       store.selectedPageID = nil
-    case .task(let pageID, list: _):
+    case .task(let identity, list: _):
       showsQuickTaskCapture = false
-      store.selectedPageID = pageID
+      store.selectedPageID = identity.nodeID
     case .quickAdd:
       store.selectedPageID = nil
       showsQuickTaskCapture = true
+    }
+  }
+
+  private func workspaceStore(for vaultID: VaultID) -> LibraryStore? {
+    guard let vaultSession else { return store.vaultID == vaultID ? store : nil }
+    do {
+      if vaultSession.selectedVault.id != vaultID {
+        try selectVault(vaultID)
+      }
+      return vaultSession.store
+    } catch {
+      return nil
     }
   }
 

--- a/apps/enchiridion/Sources/macOS/MacRootView.swift
+++ b/apps/enchiridion/Sources/macOS/MacRootView.swift
@@ -5,7 +5,9 @@ struct MacRootView: View {
   @Environment(\.openWindow) private var openWindow
   @Environment(\.scenePhase) private var scenePhase
 
-  @State private var store: LibraryStore
+  let store: LibraryStore
+  let vaultSession: VaultSession?
+  let selectVault: @MainActor (VaultID) throws -> Void
   @State private var selection: MacSidebarSelection = .section(.today)
   @State private var query = ""
   @State private var editingTag: SupertagDefinition?
@@ -20,13 +22,24 @@ struct MacRootView: View {
   @State private var systemHandoffCoordinator = TaskSystemHandoffCoordinator()
   @State private var pagePendingPermanentDeletion: PageSnapshot?
 
-  init(store: LibraryStore = LibraryStore()) {
-    _store = State(initialValue: store)
+  init(
+    store: LibraryStore = LibraryStore(),
+    vaultSession: VaultSession? = nil,
+    selectVault: @escaping @MainActor (VaultID) throws -> Void = { _ in }
+  ) {
+    self.store = store
+    self.vaultSession = vaultSession
+    self.selectVault = selectVault
   }
 
   var body: some View {
     NavigationSplitView {
       List(selection: sidebarSelectionBinding) {
+        if let vaultSession {
+          Section("Vault") {
+            VaultSwitcherMenu(session: vaultSession, selectVault: selectVault)
+          }
+        }
         Section("Tasks") {
           ForEach(TaskSmartList.allCases) { list in
             HStack {

--- a/apps/enchiridion/Sources/macOS/MacRootView.swift
+++ b/apps/enchiridion/Sources/macOS/MacRootView.swift
@@ -21,6 +21,9 @@ struct MacRootView: View {
   @State private var editorFlushController = EditorFlushController()
   @State private var systemHandoffCoordinator = TaskSystemHandoffCoordinator()
   @State private var pagePendingPermanentDeletion: PageSnapshot?
+  @State private var showsGraphQuery = false
+  @State private var showsGraphIssues = false
+  @State private var showsGraphRelationDefinitions = false
 
   init(
     store: LibraryStore = LibraryStore(),
@@ -164,6 +167,26 @@ struct MacRootView: View {
             presentViewEditor(.init(name: "New View", source: .pages))
           } label: {
             Label("New View", systemImage: "plus")
+          }
+          .buttonStyle(.plain)
+        }
+        Section("Graph") {
+          Button {
+            showsGraphQuery = true
+          } label: {
+            Label("Query", systemImage: "point.3.connected.trianglepath.dotted")
+          }
+          .buttonStyle(.plain)
+          Button {
+            showsGraphRelationDefinitions = true
+          } label: {
+            Label("Relationship Types", systemImage: "arrow.left.arrow.right")
+          }
+          .buttonStyle(.plain)
+          Button {
+            showsGraphIssues = true
+          } label: {
+            Label("Needs Attention", systemImage: "exclamationmark.triangle")
           }
           .buttonStyle(.plain)
         }
@@ -426,6 +449,45 @@ struct MacRootView: View {
     }
     .sheet(item: $taskCollectionDraft) { draft in
       TaskCollectionCreator(store: store, draft: draft)
+    }
+    .sheet(isPresented: $showsGraphQuery) {
+      NavigationStack {
+        GraphQueryWorkspace(store: store) { pageID in
+          showsGraphQuery = false
+          selectPage(pageID)
+        }
+        .frame(minWidth: 760, minHeight: 620)
+        .toolbar {
+          ToolbarItem(placement: .cancellationAction) {
+            Button("Done") { showsGraphQuery = false }
+          }
+        }
+      }
+    }
+    .sheet(isPresented: $showsGraphRelationDefinitions) {
+      NavigationStack {
+        GraphRelationDefinitionsView(store: store)
+          .frame(minWidth: 620, minHeight: 620)
+          .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+              Button("Done") { showsGraphRelationDefinitions = false }
+            }
+          }
+      }
+    }
+    .sheet(isPresented: $showsGraphIssues) {
+      NavigationStack {
+        GraphIssuesView(store: store) { pageID in
+          showsGraphIssues = false
+          selectPage(pageID)
+        }
+        .frame(minWidth: 560, minHeight: 520)
+        .toolbar {
+          ToolbarItem(placement: .cancellationAction) {
+            Button("Done") { showsGraphIssues = false }
+          }
+        }
+      }
     }
     .confirmationDialog(
       "Delete \(perspectivePendingDeletion?.name ?? "Perspective")?",

--- a/apps/enchiridion/Sources/macOS/MacRootView.swift
+++ b/apps/enchiridion/Sources/macOS/MacRootView.swift
@@ -24,6 +24,7 @@ struct MacRootView: View {
   @State private var showsGraphQuery = false
   @State private var showsGraphIssues = false
   @State private var showsGraphRelationDefinitions = false
+  @State private var routeErrorMessage: String?
 
   init(
     store: LibraryStore = LibraryStore(),
@@ -501,6 +502,11 @@ struct MacRootView: View {
     } message: {
       Text("The perspective will disappear on every synced device. Your tasks are not deleted.")
     }
+    .alert("Unable to Open Task", isPresented: routeErrorBinding) {
+      Button("Dismiss Error", role: .cancel) {}
+    } message: {
+      Text(routeErrorMessage ?? "The linked vault could not be opened.")
+    }
     .onChange(of: store.savedViews) { oldViews, views in
       if case .view(let id) = selection, !views.contains(where: { $0.id == id }) {
         let removedView = oldViews.first { $0.id == id }
@@ -812,12 +818,17 @@ struct MacRootView: View {
 
   private func receive(_ route: TaskDeepLinkRoute) async {
     guard await editorFlushController.flush() else { return }
-    guard let workspaceStore = workspaceStore(for: route.vaultID) else { return }
-    let outcome = await systemHandoffCoordinator.open(route) {
-      await workspaceStore.reload()
+    do {
+      let workspaceStore = try workspaceStore(for: route.vaultID)
+      let outcome = await systemHandoffCoordinator.open(route) {
+        await workspaceStore.reload()
+      }
+      guard let route = outcome?.route else { return }
+      routeErrorMessage = nil
+      apply(route, store: workspaceStore)
+    } catch {
+      routeErrorMessage = error.localizedDescription
     }
-    guard let route = outcome?.route else { return }
-    apply(route)
   }
 
   private func refreshForActivation() async {
@@ -826,10 +837,10 @@ struct MacRootView: View {
       return await store.reload()
     }
     guard let route = outcome?.route else { return }
-    apply(route)
+    apply(route, store: store)
   }
 
-  private func apply(_ route: TaskDeepLinkRoute) {
+  private func apply(_ route: TaskDeepLinkRoute, store: LibraryStore) {
     query = ""
     selection = .task(.smart(route.list))
 
@@ -846,16 +857,19 @@ struct MacRootView: View {
     }
   }
 
-  private func workspaceStore(for vaultID: VaultID) -> LibraryStore? {
-    guard let vaultSession else { return store.vaultID == vaultID ? store : nil }
-    do {
-      if vaultSession.selectedVault.id != vaultID {
-        try selectVault(vaultID)
-      }
-      return vaultSession.store
-    } catch {
-      return nil
+  private func workspaceStore(for vaultID: VaultID) throws -> LibraryStore {
+    guard let vaultSession else {
+      guard store.vaultID == vaultID else { throw VaultRegistryError.vaultNotFound }
+      return store
     }
+    return try vaultSession.store(forVault: vaultID, selectingWith: selectVault)
+  }
+
+  private var routeErrorBinding: Binding<Bool> {
+    Binding(
+      get: { routeErrorMessage != nil },
+      set: { if !$0 { routeErrorMessage = nil } }
+    )
   }
 
   private func selectPage(_ pageID: PageID) {

--- a/apps/enchiridion/Sources/macOS/MacSettingsView.swift
+++ b/apps/enchiridion/Sources/macOS/MacSettingsView.swift
@@ -1,34 +1,37 @@
 import EnchiridionCore
 import SwiftUI
 
+struct VaultSettingsContext {
+  let session: VaultSession
+  let selectVault: @MainActor (VaultID) throws -> Void
+  let workspaceDidChange: @MainActor () -> Void
+}
+
 struct MacSettingsView: View {
   let store: LibraryStore
   let contactsResolver: DeviceContactsResolver
-  let vaultSession: VaultSession?
-  let selectVault: @MainActor (VaultID) throws -> Void
-  let workspaceDidChange: @MainActor () -> Void
+  let vaultContext: VaultSettingsContext?
   @State private var showsVaultManager = false
 
   init(
     store: LibraryStore,
     contactsResolver: DeviceContactsResolver,
-    vaultSession: VaultSession? = nil,
-    selectVault: @escaping @MainActor (VaultID) throws -> Void = { _ in },
-    workspaceDidChange: @escaping @MainActor () -> Void = {}
+    vaultContext: VaultSettingsContext? = nil
   ) {
     self.store = store
     self.contactsResolver = contactsResolver
-    self.vaultSession = vaultSession
-    self.selectVault = selectVault
-    self.workspaceDidChange = workspaceDidChange
+    self.vaultContext = vaultContext
   }
 
   var body: some View {
     NavigationStack {
       Form {
-        if let vaultSession {
+        if let vaultContext {
           Section("Vault") {
-            VaultSwitcherMenu(session: vaultSession, selectVault: selectVault)
+            VaultSwitcherMenu(
+              session: vaultContext.session,
+              selectVault: vaultContext.selectVault
+            )
             Button("Manage Vaults") { showsVaultManager = true }
             Text("Each vault is an independent graph. External capture can use a separate default vault.")
               .font(.caption)
@@ -47,11 +50,11 @@ struct MacSettingsView: View {
       .formStyle(.grouped)
       .navigationTitle("Settings")
       .sheet(isPresented: $showsVaultManager) {
-        if let vaultSession {
+        if let vaultContext {
           VaultManagementView(
-            session: vaultSession,
-            selectVault: selectVault,
-            workspaceDidChange: workspaceDidChange
+            session: vaultContext.session,
+            selectVault: vaultContext.selectVault,
+            workspaceDidChange: vaultContext.workspaceDidChange
           )
           .frame(minWidth: 480, minHeight: 420)
         }

--- a/apps/enchiridion/Sources/macOS/MacSettingsView.swift
+++ b/apps/enchiridion/Sources/macOS/MacSettingsView.swift
@@ -4,10 +4,37 @@ import SwiftUI
 struct MacSettingsView: View {
   let store: LibraryStore
   let contactsResolver: DeviceContactsResolver
+  let vaultSession: VaultSession?
+  let selectVault: @MainActor (VaultID) throws -> Void
+  let workspaceDidChange: @MainActor () -> Void
+  @State private var showsVaultManager = false
+
+  init(
+    store: LibraryStore,
+    contactsResolver: DeviceContactsResolver,
+    vaultSession: VaultSession? = nil,
+    selectVault: @escaping @MainActor (VaultID) throws -> Void = { _ in },
+    workspaceDidChange: @escaping @MainActor () -> Void = {}
+  ) {
+    self.store = store
+    self.contactsResolver = contactsResolver
+    self.vaultSession = vaultSession
+    self.selectVault = selectVault
+    self.workspaceDidChange = workspaceDidChange
+  }
 
   var body: some View {
     NavigationStack {
       Form {
+        if let vaultSession {
+          Section("Vault") {
+            VaultSwitcherMenu(session: vaultSession, selectVault: selectVault)
+            Button("Manage Vaults") { showsVaultManager = true }
+            Text("Each vault is an independent graph. External capture can use a separate default vault.")
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+        }
         Section("Storage") {
           LabeledContent("Persistence", value: "Local SQLite + Automerge")
           Text("Calendar event filters and contact matches stay on this Mac. Promoted pages can sync through iCloud.")
@@ -19,6 +46,16 @@ struct MacSettingsView: View {
       }
       .formStyle(.grouped)
       .navigationTitle("Settings")
+      .sheet(isPresented: $showsVaultManager) {
+        if let vaultSession {
+          VaultManagementView(
+            session: vaultSession,
+            selectVault: selectVault,
+            workspaceDidChange: workspaceDidChange
+          )
+          .frame(minWidth: 480, minHeight: 420)
+        }
+      }
     }
     .frame(width: 520, height: 620)
   }

--- a/apps/enchiridion/Sources/macOS/TaskReminderAppDelegate.swift
+++ b/apps/enchiridion/Sources/macOS/TaskReminderAppDelegate.swift
@@ -2,14 +2,6 @@ import AppKit
 
 final class EnchiridionMacAppDelegate: NSObject, NSApplicationDelegate {
   func applicationDidFinishLaunching(_ notification: Notification) {
-    TaskReminderNotificationCoordinator.shared.configure(
-      store: EnchiridionMacRuntime.shared.store,
-      resolveStore: { vaultID in
-        try EnchiridionMacRuntime.shared.store(for: vaultID)
-      },
-      openURL: { url in
-        NSWorkspace.shared.open(url)
-      }
-    )
+    EnchiridionMacRuntime.shared.workspaceDidChange()
   }
 }

--- a/apps/enchiridion/Sources/macOS/TaskReminderAppDelegate.swift
+++ b/apps/enchiridion/Sources/macOS/TaskReminderAppDelegate.swift
@@ -4,6 +4,9 @@ final class EnchiridionMacAppDelegate: NSObject, NSApplicationDelegate {
   func applicationDidFinishLaunching(_ notification: Notification) {
     TaskReminderNotificationCoordinator.shared.configure(
       store: EnchiridionMacRuntime.shared.store,
+      resolveStore: { vaultID in
+        try EnchiridionMacRuntime.shared.store(for: vaultID)
+      },
       openURL: { url in
         NSWorkspace.shared.open(url)
       }

--- a/apps/enchiridion/Tests/EnchiridionCoreTests/CloudSyncTests.swift
+++ b/apps/enchiridion/Tests/EnchiridionCoreTests/CloudSyncTests.swift
@@ -139,10 +139,34 @@ final class CloudSyncPolicyTests: XCTestCase {
         recordName: "saved-view:view-1"
       )
     )
+    XCTAssertTrue(
+      CloudSyncCoordinator.isValidRecordIdentity(
+        recordType: "GraphRelation",
+        recordName: "graph-relation:reports-to"
+      )
+    )
+    XCTAssertTrue(
+      CloudSyncCoordinator.isValidRecordIdentity(
+        recordType: "GraphQuery",
+        recordName: "graph-query:leadership"
+      )
+    )
     XCTAssertFalse(
       CloudSyncCoordinator.isValidRecordIdentity(
         recordType: "Page",
         recordName: "saved-view:view-1"
+      )
+    )
+    XCTAssertFalse(
+      CloudSyncCoordinator.isValidRecordIdentity(
+        recordType: "Page",
+        recordName: "graph-relation:reports-to"
+      )
+    )
+    XCTAssertFalse(
+      CloudSyncCoordinator.isValidRecordIdentity(
+        recordType: "GraphQuery",
+        recordName: "graph-relation:leadership"
       )
     )
     XCTAssertFalse(

--- a/apps/enchiridion/Tests/EnchiridionCoreTests/GraphModelTests.swift
+++ b/apps/enchiridion/Tests/EnchiridionCoreTests/GraphModelTests.swift
@@ -48,6 +48,20 @@ final class GraphModelTests: XCTestCase {
     }
   }
 
+  func testEffectiveTagIDsTerminateAndIncludeEveryTagInACycle() {
+    var first = SupertagDefinition.draft(name: "First")
+    var second = SupertagDefinition.draft(name: "Second")
+    first.parentIDs = [second.id]
+    second.parentIDs = [first.id]
+
+    let effectiveTagIDs = SupertagInheritance.effectiveTagIDs(
+      for: [first.id],
+      definitions: [first, second]
+    )
+
+    XCTAssertEqual(effectiveTagIDs, [first.id, second.id])
+  }
+
   func testVaultScopedNodeIdentityCannotCollideAcrossVaults() {
     let nodeID = PageID.free(UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")!)
     let first = VaultScopedNodeID(vaultID: .init(rawValue: "vault_one"), nodeID: nodeID)

--- a/apps/enchiridion/Tests/EnchiridionCoreTests/GraphModelTests.swift
+++ b/apps/enchiridion/Tests/EnchiridionCoreTests/GraphModelTests.swift
@@ -80,7 +80,10 @@ final class GraphModelTests: XCTestCase {
 
   func testLocalDateRejectsInstantsAndRetainsCalendarIdentity() {
     XCTAssertEqual(LocalDate(rawValue: "2026-07-30")?.rawValue, "2026-07-30")
+    XCTAssertEqual(LocalDate(rawValue: "2028-02-29")?.rawValue, "2028-02-29")
     XCTAssertNil(LocalDate(rawValue: "2026-07-30T12:00:00Z"))
     XCTAssertNil(LocalDate(rawValue: "2026-13-30"))
+    XCTAssertNil(LocalDate(rawValue: "2026-02-29"))
+    XCTAssertNil(LocalDate(rawValue: "2026-04-31"))
   }
 }

--- a/apps/enchiridion/Tests/EnchiridionCoreTests/GraphModelTests.swift
+++ b/apps/enchiridion/Tests/EnchiridionCoreTests/GraphModelTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import EnchiridionCore
+
+final class GraphModelTests: XCTestCase {
+  func testFixedBaseOntologyIncludesGraphTypesAndCompanyInheritance() {
+    let definitions = Dictionary(uniqueKeysWithValues: BuiltInSupertags.all.map { ($0.id, $0) })
+
+    XCTAssertNotNil(definitions[BuiltInSupertags.person])
+    XCTAssertNotNil(definitions[BuiltInSupertags.event])
+    XCTAssertEqual(definitions[BuiltInSupertags.company]?.parentIDs, [BuiltInSupertags.organization])
+  }
+
+  func testBuiltInRelationsCoverEveryCardinalityShape() {
+    let relations = BuiltInRelations.all
+
+    XCTAssertTrue(relations.contains { $0.cardinality == .manyToOne })
+    XCTAssertTrue(relations.contains { $0.cardinality == .manyToMany })
+    XCTAssertEqual(
+      relations.first(where: { $0.id == BuiltInRelations.taskProject })?.inverseName,
+      "tasks"
+    )
+  }
+
+  func testLegacyReferenceFieldMapsToCanonicalRelation() {
+    let key = SupertagPropertyKey(
+      supertagID: BuiltInSupertags.task,
+      fieldID: .init(rawValue: "project")
+    )
+
+    XCTAssertEqual(BuiltInRelations.relationID(for: key), BuiltInRelations.taskProject)
+    XCTAssertEqual(BuiltInRelations.propertyKey(for: BuiltInRelations.taskProject), key)
+  }
+
+  func testVaultScopedNodeIdentityCannotCollideAcrossVaults() {
+    let nodeID = PageID.free(UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")!)
+    let first = VaultScopedNodeID(vaultID: .init(rawValue: "vault_one"), nodeID: nodeID)
+    let second = VaultScopedNodeID(vaultID: .init(rawValue: "vault_two"), nodeID: nodeID)
+
+    XCTAssertNotEqual(first, second)
+    XCTAssertNotEqual(first.id, second.id)
+  }
+
+  func testLocalDateRejectsInstantsAndRetainsCalendarIdentity() {
+    XCTAssertEqual(LocalDate(rawValue: "2026-07-30")?.rawValue, "2026-07-30")
+    XCTAssertNil(LocalDate(rawValue: "2026-07-30T12:00:00Z"))
+    XCTAssertNil(LocalDate(rawValue: "2026-13-30"))
+  }
+}

--- a/apps/enchiridion/Tests/EnchiridionCoreTests/GraphModelTests.swift
+++ b/apps/enchiridion/Tests/EnchiridionCoreTests/GraphModelTests.swift
@@ -31,6 +31,23 @@ final class GraphModelTests: XCTestCase {
     XCTAssertEqual(BuiltInRelations.propertyKey(for: BuiltInRelations.taskProject), key)
   }
 
+  func testEventReferenceFieldsMapBackFromCanonicalRelations() {
+    let mappings: [(String, RelationID)] = [
+      ("organizer", BuiltInRelations.eventOrganizer),
+      ("attendees", BuiltInRelations.eventAttendees),
+      ("place", BuiltInRelations.eventPlace),
+    ]
+
+    for (fieldID, relationID) in mappings {
+      let key = SupertagPropertyKey(
+        supertagID: BuiltInSupertags.event,
+        fieldID: .init(rawValue: fieldID)
+      )
+      XCTAssertEqual(BuiltInRelations.relationID(for: key), relationID)
+      XCTAssertEqual(BuiltInRelations.propertyKey(for: relationID), key)
+    }
+  }
+
   func testVaultScopedNodeIdentityCannotCollideAcrossVaults() {
     let nodeID = PageID.free(UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")!)
     let first = VaultScopedNodeID(vaultID: .init(rawValue: "vault_one"), nodeID: nodeID)
@@ -38,6 +55,13 @@ final class GraphModelTests: XCTestCase {
 
     XCTAssertNotEqual(first, second)
     XCTAssertNotEqual(first.id, second.id)
+  }
+
+  func testLegacyUnscopedNodeIdentityDefaultsToPersonalVault() throws {
+    let nodeID = PageID(rawValue: "page_legacy")
+    let identity = try XCTUnwrap(VaultScopedNodeID(serialized: nodeID.rawValue))
+
+    XCTAssertEqual(identity, .init(vaultID: .personal, nodeID: nodeID))
   }
 
   func testLocalDateRejectsInstantsAndRetainsCalendarIdentity() {

--- a/apps/enchiridion/Tests/EnchiridionCoreTests/GraphRepositoryTests.swift
+++ b/apps/enchiridion/Tests/EnchiridionCoreTests/GraphRepositoryTests.swift
@@ -113,6 +113,14 @@ final class GraphRepositoryTests: XCTestCase {
     XCTAssertEqual(outgoingEdges, [edge])
     XCTAssertEqual(backlinks.map(\.edge), [edge])
 
+    try await fixture.repository.setProperty(
+      pageID: task.id,
+      key: TaskFields.project,
+      values: [.page(firstProject.id)]
+    )
+    let stableOutgoingEdges = try await fixture.repository.outgoingEdges(from: task.id)
+    XCTAssertEqual(stableOutgoingEdges, [edge])
+
     let inverse = try fixture.repository.runGraphSQL(
       "SELECT from_node_id, to_node_id, relationship_name FROM graph_edges WHERE edge_id = :edge AND direction = 'inverse'",
       arguments: ["edge": .text(edge.id.rawValue)]

--- a/apps/enchiridion/Tests/EnchiridionCoreTests/GraphRepositoryTests.swift
+++ b/apps/enchiridion/Tests/EnchiridionCoreTests/GraphRepositoryTests.swift
@@ -90,6 +90,20 @@ final class GraphRepositoryTests: XCTestCase {
     XCTAssertFalse(compiled.sql.contains("FROM graph_nodes seed"))
   }
 
+  func testGraphQueryCompilerEscapesLiteralContainsAndSortsBooleanFacts() {
+    let predicate = PredicateID(rawValue: "predicate:test")
+    let definition = GraphQueryDefinition(
+      expression: .fact(predicate, .contains, .text(#"50%_off\today"#)),
+      sorts: [.init(key: .fact(predicate))]
+    )
+
+    let compiled = GraphQueryCompiler.compile(definition)
+
+    XCTAssertTrue(compiled.sql.contains("ESCAPE '\\'"))
+    XCTAssertTrue(compiled.sql.contains("fact.boolean_value"))
+    XCTAssertTrue(compiled.arguments.values.contains(.text(#"50\%\_off\\today"#)))
+  }
+
   func testMultipleInheritanceClosureIsQueryVisibleAndCyclesRollback() async throws {
     let fixture = try GraphRepositoryFixture(testCase: self)
     let company = try await fixture.repository.createTaggedPage(
@@ -114,6 +128,28 @@ final class GraphRepositoryTests: XCTestCase {
     }
     let persisted = try await fixture.repository.supertags().first { $0.id == parent.id }
     XCTAssertEqual(persisted?.parentIDs, [])
+  }
+
+  func testDeletingParentSupertagDoesNotBlockLaterSchemaWrites() async throws {
+    let fixture = try GraphRepositoryFixture(testCase: self)
+    var parent = SupertagDefinition.draft(name: "Parent")
+    var child = SupertagDefinition.draft(name: "Child")
+    child.parentIDs = [parent.id]
+    try await fixture.repository.saveSupertag(parent)
+    try await fixture.repository.saveSupertag(child)
+
+    parent.isDeleted = true
+    try await fixture.repository.saveSupertag(parent)
+    child.name = "Renamed Child"
+    try await fixture.repository.saveSupertag(child)
+
+    let page = try await fixture.repository.createTaggedPage(
+      title: "Child page",
+      supertagID: child.id
+    )
+    let effectiveTags = try await fixture.repository.effectiveTagIDs(for: page.id)
+    XCTAssertTrue(effectiveTags.contains(child.id))
+    XCTAssertFalse(effectiveTags.contains(parent.id))
   }
 
   func testCanonicalEdgeDrivesPropertyAdapterInverseBacklinkAndCardinality() async throws {
@@ -158,8 +194,9 @@ final class GraphRepositoryTests: XCTestCase {
       "SELECT from_node_id, to_node_id, relationship_name FROM graph_edges WHERE edge_id = :edge AND direction = 'inverse'",
       arguments: ["edge": .text(edge.id.rawValue)]
     )
-    XCTAssertEqual(inverse.value(column: "from_node_id", in: inverse.rows[0]), .text(firstProject.id.rawValue))
-    XCTAssertEqual(inverse.value(column: "relationship_name", in: inverse.rows[0]), .text("tasks"))
+    let inverseRow = try XCTUnwrap(inverse.rows.first)
+    XCTAssertEqual(inverse.value(column: "from_node_id", in: inverseRow), .text(firstProject.id.rawValue))
+    XCTAssertEqual(inverse.value(column: "relationship_name", in: inverseRow), .text("tasks"))
 
     await XCTAssertThrowsErrorAsync(
       try await fixture.repository.createEdge(
@@ -347,7 +384,8 @@ final class GraphRepositoryTests: XCTestCase {
       "SELECT node_id, title FROM graph_text_search WHERE graph_text_search MATCH :term",
       arguments: ["term": .text("backlinks")]
     )
-    XCTAssertEqual(search.value(column: "node_id", in: search.rows[0]), .text(task.id.rawValue))
+    let searchRow = try XCTUnwrap(search.rows.first)
+    XCTAssertEqual(search.value(column: "node_id", in: searchRow), .text(task.id.rawValue))
   }
 
   func testBuilderAndSQLSavedQueriesRoundTrip() async throws {
@@ -373,6 +411,24 @@ final class GraphRepositoryTests: XCTestCase {
     try await reopened.deleteGraphQuery(builder.id)
     let remainingQueries = try await reopened.savedGraphQueries()
     XCTAssertEqual(remainingQueries, [sql])
+  }
+
+  func testSavedQueryPresentationIsValidatedBeforePersistence() async throws {
+    let fixture = try GraphRepositoryFixture(testCase: self)
+    let query = SavedGraphQuery(
+      name: "Invalid list",
+      source: .sql("SELECT title FROM graph_nodes"),
+      presentation: .init(kind: .list)
+    )
+
+    await XCTAssertThrowsErrorAsync(try await fixture.repository.saveGraphQuery(query)) { error in
+      XCTAssertEqual(
+        error as? GraphQueryError,
+        .sqlite("This presentation requires a node_id column.")
+      )
+    }
+    let savedQueries = try await fixture.repository.savedGraphQueries()
+    XCTAssertTrue(savedQueries.isEmpty)
   }
 
   func testGraphMetadataCloudRoundTripPreservesDirtyLocalChangesAndTombstones() async throws {

--- a/apps/enchiridion/Tests/EnchiridionCoreTests/GraphRepositoryTests.swift
+++ b/apps/enchiridion/Tests/EnchiridionCoreTests/GraphRepositoryTests.swift
@@ -55,6 +55,13 @@ final class GraphRepositoryTests: XCTestCase {
     ) { error in
       XCTAssertEqual(error as? GraphQueryError, .multipleStatements)
     }
+    XCTAssertThrowsError(
+      try fixture.repository.runGraphSQL("SELECT * FROM 'graph_text_search_content'")
+    ) { error in
+      guard case .unauthorized = error as? GraphQueryError else {
+        return XCTFail("Expected an authorization error, got \(error)")
+      }
+    }
   }
 
   func testMultipleInheritanceClosureIsQueryVisibleAndCyclesRollback() async throws {
@@ -139,6 +146,57 @@ final class GraphRepositoryTests: XCTestCase {
     }
   }
 
+  func testEventReferencePropertiesRoundTripThroughCanonicalEdges() async throws {
+    let fixture = try GraphRepositoryFixture(testCase: self)
+    let event = try await fixture.repository.createTaggedPage(
+      title: "Graph review",
+      supertagID: BuiltInSupertags.event
+    )
+    let organizer = try await fixture.repository.createTaggedPage(
+      title: "Ada",
+      supertagID: BuiltInSupertags.person
+    )
+    let attendee = try await fixture.repository.createTaggedPage(
+      title: "Grace",
+      supertagID: BuiltInSupertags.person
+    )
+    let place = try await fixture.repository.createTaggedPage(
+      title: "Studio",
+      supertagID: BuiltInSupertags.place
+    )
+    let properties: [(String, [SupertagValue])] = [
+      ("organizer", [.page(organizer.id)]),
+      ("attendees", [.page(organizer.id), .page(attendee.id)]),
+      ("place", [.page(place.id)]),
+    ]
+
+    for (fieldID, values) in properties {
+      try await fixture.repository.setProperty(
+        pageID: event.id,
+        key: .init(
+          supertagID: BuiltInSupertags.event,
+          fieldID: .init(rawValue: fieldID)
+        ),
+        values: values
+      )
+    }
+
+    let reloadedPage = try await fixture.repository.page(id: event.id)
+    let reloaded = try XCTUnwrap(reloadedPage)
+    for (fieldID, values) in properties {
+      let key = SupertagPropertyKey(
+        supertagID: BuiltInSupertags.event,
+        fieldID: .init(rawValue: fieldID)
+      )
+      let reloadedValues = reloaded.objectMetadata.properties[key]
+      if values.count > 1 {
+        XCTAssertEqual(Set(reloadedValues ?? []), Set(values))
+      } else {
+        XCTAssertEqual(reloadedValues, values)
+      }
+    }
+  }
+
   func testConcurrentMaxOneEdgesArePreservedFlaggedAndExplicitlyResolved() async throws {
     let fixture = try GraphRepositoryFixture(testCase: self)
     let task = try await fixture.repository.createTaggedPage(
@@ -190,6 +248,39 @@ final class GraphRepositoryTests: XCTestCase {
     let resolvedIssues = try await fixture.repository.graphIssues()
     XCTAssertEqual(resolvedEdges, [firstEdge])
     XCTAssertTrue(resolvedIssues.isEmpty)
+  }
+
+  func testChangingRelationSourceConstraintProjectsAnIssueForExistingEdge() async throws {
+    let fixture = try GraphRepositoryFixture(testCase: self)
+    let task = try await fixture.repository.createTaggedPage(
+      title: "Prepare launch",
+      supertagID: BuiltInSupertags.task
+    )
+    let project = try await fixture.repository.createTaggedPage(
+      title: "Launch",
+      supertagID: BuiltInSupertags.project
+    )
+    var relation = RelationDefinition(
+      id: .random(),
+      sourceTagIDs: [BuiltInSupertags.task],
+      targetTagIDs: [BuiltInSupertags.project],
+      forwardName: "Contributes to",
+      inverseName: "Contributions"
+    )
+    try await fixture.repository.saveRelationDefinition(relation)
+    let edge = try await fixture.repository.createEdge(
+      relationID: relation.id,
+      from: task.id,
+      to: project.id
+    )
+
+    relation.sourceTagIDs = [BuiltInSupertags.person]
+    try await fixture.repository.saveRelationDefinition(relation)
+
+    let issues = try await fixture.repository.graphIssues()
+    XCTAssertTrue(issues.contains {
+      $0.kind == .invalidSourceType && $0.edgeID == edge.id && $0.relationID == relation.id
+    })
   }
 
   func testVisualQueryCompilerTraversesMultipleHopsAndSQLCanUseFTS() async throws {

--- a/apps/enchiridion/Tests/EnchiridionCoreTests/GraphRepositoryTests.swift
+++ b/apps/enchiridion/Tests/EnchiridionCoreTests/GraphRepositoryTests.swift
@@ -64,6 +64,32 @@ final class GraphRepositoryTests: XCTestCase {
     }
   }
 
+  func testDecodedAndCompiledGraphQueriesEnforceResourceBounds() throws {
+    var traversal = GraphTraversal()
+    traversal.minimumDepth = -100
+    traversal.maximumDepth = 10_000
+    let decodedTraversal = try JSONDecoder.enchiridion.decode(
+      GraphTraversal.self,
+      from: JSONEncoder.enchiridion.encode(traversal)
+    )
+    XCTAssertEqual(decodedTraversal.minimumDepth, 1)
+    XCTAssertEqual(decodedTraversal.maximumDepth, GraphTraversal.maximumAllowedDepth)
+
+    var definition = GraphQueryDefinition(expression: .traversal(traversal))
+    definition.limit = 100_000
+    let decodedDefinition = try JSONDecoder.enchiridion.decode(
+      GraphQueryDefinition.self,
+      from: JSONEncoder.enchiridion.encode(definition)
+    )
+    XCTAssertEqual(decodedDefinition.limit, GraphQueryDefinition.maximumAllowedLimit)
+
+    let compiled = GraphQueryCompiler.compile(definition)
+    XCTAssertTrue(compiled.sql.contains("walk.depth < 8"))
+    XCTAssertTrue(compiled.sql.contains("LIMIT 5000"))
+    XCTAssertTrue(compiled.sql.contains("SELECT node.node_id, 0"))
+    XCTAssertFalse(compiled.sql.contains("FROM graph_nodes seed"))
+  }
+
   func testMultipleInheritanceClosureIsQueryVisibleAndCyclesRollback() async throws {
     let fixture = try GraphRepositoryFixture(testCase: self)
     let company = try await fixture.repository.createTaggedPage(

--- a/apps/enchiridion/Tests/EnchiridionCoreTests/GraphRepositoryTests.swift
+++ b/apps/enchiridion/Tests/EnchiridionCoreTests/GraphRepositoryTests.swift
@@ -251,6 +251,11 @@ final class GraphRepositoryTests: XCTestCase {
 
     let savedQueries = try await reopened.savedGraphQueries()
     XCTAssertEqual(Set(savedQueries), Set([builder, sql]))
+
+    XCTAssertEqual(try reopened.runGraphQuery(sql).columns.map(\.name), ["count"])
+    try await reopened.deleteGraphQuery(builder.id)
+    let remainingQueries = try await reopened.savedGraphQueries()
+    XCTAssertEqual(remainingQueries, [sql])
   }
 }
 

--- a/apps/enchiridion/Tests/EnchiridionCoreTests/GraphRepositoryTests.swift
+++ b/apps/enchiridion/Tests/EnchiridionCoreTests/GraphRepositoryTests.swift
@@ -1,0 +1,273 @@
+import Foundation
+import XCTest
+@testable import EnchiridionCore
+
+final class GraphRepositoryTests: XCTestCase {
+  func testGraphProjectionExposesTypedFactsThroughReadOnlySQLite() async throws {
+    let fixture = try GraphRepositoryFixture(testCase: self)
+    let project = try await fixture.repository.createTaggedPage(
+      title: "Graph launch",
+      supertagID: BuiltInSupertags.project
+    )
+    try await fixture.repository.setProperty(
+      pageID: project.id,
+      key: ProjectFields.status,
+      values: [.select("active")]
+    )
+
+    let result = try fixture.repository.runGraphSQL(
+      """
+      SELECT node.node_id, node.title, fact.text_value AS status
+      FROM graph_nodes node
+      JOIN graph_facts fact ON fact.node_id = node.node_id
+      WHERE fact.predicate_id = :predicate
+      """,
+      arguments: [
+        "predicate": .text(
+          PredicateID.property(
+            tagID: BuiltInSupertags.project,
+            fieldID: ProjectFields.status.fieldID
+          ).rawValue
+        )
+      ]
+    )
+
+    XCTAssertEqual(result.rows.count, 1)
+    XCTAssertEqual(result.value(column: "node_id", in: result.rows[0]), .text(project.id.rawValue))
+    XCTAssertEqual(result.value(column: "status", in: result.rows[0]), .text("active"))
+    let facts = try await fixture.repository.graphFacts(for: project.id)
+    XCTAssertEqual(facts.first?.value, .select("active"))
+  }
+
+  func testSQLAuthorizerHidesPhysicalTablesAndRejectsWritesAndMultipleStatements() throws {
+    let fixture = try GraphRepositoryFixture(testCase: self)
+
+    XCTAssertThrowsError(try fixture.repository.runGraphSQL("SELECT * FROM pages")) { error in
+      guard case .unauthorized = error as? GraphQueryError else {
+        return XCTFail("Expected an authorization error, got \(error)")
+      }
+    }
+    XCTAssertThrowsError(try fixture.repository.runGraphSQL("DELETE FROM graph_nodes")) { error in
+      XCTAssertEqual(error as? GraphQueryError, .readOnlyRequired)
+    }
+    XCTAssertThrowsError(
+      try fixture.repository.runGraphSQL("SELECT * FROM graph_nodes; SELECT * FROM graph_tags")
+    ) { error in
+      XCTAssertEqual(error as? GraphQueryError, .multipleStatements)
+    }
+  }
+
+  func testMultipleInheritanceClosureIsQueryVisibleAndCyclesRollback() async throws {
+    let fixture = try GraphRepositoryFixture(testCase: self)
+    let company = try await fixture.repository.createTaggedPage(
+      title: "Acme",
+      supertagID: BuiltInSupertags.company
+    )
+    let effective = try await fixture.repository.effectiveTagIDs(for: company.id)
+    XCTAssertTrue(effective.isSuperset(of: [BuiltInSupertags.company, BuiltInSupertags.organization]))
+
+    let parent = SupertagDefinition.draft(name: "Parent")
+    var child = SupertagDefinition.draft(name: "Child")
+    child.parentIDs = [parent.id]
+    try await fixture.repository.saveSupertag(parent)
+    try await fixture.repository.saveSupertag(child)
+    var cyclicParent = parent
+    cyclicParent.parentIDs = [child.id]
+
+    await XCTAssertThrowsErrorAsync(try await fixture.repository.saveSupertag(cyclicParent)) { error in
+      guard case .inheritanceCycle = error as? GraphModelError else {
+        return XCTFail("Expected an inheritance cycle, got \(error)")
+      }
+    }
+    let persisted = try await fixture.repository.supertags().first { $0.id == parent.id }
+    XCTAssertEqual(persisted?.parentIDs, [])
+  }
+
+  func testCanonicalEdgeDrivesPropertyAdapterInverseBacklinkAndCardinality() async throws {
+    let fixture = try GraphRepositoryFixture(testCase: self)
+    let task = try await fixture.repository.createTaggedPage(
+      title: "Ship graph",
+      supertagID: BuiltInSupertags.task
+    )
+    let firstProject = try await fixture.repository.createTaggedPage(
+      title: "Graph V2",
+      supertagID: BuiltInSupertags.project
+    )
+    let secondProject = try await fixture.repository.createTaggedPage(
+      title: "Other",
+      supertagID: BuiltInSupertags.project
+    )
+
+    let edge = try await fixture.repository.createEdge(
+      relationID: BuiltInRelations.taskProject,
+      from: task.id,
+      to: firstProject.id
+    )
+    let reloadedTask = try await fixture.repository.page(id: task.id)
+    XCTAssertEqual(
+      reloadedTask?.objectMetadata.properties[TaskFields.project],
+      [.page(firstProject.id)]
+    )
+    let outgoingEdges = try await fixture.repository.outgoingEdges(from: task.id)
+    let backlinks = try await fixture.repository.graphBacklinks(to: firstProject.id)
+    XCTAssertEqual(outgoingEdges, [edge])
+    XCTAssertEqual(backlinks.map(\.edge), [edge])
+
+    let inverse = try fixture.repository.runGraphSQL(
+      "SELECT from_node_id, to_node_id, relationship_name FROM graph_edges WHERE edge_id = :edge AND direction = 'inverse'",
+      arguments: ["edge": .text(edge.id.rawValue)]
+    )
+    XCTAssertEqual(inverse.value(column: "from_node_id", in: inverse.rows[0]), .text(firstProject.id.rawValue))
+    XCTAssertEqual(inverse.value(column: "relationship_name", in: inverse.rows[0]), .text("tasks"))
+
+    await XCTAssertThrowsErrorAsync(
+      try await fixture.repository.createEdge(
+        relationID: BuiltInRelations.taskProject,
+        from: task.id,
+        to: secondProject.id
+      )
+    ) { error in
+      XCTAssertEqual(error as? GraphModelError, .cardinalityViolation(BuiltInRelations.taskProject))
+    }
+  }
+
+  func testConcurrentMaxOneEdgesArePreservedFlaggedAndExplicitlyResolved() async throws {
+    let fixture = try GraphRepositoryFixture(testCase: self)
+    let task = try await fixture.repository.createTaggedPage(
+      title: "Concurrent task",
+      supertagID: BuiltInSupertags.task
+    )
+    let firstProject = try await fixture.repository.createTaggedPage(
+      title: "First",
+      supertagID: BuiltInSupertags.project
+    )
+    let secondProject = try await fixture.repository.createTaggedPage(
+      title: "Second",
+      supertagID: BuiltInSupertags.project
+    )
+    let firstEdge = KnowledgeEdge(
+      relationID: BuiltInRelations.taskProject,
+      sourceNodeID: task.id,
+      targetNodeID: firstProject.id
+    )
+    let secondEdge = KnowledgeEdge(
+      relationID: BuiltInRelations.taskProject,
+      sourceNodeID: task.id,
+      targetNodeID: secondProject.id
+    )
+    let first = try PageDocument.upsertEdge(firstEdge, in: task.document)
+    let second = try PageDocument.upsertEdge(secondEdge, in: task.document)
+    let mergedDocument = try PageDocument.merge(
+      local: first.document,
+      remote: second.document,
+      pageID: task.id
+    )
+    _ = try await fixture.repository.mergeCloudPage(
+      pageID: task.id,
+      kind: task.kind,
+      remoteDocument: mergedDocument.document,
+      systemFields: Data([1])
+    )
+
+    let conflictedEdges = try await fixture.repository.outgoingEdges(from: task.id)
+    let conflictIssues = try await fixture.repository.graphIssues()
+    XCTAssertEqual(conflictedEdges.count, 2)
+    XCTAssertEqual(conflictIssues.filter { $0.kind == .cardinalityViolation }.count, 2)
+
+    try await fixture.repository.resolveCardinalityConflict(
+      relationID: BuiltInRelations.taskProject,
+      keeping: firstEdge.id
+    )
+    let resolvedEdges = try await fixture.repository.outgoingEdges(from: task.id)
+    let resolvedIssues = try await fixture.repository.graphIssues()
+    XCTAssertEqual(resolvedEdges, [firstEdge])
+    XCTAssertTrue(resolvedIssues.isEmpty)
+  }
+
+  func testVisualQueryCompilerTraversesMultipleHopsAndSQLCanUseFTS() async throws {
+    let fixture = try GraphRepositoryFixture(testCase: self)
+    let area = try await fixture.repository.createTaggedPage(
+      title: "Product",
+      supertagID: BuiltInSupertags.area
+    )
+    let project = try await fixture.repository.createTaggedPage(
+      title: "Knowledge graph",
+      supertagID: BuiltInSupertags.project
+    )
+    let task = try await fixture.repository.createTaggedPage(
+      title: "Model backlinks",
+      supertagID: BuiltInSupertags.task
+    )
+    _ = try await fixture.repository.createEdge(
+      relationID: BuiltInRelations.projectArea,
+      from: project.id,
+      to: area.id
+    )
+    _ = try await fixture.repository.createEdge(
+      relationID: BuiltInRelations.taskProject,
+      from: task.id,
+      to: project.id
+    )
+
+    let query = GraphQueryDefinition(
+      expression: .and([
+        .tag(BuiltInSupertags.task),
+        .traversal(.init(maximumDepth: 2, targetTagID: BuiltInSupertags.area)),
+      ])
+    )
+    let result = try fixture.repository.runGraphQuery(query)
+    XCTAssertEqual(result.rows.compactMap { result.value(column: "node_id", in: $0) }, [.text(task.id.rawValue)])
+
+    let search = try fixture.repository.runGraphSQL(
+      "SELECT node_id, title FROM graph_text_search WHERE graph_text_search MATCH :term",
+      arguments: ["term": .text("backlinks")]
+    )
+    XCTAssertEqual(search.value(column: "node_id", in: search.rows[0]), .text(task.id.rawValue))
+  }
+
+  func testBuilderAndSQLSavedQueriesRoundTrip() async throws {
+    let fixture = try GraphRepositoryFixture(testCase: self)
+    let builder = SavedGraphQuery(
+      name: "Tasks",
+      source: .builder(.init(expression: .tag(BuiltInSupertags.task)))
+    )
+    let sql = SavedGraphQuery(
+      name: "Counts",
+      source: .sql("SELECT COUNT(*) AS count FROM graph_nodes"),
+      presentation: .init(kind: .table)
+    )
+
+    try await fixture.repository.saveGraphQuery(builder)
+    try await fixture.repository.saveGraphQuery(sql)
+    let reopened = try LibraryRepository(path: fixture.path)
+
+    let savedQueries = try await reopened.savedGraphQueries()
+    XCTAssertEqual(Set(savedQueries), Set([builder, sql]))
+  }
+}
+
+private struct GraphRepositoryFixture {
+  let path: String
+  let repository: LibraryRepository
+
+  init(testCase: XCTestCase) throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("GraphRepositoryTests-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    testCase.addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+    path = directory.appendingPathComponent("graph.sqlite").path
+    repository = try LibraryRepository(path: path)
+  }
+}
+
+private func XCTAssertThrowsErrorAsync<T>(
+  _ expression: @autoclosure () async throws -> T,
+  _ errorHandler: (Error) -> Void = { _ in }
+) async {
+  do {
+    _ = try await expression()
+    XCTFail("Expected expression to throw")
+  } catch {
+    errorHandler(error)
+  }
+}

--- a/apps/enchiridion/Tests/EnchiridionCoreTests/GraphRepositoryTests.swift
+++ b/apps/enchiridion/Tests/EnchiridionCoreTests/GraphRepositoryTests.swift
@@ -257,6 +257,109 @@ final class GraphRepositoryTests: XCTestCase {
     let remainingQueries = try await reopened.savedGraphQueries()
     XCTAssertEqual(remainingQueries, [sql])
   }
+
+  func testGraphMetadataCloudRoundTripPreservesDirtyLocalChangesAndTombstones() async throws {
+    let source = try GraphRepositoryFixture(testCase: self)
+    var relation = RelationDefinition(
+      id: .random(),
+      forwardName: "Mentors",
+      inverseName: "Mentored by"
+    )
+    var query = SavedGraphQuery(
+      name: "Mentorship",
+      source: .sql("SELECT node_id, title FROM graph_nodes")
+    )
+    try await source.repository.saveRelationDefinition(
+      relation,
+      now: Date(timeIntervalSince1970: 10)
+    )
+    try await source.repository.saveGraphQuery(query, now: Date(timeIntervalSince1970: 10))
+
+    let loadedRelationRecord = try await source.repository.relationDefinitionCloudRecord(
+      id: relation.id
+    )
+    let loadedQueryRecord = try await source.repository.savedGraphQueryCloudRecord(id: query.id)
+    let relationRecord = try XCTUnwrap(loadedRelationRecord)
+    let queryRecord = try XCTUnwrap(loadedQueryRecord)
+
+    relation.forwardName = "Coaches"
+    query.name = "Coaching"
+    try await source.repository.saveRelationDefinition(
+      relation,
+      now: Date(timeIntervalSince1970: 20)
+    )
+    try await source.repository.saveGraphQuery(query, now: Date(timeIntervalSince1970: 20))
+    let relationStillDirty = try await source.repository.markRelationDefinitionCloudSaved(
+      id: relation.id,
+      sentGeneration: relationRecord.dirtyGeneration,
+      systemFields: Data([1])
+    )
+    let queryStillDirty = try await source.repository.markGraphQueryCloudSaved(
+      id: query.id,
+      sentGeneration: queryRecord.dirtyGeneration,
+      systemFields: Data([2])
+    )
+    XCTAssertTrue(relationStillDirty)
+    XCTAssertTrue(queryStillDirty)
+
+    let target = try GraphRepositoryFixture(testCase: self)
+    let relationNeedsUpload = try await target.repository.mergeCloudRelationDefinition(
+      id: relationRecord.definition.id,
+      definition: relationRecord.definition,
+      isDeleted: relationRecord.definition.isDeleted,
+      modifiedAt: relationRecord.modifiedAt,
+      dirtyGeneration: relationRecord.dirtyGeneration,
+      systemFields: Data([3])
+    )
+    let queryNeedsUpload = try await target.repository.mergeCloudGraphQuery(
+      id: queryRecord.query.id,
+      query: queryRecord.query,
+      isDeleted: queryRecord.isDeleted,
+      sortOrder: queryRecord.sortOrder,
+      modifiedAt: queryRecord.modifiedAt,
+      dirtyGeneration: queryRecord.dirtyGeneration,
+      systemFields: Data([4])
+    )
+    let dirtyRelations = try await target.repository.dirtyRelationDefinitions()
+    let dirtyQueries = try await target.repository.dirtyGraphQueries()
+    let targetRelations = try await target.repository.relationDefinitions()
+    let targetQueries = try await target.repository.savedGraphQueries()
+    XCTAssertFalse(relationNeedsUpload)
+    XCTAssertFalse(queryNeedsUpload)
+    XCTAssertTrue(dirtyRelations.isEmpty)
+    XCTAssertTrue(dirtyQueries.isEmpty)
+    XCTAssertTrue(targetRelations.contains {
+      $0.id == relationRecord.definition.id
+    })
+    XCTAssertEqual(targetQueries, [queryRecord.query])
+
+    let relationDeletionNeedsUpload = try await target.repository.applyCloudRelationDefinitionRecordDeletion(
+      id: relationRecord.definition.id
+    )
+    let queryDeletionNeedsUpload = try await target.repository.applyCloudGraphQueryRecordDeletion(
+      id: queryRecord.query.id
+    )
+    let remainingRelations = try await target.repository.relationDefinitions()
+    let remainingQueries = try await target.repository.savedGraphQueries()
+    XCTAssertFalse(relationDeletionNeedsUpload)
+    XCTAssertFalse(queryDeletionNeedsUpload)
+    XCTAssertFalse(remainingRelations.contains {
+      $0.id == relationRecord.definition.id
+    })
+    XCTAssertTrue(remainingQueries.isEmpty)
+
+    try await target.repository.markAllCloudDataForZoneRecovery()
+    let recoveredRelations = try await target.repository.dirtyRelationDefinitions()
+    let recoveredQueries = try await target.repository.dirtyGraphQueries()
+    XCTAssertEqual(
+      recoveredRelations.map(\.definition.id),
+      [relationRecord.definition.id]
+    )
+    XCTAssertEqual(
+      recoveredQueries.map(\.query.id),
+      [queryRecord.query.id]
+    )
+  }
 }
 
 private struct GraphRepositoryFixture {

--- a/apps/enchiridion/Tests/EnchiridionCoreTests/LibraryStoreTests.swift
+++ b/apps/enchiridion/Tests/EnchiridionCoreTests/LibraryStoreTests.swift
@@ -62,7 +62,7 @@ final class LibraryRepositoryTests: XCTestCase {
   func testTaskMutationReloadSkipsFullSystemReconciliation() async throws {
     let fixture = try RepositoryFixture()
     let probe = StoreReconciliationProbe()
-    let reconciliationCoordinator = TaskSystemReconciliationCoordinator { pages in
+    let reconciliationCoordinator = TaskSystemReconciliationCoordinator { _, pages in
       await probe.record(pages)
     }
     let store = LibraryStore(
@@ -85,7 +85,7 @@ final class LibraryRepositoryTests: XCTestCase {
     let fixture = try RepositoryFixture()
     let task = try await fixture.repository.createTask(TaskDraft(title: "Reconcile refresh"))
     let probe = StoreReconciliationProbe()
-    let reconciliationCoordinator = TaskSystemReconciliationCoordinator { pages in
+    let reconciliationCoordinator = TaskSystemReconciliationCoordinator { _, pages in
       await probe.record(pages)
     }
     let store = LibraryStore(

--- a/apps/enchiridion/Tests/EnchiridionCoreTests/TaskBatchMutationTests.swift
+++ b/apps/enchiridion/Tests/EnchiridionCoreTests/TaskBatchMutationTests.swift
@@ -599,11 +599,11 @@ final class TaskBatchMutationTests: XCTestCase {
     XCTAssertEqual(added.tasks[1].taskData?.tags, ["alpha", "beta", "common", "shared"])
     XCTAssertEqual(
       added.tasks[0].taskData?.assigneeIDs,
-      [firstPerson.id, sharedPerson.id]
+      TaskData.normalizedPageIDs([firstPerson.id, sharedPerson.id])
     )
     XCTAssertEqual(
       added.tasks[1].taskData?.assigneeIDs,
-      [secondPerson.id, sharedPerson.id]
+      TaskData.normalizedPageIDs([secondPerson.id, sharedPerson.id])
     )
 
     let addUndo = try await fixture.repository.undoTaskBatch(added.undoReceipt)

--- a/apps/enchiridion/Tests/EnchiridionCoreTests/TaskDeepLinkRouteTests.swift
+++ b/apps/enchiridion/Tests/EnchiridionCoreTests/TaskDeepLinkRouteTests.swift
@@ -4,43 +4,53 @@ import XCTest
 @testable import EnchiridionCore
 
 final class TaskDeepLinkRouteTests: XCTestCase {
+  private let vaultID = VaultID(rawValue: "vault_personal")
+
   func testRoutesEverySmartList() throws {
     for list in TaskSmartList.allCases {
-      let url = try XCTUnwrap(URL(string: "enchiridion://tasks/\(list.rawValue)"))
-      XCTAssertEqual(TaskDeepLinkRoute(url: url), .list(list))
+      let url = try XCTUnwrap(
+        URL(string: "enchiridion://tasks/\(list.rawValue)?vault=\(vaultID.rawValue)")
+      )
+      XCTAssertEqual(TaskDeepLinkRoute(url: url), .list(list, vaultID: vaultID))
     }
   }
 
   func testTaskRoutePreservesItsFallbackList() throws {
-    let url = try XCTUnwrap(URL(string: "enchiridion://tasks/upcoming?task=task-123"))
+    let url = try XCTUnwrap(
+      URL(string: "enchiridion://tasks/upcoming?vault=\(vaultID.rawValue)&task=task-123")
+    )
 
     XCTAssertEqual(
       TaskDeepLinkRoute(url: url),
-      .task(PageID(rawValue: "task-123"), list: .upcoming)
+      .task(scoped("task-123"), list: .upcoming)
     )
   }
 
   func testQuickAddRouteUsesTheRequestedList() throws {
-    let url = try XCTUnwrap(URL(string: "enchiridion://tasks/inbox?quickAdd=1"))
+    let url = try XCTUnwrap(
+      URL(string: "enchiridion://tasks/inbox?vault=\(vaultID.rawValue)&quickAdd=1")
+    )
 
-    XCTAssertEqual(TaskDeepLinkRoute(url: url), .quickAdd(.inbox))
+    XCTAssertEqual(TaskDeepLinkRoute(url: url), .quickAdd(.inbox, vaultID: vaultID))
   }
 
   func testExactTaskTakesPrecedenceOverQuickAdd() throws {
     let url = try XCTUnwrap(
-      URL(string: "enchiridion://tasks/today?quickAdd=1&task=task-123")
+      URL(
+        string: "enchiridion://tasks/today?vault=\(vaultID.rawValue)&quickAdd=1&task=task-123"
+      )
     )
 
     XCTAssertEqual(
       TaskDeepLinkRoute(url: url),
-      .task(PageID(rawValue: "task-123"), list: .today)
+      .task(scoped("task-123"), list: .today)
     )
   }
 
   func testEmptyPathDefaultsToInbox() throws {
-    let url = try XCTUnwrap(URL(string: "enchiridion://tasks"))
+    let url = try XCTUnwrap(URL(string: "enchiridion://tasks?vault=\(vaultID.rawValue)"))
 
-    XCTAssertEqual(TaskDeepLinkRoute(url: url), .list(.inbox))
+    XCTAssertEqual(TaskDeepLinkRoute(url: url), .list(.inbox, vaultID: vaultID))
   }
 
   func testRejectsForeignAndMalformedRoutes() throws {
@@ -49,6 +59,7 @@ final class TaskDeepLinkRouteTests: XCTestCase {
       XCTUnwrap(URL(string: "enchiridion://calendar/today")),
       XCTUnwrap(URL(string: "enchiridion://tasks/unknown")),
       XCTUnwrap(URL(string: "enchiridion://tasks/today/extra")),
+      XCTUnwrap(URL(string: "enchiridion://tasks/today")),
     ]
 
     for url in routes {
@@ -57,36 +68,38 @@ final class TaskDeepLinkRouteTests: XCTestCase {
   }
 
   func testEmptyTaskIdentifierFallsBackToTheListRoute() throws {
-    let url = try XCTUnwrap(URL(string: "enchiridion://tasks/today?task=%20%20"))
+    let url = try XCTUnwrap(
+      URL(string: "enchiridion://tasks/today?vault=\(vaultID.rawValue)&task=%20%20")
+    )
 
-    XCTAssertEqual(TaskDeepLinkRoute(url: url), .list(.today))
+    XCTAssertEqual(TaskDeepLinkRoute(url: url), .list(.today, vaultID: vaultID))
   }
 
   func testValidTaskSurvivesStoreValidation() {
     let pageID = PageID(rawValue: "task-123")
-    let route = TaskDeepLinkRoute.task(pageID, list: .today)
+    let route = TaskDeepLinkRoute.task(scoped(pageID.rawValue), list: .today)
 
     XCTAssertEqual(route.validated(against: [page(id: pageID, isTask: true)]), route)
   }
 
   func testMissingAndNonTaskPagesFallBackToTheRequestedList() {
     let pageID = PageID(rawValue: "task-123")
-    let route = TaskDeepLinkRoute.task(pageID, list: .upcoming)
+    let route = TaskDeepLinkRoute.task(scoped(pageID.rawValue), list: .upcoming)
 
-    XCTAssertEqual(route.validated(against: []), .list(.upcoming))
+    XCTAssertEqual(route.validated(against: []), .list(.upcoming, vaultID: vaultID))
     XCTAssertEqual(
       route.validated(against: [page(id: pageID, isTask: false)]),
-      .list(.upcoming)
+      .list(.upcoming, vaultID: vaultID)
     )
   }
 
   func testDeletedTaskFallsBackToTheRequestedList() {
     let pageID = PageID(rawValue: "task-123")
-    let route = TaskDeepLinkRoute.task(pageID, list: .today)
+    let route = TaskDeepLinkRoute.task(scoped(pageID.rawValue), list: .today)
 
     XCTAssertEqual(
       route.validated(against: [page(id: pageID, isTask: true, isDeleted: true)]),
-      .list(.today)
+      .list(.today, vaultID: vaultID)
     )
   }
 
@@ -103,5 +116,9 @@ final class TaskDeepLinkRouteTests: XCTestCase {
       deletedAt: isDeleted ? .distantPast : nil,
       objectMetadata: .init(supertagIDs: isTask ? [BuiltInSupertags.task] : [])
     )
+  }
+
+  private func scoped(_ pageID: String) -> VaultScopedNodeID {
+    .init(vaultID: vaultID, nodeID: .init(rawValue: pageID))
   }
 }

--- a/apps/enchiridion/Tests/EnchiridionCoreTests/TaskDeepLinkRouteTests.swift
+++ b/apps/enchiridion/Tests/EnchiridionCoreTests/TaskDeepLinkRouteTests.swift
@@ -53,13 +53,22 @@ final class TaskDeepLinkRouteTests: XCTestCase {
     XCTAssertEqual(TaskDeepLinkRoute(url: url), .list(.inbox, vaultID: vaultID))
   }
 
+  func testLegacyRouteWithoutVaultDefaultsToPersonal() throws {
+    let url = try XCTUnwrap(URL(string: "enchiridion://tasks/today?task=task-123"))
+
+    XCTAssertEqual(
+      TaskDeepLinkRoute(url: url),
+      .task(scoped("task-123"), list: .today)
+    )
+  }
+
   func testRejectsForeignAndMalformedRoutes() throws {
     let routes = try [
       XCTUnwrap(URL(string: "https://tasks/today")),
       XCTUnwrap(URL(string: "enchiridion://calendar/today")),
       XCTUnwrap(URL(string: "enchiridion://tasks/unknown")),
       XCTUnwrap(URL(string: "enchiridion://tasks/today/extra")),
-      XCTUnwrap(URL(string: "enchiridion://tasks/today")),
+      XCTUnwrap(URL(string: "enchiridion://tasks/today?vault=personal")),
     ]
 
     for url in routes {

--- a/apps/enchiridion/Tests/EnchiridionCoreTests/TaskReminderSchedulerTests.swift
+++ b/apps/enchiridion/Tests/EnchiridionCoreTests/TaskReminderSchedulerTests.swift
@@ -4,32 +4,43 @@ import XCTest
 @testable import EnchiridionCore
 
 final class TaskReminderSchedulerTests: XCTestCase {
+  private let vaultID = VaultID(rawValue: "vault_personal")
+
   func testRouteMapsNotificationActionsToTheExactTask() {
     let pageID = PageID(rawValue: "task-123")
     let route = TaskReminderScheduler.route(
       actionIdentifier: TaskReminderAction.complete.notificationActionIdentifier,
-      userInfo: [TaskReminderScheduler.pageIDUserInfoKey: pageID.rawValue]
+      userInfo: [
+        TaskReminderScheduler.pageIDUserInfoKey: pageID.rawValue,
+        TaskReminderScheduler.vaultIDUserInfoKey: vaultID.rawValue,
+      ]
     )
 
-    XCTAssertEqual(route, .init(pageID: pageID, action: .complete))
+    XCTAssertEqual(route, .init(identity: scoped(pageID), action: .complete))
   }
 
   func testDefaultNotificationTapOpensTheExactTask() {
     let pageID = PageID(rawValue: "task-123")
     let route = TaskReminderScheduler.route(
       actionIdentifier: "default",
-      userInfo: [TaskReminderScheduler.pageIDUserInfoKey: pageID.rawValue],
+      userInfo: [
+        TaskReminderScheduler.pageIDUserInfoKey: pageID.rawValue,
+        TaskReminderScheduler.vaultIDUserInfoKey: vaultID.rawValue,
+      ],
       defaultActionIdentifier: "default"
     )
 
-    XCTAssertEqual(route, .init(pageID: pageID, action: .open))
+    XCTAssertEqual(route, .init(identity: scoped(pageID), action: .open))
   }
 
   func testRouteRejectsUnknownActionsAndMissingTaskIDs() {
     XCTAssertNil(
       TaskReminderScheduler.route(
         actionIdentifier: "unexpected",
-        userInfo: [TaskReminderScheduler.pageIDUserInfoKey: "task-123"]
+        userInfo: [
+          TaskReminderScheduler.pageIDUserInfoKey: "task-123",
+          TaskReminderScheduler.vaultIDUserInfoKey: vaultID.rawValue,
+        ]
       ))
     XCTAssertNil(
       TaskReminderScheduler.route(
@@ -42,18 +53,22 @@ final class TaskReminderSchedulerTests: XCTestCase {
     let pageID = PageID(rawValue: "task-123")
     let now = Date(timeIntervalSince1970: 1_817_000_000)
     let plan = TaskReminderActionPlan.make(
-      route: .init(pageID: pageID, action: .snooze),
+      route: .init(identity: scoped(pageID), action: .snooze),
       now: now,
       snoozeInterval: 15 * 60
     )
 
-    XCTAssertEqual(plan, .snooze(pageID, until: now.addingTimeInterval(15 * 60)))
+    XCTAssertEqual(plan, .snooze(scoped(pageID), until: now.addingTimeInterval(15 * 60)))
   }
 
   func testTaskURLRoutesToTheExactTask() throws {
     let pageID = PageID(rawValue: "task-123")
-    let url = try XCTUnwrap(TaskReminderScheduler.taskURL(for: pageID))
+    let url = try XCTUnwrap(TaskReminderScheduler.taskURL(for: scoped(pageID)))
 
-    XCTAssertEqual(TaskDeepLinkRoute(url: url), .task(pageID, list: .today))
+    XCTAssertEqual(TaskDeepLinkRoute(url: url), .task(scoped(pageID), list: .today))
+  }
+
+  private func scoped(_ pageID: PageID) -> VaultScopedNodeID {
+    .init(vaultID: vaultID, nodeID: pageID)
   }
 }

--- a/apps/enchiridion/Tests/EnchiridionCoreTests/TaskSystemCaptureTests.swift
+++ b/apps/enchiridion/Tests/EnchiridionCoreTests/TaskSystemCaptureTests.swift
@@ -36,12 +36,16 @@ final class TaskSystemCaptureTests: XCTestCase {
 
   func testSpotlightUsesOneStableIdentifierAndRoutesToTheExactTask() throws {
     let pageID = PageID(rawValue: "spotlight-task")
+    let identity = VaultScopedNodeID(
+      vaultID: .init(rawValue: "vault_personal"),
+      nodeID: pageID
+    )
 
-    XCTAssertEqual(TaskSystemSpotlight.searchableIdentifier(for: pageID), pageID.rawValue)
-    let url = try XCTUnwrap(TaskSystemSpotlight.contentURL(for: pageID))
+    XCTAssertEqual(TaskSystemSpotlight.searchableIdentifier(for: identity), identity.id)
+    let url = try XCTUnwrap(TaskSystemSpotlight.contentURL(for: identity))
     XCTAssertEqual(
       TaskDeepLinkRoute(url: url),
-      .task(pageID, list: .today)
+      .task(identity, list: .today)
     )
   }
 

--- a/apps/enchiridion/Tests/EnchiridionCoreTests/TaskSystemCoordinationTests.swift
+++ b/apps/enchiridion/Tests/EnchiridionCoreTests/TaskSystemCoordinationTests.swift
@@ -110,6 +110,27 @@ final class TaskSystemCoordinationTests: XCTestCase {
     XCTAssertEqual(snapshot.maximumConcurrentOperations, 1)
   }
 
+  func testReconciliationRetainsPendingSnapshotsForEveryVault() async {
+    let gate = OneShotGate()
+    let probe = MultiVaultReconciliationProbe(gate: gate)
+    let coordinator = TaskSystemReconciliationCoordinator { vaultID, pages in
+      await probe.reconcile(vaultID: vaultID, pages: pages)
+    }
+    let firstVault = VaultID(rawValue: "vault-a")
+    let secondVault = VaultID(rawValue: "vault-b")
+    let thirdVault = VaultID(rawValue: "vault-c")
+
+    await coordinator.submit(vaultID: firstVault, pages: [page("a")])
+    await gate.waitUntilEntered()
+    await coordinator.submit(vaultID: secondVault, pages: [page("b")])
+    await coordinator.submit(vaultID: thirdVault, pages: [page("c")])
+    await gate.release()
+    await coordinator.waitUntilIdle()
+
+    let reconciledVaultIDs = await probe.vaultIDs()
+    XCTAssertEqual(reconciledVaultIDs, [firstVault, secondVault, thirdVault])
+  }
+
   private func scoped(_ pageID: PageID) -> VaultScopedNodeID {
     .init(vaultID: vaultID, nodeID: pageID)
   }
@@ -203,6 +224,24 @@ private actor OneShotGate {
     let waiters = releaseWaiters
     releaseWaiters.removeAll()
     for waiter in waiters { waiter.resume() }
+  }
+}
+
+private actor MultiVaultReconciliationProbe {
+  private let gate: OneShotGate
+  private var reconciledVaultIDs: [VaultID] = []
+
+  init(gate: OneShotGate) {
+    self.gate = gate
+  }
+
+  func reconcile(vaultID: VaultID, pages: [PageSnapshot]) async {
+    if reconciledVaultIDs.isEmpty { await gate.enterAndWait() }
+    reconciledVaultIDs.append(vaultID)
+  }
+
+  func vaultIDs() -> [VaultID] {
+    reconciledVaultIDs
   }
 }
 

--- a/apps/enchiridion/Tests/EnchiridionCoreTests/TaskSystemCoordinationTests.swift
+++ b/apps/enchiridion/Tests/EnchiridionCoreTests/TaskSystemCoordinationTests.swift
@@ -5,10 +5,12 @@ import XCTest
 
 @MainActor
 final class TaskSystemCoordinationTests: XCTestCase {
+  private let vaultID = VaultID(rawValue: "vault_personal")
+
   func testColdLaunchDeliversExactTaskAfterFreshRead() async {
     let coordinator = TaskSystemHandoffCoordinator()
     let task = page("cold-launch")
-    let route = TaskDeepLinkRoute.task(task.id, list: .today)
+    let route = TaskDeepLinkRoute.task(scoped(task.id), list: .today)
 
     let outcome = await coordinator.open(route) { [task] in [task] }
 
@@ -20,7 +22,7 @@ final class TaskSystemCoordinationTests: XCTestCase {
     let coordinator = TaskSystemHandoffCoordinator()
     let gate = OneShotGate()
     let task = page("activation-url")
-    let route = TaskDeepLinkRoute.task(task.id, list: .inbox)
+    let route = TaskDeepLinkRoute.task(scoped(task.id), list: .inbox)
 
     let urlRequest = Task {
       await coordinator.open(route) { [task] in
@@ -49,8 +51,8 @@ final class TaskSystemCoordinationTests: XCTestCase {
     let firstTask = page("first")
     let secondTask = page("second")
     let pages = [firstTask, secondTask]
-    let firstRoute = TaskDeepLinkRoute.task(firstTask.id, list: .today)
-    let secondRoute = TaskDeepLinkRoute.task(secondTask.id, list: .upcoming)
+    let firstRoute = TaskDeepLinkRoute.task(scoped(firstTask.id), list: .today)
+    let secondRoute = TaskDeepLinkRoute.task(scoped(secondTask.id), list: .upcoming)
 
     let firstRequest = Task {
       await coordinator.open(firstRoute) { [pages] in
@@ -76,7 +78,7 @@ final class TaskSystemCoordinationTests: XCTestCase {
   func testFailedRefreshKeepsExactRoutePendingForNextSuccessfulActivation() async {
     let coordinator = TaskSystemHandoffCoordinator()
     let task = page("retry-after-refresh")
-    let route = TaskDeepLinkRoute.task(task.id, list: .today)
+    let route = TaskDeepLinkRoute.task(scoped(task.id), list: .today)
 
     let failedOutcome = await coordinator.open(route) { nil }
     let recoveredOutcome = await coordinator.activate { [task] in [task] }
@@ -89,23 +91,27 @@ final class TaskSystemCoordinationTests: XCTestCase {
   func testReconciliationIsSerializedAndCoalescesToLatestSnapshot() async {
     let gate = OneShotGate()
     let probe = ReconciliationProbe(gate: gate)
-    let coordinator = TaskSystemReconciliationCoordinator { pages in
+    let coordinator = TaskSystemReconciliationCoordinator { _, pages in
       await probe.reconcile(pages)
     }
     let first = page("first")
     let middle = page("middle")
     let latest = page("latest")
 
-    await coordinator.submit([first])
+    await coordinator.submit(vaultID: vaultID, pages: [first])
     await gate.waitUntilEntered()
-    await coordinator.submit([middle])
-    await coordinator.submit([latest])
+    await coordinator.submit(vaultID: vaultID, pages: [middle])
+    await coordinator.submit(vaultID: vaultID, pages: [latest])
     await gate.release()
     await coordinator.waitUntilIdle()
 
     let snapshot = await probe.snapshot()
     XCTAssertEqual(snapshot.calls, [[first.id], [latest.id]])
     XCTAssertEqual(snapshot.maximumConcurrentOperations, 1)
+  }
+
+  private func scoped(_ pageID: PageID) -> VaultScopedNodeID {
+    .init(vaultID: vaultID, nodeID: pageID)
   }
 
   func testExclusiveOperationLaneDoesNotReenterAcrossSuspension() async {

--- a/apps/enchiridion/Tests/EnchiridionCoreTests/VaultRegistryTests.swift
+++ b/apps/enchiridion/Tests/EnchiridionCoreTests/VaultRegistryTests.swift
@@ -8,7 +8,9 @@ final class VaultRegistryTests: XCTestCase {
     let snapshot = try fixture.registry.snapshot()
 
     XCTAssertEqual(snapshot.vaults.map(\.name), ["Personal"])
+    XCTAssertEqual(snapshot.vaults.map(\.id), [.personal])
     XCTAssertEqual(snapshot.selectedVaultID, snapshot.defaultCaptureVaultID)
+    XCTAssertEqual(snapshot.vaults[0].cloudZoneName, "EnchiridionGraph-vault_personal")
     XCTAssertEqual(
       URL(fileURLWithPath: try fixture.registry.graphPath(selection: .selected)).lastPathComponent,
       "graph.sqlite"

--- a/apps/enchiridion/Tests/EnchiridionCoreTests/VaultRegistryTests.swift
+++ b/apps/enchiridion/Tests/EnchiridionCoreTests/VaultRegistryTests.swift
@@ -10,7 +10,7 @@ final class VaultRegistryTests: XCTestCase {
     XCTAssertEqual(snapshot.vaults.map(\.name), ["Personal"])
     XCTAssertEqual(snapshot.vaults.map(\.id), [.personal])
     XCTAssertEqual(snapshot.selectedVaultID, snapshot.defaultCaptureVaultID)
-    XCTAssertEqual(snapshot.vaults[0].cloudZoneName, "EnchiridionGraph-vault_personal")
+    XCTAssertEqual(snapshot.vaults[0].cloudZoneName, "EnchiridionVault")
     XCTAssertEqual(
       URL(fileURLWithPath: try fixture.registry.graphPath(selection: .selected)).lastPathComponent,
       "graph.sqlite"
@@ -65,6 +65,32 @@ final class VaultRegistryTests: XCTestCase {
     ) { error in
       XCTAssertEqual(error as? VaultRegistryError, .invalidIdentifier)
     }
+  }
+
+  func testCustomVaultUsesIndependentCloudZone() {
+    let vault = VaultID(rawValue: "vault_work")
+
+    XCTAssertEqual(vault.cloudZoneName, "EnchiridionGraph-vault_work")
+  }
+
+  func testLegacyLibraryMigratesToPersonalGraphBeforeCatalogOpens() throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("VaultRegistryMigrationTests-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+    let legacyDatabase = directory.appendingPathComponent("legacy-library.sqlite")
+    let catalogPath = directory.appendingPathComponent("vaults/catalog.sqlite").path
+    let contents = Data("legacy-library".utf8)
+    try contents.write(to: legacyDatabase)
+
+    try VaultRegistry.migrateLegacyPersonalVaultIfNeeded(
+      catalogPath: catalogPath,
+      legacyDatabaseURLs: [legacyDatabase]
+    )
+
+    let personalGraph = directory
+      .appendingPathComponent("vaults/vault_personal/graph.sqlite")
+    XCTAssertEqual(try Data(contentsOf: personalGraph), contents)
   }
 
   private func makeFixture() throws -> (

--- a/apps/enchiridion/Tests/EnchiridionCoreTests/VaultRegistryTests.swift
+++ b/apps/enchiridion/Tests/EnchiridionCoreTests/VaultRegistryTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import XCTest
+@testable import EnchiridionCore
+
+final class VaultRegistryTests: XCTestCase {
+  func testFreshCatalogCreatesPersonalVaultAndIndependentGraphPath() throws {
+    let fixture = try makeFixture()
+    let snapshot = try fixture.registry.snapshot()
+
+    XCTAssertEqual(snapshot.vaults.map(\.name), ["Personal"])
+    XCTAssertEqual(snapshot.selectedVaultID, snapshot.defaultCaptureVaultID)
+    XCTAssertEqual(
+      URL(fileURLWithPath: try fixture.registry.graphPath(selection: .selected)).lastPathComponent,
+      "graph.sqlite"
+    )
+    XCTAssertTrue(
+      try fixture.registry.graphPath(selection: .selected)
+        .contains(snapshot.selectedVaultID.rawValue)
+    )
+  }
+
+  func testCreateRenameReorderAndSelectionsPersistAcrossReopen() throws {
+    let fixture = try makeFixture()
+    let work = try fixture.registry.createVault(name: "  Work  ")
+    let personal = try fixture.registry.snapshot().vaults.first { $0.name == "Personal" }!
+
+    try fixture.registry.renameVault(work.id, name: "Studio")
+    try fixture.registry.reorderVaults([work.id, personal.id])
+    try fixture.registry.setSelectedVault(work.id)
+    try fixture.registry.setDefaultCaptureVault(personal.id)
+
+    let reopened = try VaultRegistry(path: fixture.catalogPath)
+    let snapshot = try reopened.snapshot()
+    XCTAssertEqual(snapshot.vaults.map(\.name), ["Studio", "Personal"])
+    XCTAssertEqual(snapshot.selectedVaultID, work.id)
+    XCTAssertEqual(snapshot.defaultCaptureVaultID, personal.id)
+  }
+
+  func testDeletingSelectedVaultFallsBackWithoutDeletingLastVault() throws {
+    let fixture = try makeFixture()
+    let personal = try fixture.registry.snapshot().selectedVaultID
+    let second = try fixture.registry.createVault(name: "Work")
+    try fixture.registry.setSelectedVault(second.id)
+    try fixture.registry.setDefaultCaptureVault(second.id)
+
+    let deletedPath = try fixture.registry.deleteVault(second.id)
+    let snapshot = try fixture.registry.snapshot()
+
+    XCTAssertTrue(deletedPath.contains(second.id.rawValue))
+    XCTAssertEqual(snapshot.vaults.map(\.id), [personal])
+    XCTAssertEqual(snapshot.selectedVaultID, personal)
+    XCTAssertEqual(snapshot.defaultCaptureVaultID, personal)
+    XCTAssertThrowsError(try fixture.registry.deleteVault(personal)) { error in
+      XCTAssertEqual(error as? VaultRegistryError, .cannotDeleteOnlyVault)
+    }
+  }
+
+  func testGraphPathRejectsUntrustedVaultIdentifier() throws {
+    let fixture = try makeFixture()
+
+    XCTAssertThrowsError(
+      try fixture.registry.graphPath(for: .init(rawValue: "../../outside"))
+    ) { error in
+      XCTAssertEqual(error as? VaultRegistryError, .invalidIdentifier)
+    }
+  }
+
+  private func makeFixture() throws -> (
+    registry: VaultRegistry,
+    catalogPath: String
+  ) {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("VaultRegistryTests-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+    let path = directory.appendingPathComponent("catalog.sqlite").path
+    return (try VaultRegistry(path: path), path)
+  }
+}

--- a/apps/enchiridion/Tests/EnchiridionCoreTests/VaultSearchTests.swift
+++ b/apps/enchiridion/Tests/EnchiridionCoreTests/VaultSearchTests.swift
@@ -26,12 +26,16 @@ final class VaultSearchTests: XCTestCase {
     let fixture = try VaultSearchFixture(testCase: self)
     let vault = try fixture.registry.snapshot().vaults[0]
     let repository = try LibraryRepository(path: fixture.registry.graphPath(for: vault.id))
-    _ = try await repository.createFreePage(title: "Quoted project")
+    let literalMatch = try await repository.createFreePage(title: "Quoted OR project")
     _ = try await repository.createFreePage(title: "Another quoted project")
 
-    let results = try await VaultSearch(registry: fixture.registry).search("quoted OR *", limit: 1)
+    let literalResults = try await VaultSearch(registry: fixture.registry).search("quoted OR *")
+    XCTAssertEqual(literalResults.map(\.scopedNodeID), [
+      .init(vaultID: vault.id, nodeID: literalMatch.id)
+    ])
 
-    XCTAssertLessThanOrEqual(results.count, 1)
+    let limitedResults = try await VaultSearch(registry: fixture.registry).search("quoted", limit: 1)
+    XCTAssertLessThanOrEqual(limitedResults.count, 1)
   }
 }
 

--- a/apps/enchiridion/Tests/EnchiridionCoreTests/VaultSearchTests.swift
+++ b/apps/enchiridion/Tests/EnchiridionCoreTests/VaultSearchTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import XCTest
+@testable import EnchiridionCore
+
+final class VaultSearchTests: XCTestCase {
+  func testSearchReturnsVaultScopedResultsAcrossIndependentGraphs() async throws {
+    let fixture = try VaultSearchFixture(testCase: self)
+    let snapshot = try fixture.registry.snapshot()
+    let personal = snapshot.vaults[0]
+    let work = try fixture.registry.createVault(name: "Work")
+    let personalRepository = try LibraryRepository(path: fixture.registry.graphPath(for: personal.id))
+    let workRepository = try LibraryRepository(path: fixture.registry.graphPath(for: work.id))
+    let personalPage = try await personalRepository.createFreePage(title: "Knowledge garden")
+    let workPage = try await workRepository.createFreePage(title: "Knowledge graph launch")
+
+    let results = try await VaultSearch(registry: fixture.registry).search("knowledge")
+
+    XCTAssertEqual(Set(results.map(\.scopedNodeID)), Set([
+      .init(vaultID: personal.id, nodeID: personalPage.id),
+      .init(vaultID: work.id, nodeID: workPage.id),
+    ]))
+    XCTAssertEqual(Set(results.map(\.vaultName)), Set(["Personal", "Work"]))
+  }
+
+  func testSearchTreatsFTSSyntaxAsLiteralTextAndHonorsGlobalLimit() async throws {
+    let fixture = try VaultSearchFixture(testCase: self)
+    let vault = try fixture.registry.snapshot().vaults[0]
+    let repository = try LibraryRepository(path: fixture.registry.graphPath(for: vault.id))
+    _ = try await repository.createFreePage(title: "Quoted project")
+    _ = try await repository.createFreePage(title: "Another quoted project")
+
+    let results = try await VaultSearch(registry: fixture.registry).search("quoted OR *", limit: 1)
+
+    XCTAssertLessThanOrEqual(results.count, 1)
+  }
+}
+
+private struct VaultSearchFixture {
+  let registry: VaultRegistry
+
+  init(testCase: XCTestCase) throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("VaultSearchTests-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    testCase.addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+    registry = try VaultRegistry(path: directory.appendingPathComponent("catalog.sqlite").path)
+  }
+}

--- a/apps/enchiridion/Tests/EnchiridionCoreTests/VaultSessionTests.swift
+++ b/apps/enchiridion/Tests/EnchiridionCoreTests/VaultSessionTests.swift
@@ -20,6 +20,11 @@ final class VaultSessionTests: XCTestCase {
     let personalPages = try await session.repository.pages(in: .allPages)
     XCTAssertEqual(personalPages.map(\.title), ["Personal note"])
     XCTAssertEqual(session.snapshot.selectedVaultID, personalID)
+
+    try session.selectVault(work.id)
+    let workPages = try await session.repository.pages(in: .allPages)
+    XCTAssertEqual(workPages.map(\.title), ["Work note"])
+    XCTAssertEqual(session.snapshot.selectedVaultID, work.id)
   }
 
   func testDefaultCaptureSelectionDoesNotChangeActiveWorkspace() throws {
@@ -38,7 +43,23 @@ final class VaultSessionTests: XCTestCase {
     )
   }
 
-  func testDeletingActiveVaultSwitchesToFallbackAndRemovesOnlyItsDirectory() throws {
+  func testBackgroundStoreOpensAnotherVaultWithoutChangingSelection() async throws {
+    let fixture = try VaultSessionFixture(testCase: self)
+    let session = try VaultSession(registry: fixture.registry, startImmediately: false)
+    let personalID = session.selectedVault.id
+    let work = try session.createVault(name: "Work", select: false)
+
+    let backgroundStore = try await session.backgroundStore(forVault: work.id)
+    let backgroundRepository = try XCTUnwrap(backgroundStore.repository)
+    _ = try await backgroundRepository.createFreePage(title: "Background mutation")
+    let backgroundPages = try await backgroundRepository.pages(in: .allPages)
+
+    XCTAssertEqual(session.selectedVault.id, personalID)
+    XCTAssertEqual(backgroundStore.vaultID, work.id)
+    XCTAssertEqual(backgroundPages.map(\.title), ["Background mutation"])
+  }
+
+  func testDeletingActiveVaultSwitchesToFallbackAndRemovesOnlyItsDirectory() async throws {
     let fixture = try VaultSessionFixture(testCase: self)
     let session = try VaultSession(registry: fixture.registry, startImmediately: false)
     let personalID = session.selectedVault.id
@@ -50,7 +71,7 @@ final class VaultSessionTests: XCTestCase {
       fileURLWithPath: try fixture.registry.graphPath(for: personalID)
     ).deletingLastPathComponent()
 
-    try session.deleteVault(temporary.id)
+    try await session.deleteVault(temporary.id)
 
     XCTAssertEqual(session.selectedVault.id, personalID)
     XCTAssertFalse(FileManager.default.fileExists(atPath: removedDirectory.path))

--- a/apps/enchiridion/Tests/EnchiridionCoreTests/VaultSessionTests.swift
+++ b/apps/enchiridion/Tests/EnchiridionCoreTests/VaultSessionTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import XCTest
+@testable import EnchiridionCore
+
+@MainActor
+final class VaultSessionTests: XCTestCase {
+  func testSwitchingVaultsReplacesWorkspaceAndKeepsGraphsIsolated() async throws {
+    let fixture = try VaultSessionFixture(testCase: self)
+    let session = try VaultSession(registry: fixture.registry, startImmediately: false)
+    let personalID = session.selectedVault.id
+    _ = try await session.repository.createFreePage(title: "Personal note")
+
+    let work = try session.createVault(name: "Work")
+    XCTAssertEqual(session.selectedVault.id, work.id)
+    let initialWorkPages = try await session.repository.pages(in: .allPages)
+    XCTAssertTrue(initialWorkPages.isEmpty)
+    _ = try await session.repository.createFreePage(title: "Work note")
+
+    try session.selectVault(personalID)
+    let personalPages = try await session.repository.pages(in: .allPages)
+    XCTAssertEqual(personalPages.map(\.title), ["Personal note"])
+    XCTAssertEqual(session.snapshot.selectedVaultID, personalID)
+  }
+
+  func testDefaultCaptureSelectionDoesNotChangeActiveWorkspace() throws {
+    let fixture = try VaultSessionFixture(testCase: self)
+    let session = try VaultSession(registry: fixture.registry, startImmediately: false)
+    let personalID = session.selectedVault.id
+    let inbox = try session.createVault(name: "Inbox", select: false)
+
+    try session.setDefaultCaptureVault(inbox.id)
+
+    XCTAssertEqual(session.selectedVault.id, personalID)
+    XCTAssertEqual(session.snapshot.defaultCaptureVaultID, inbox.id)
+    XCTAssertEqual(
+      try fixture.registry.graphPath(selection: .defaultCapture),
+      try fixture.registry.graphPath(for: inbox.id)
+    )
+  }
+
+  func testDeletingActiveVaultSwitchesToFallbackAndRemovesOnlyItsDirectory() throws {
+    let fixture = try VaultSessionFixture(testCase: self)
+    let session = try VaultSession(registry: fixture.registry, startImmediately: false)
+    let personalID = session.selectedVault.id
+    let temporary = try session.createVault(name: "Temporary")
+    let removedDirectory = URL(
+      fileURLWithPath: try fixture.registry.graphPath(for: temporary.id)
+    ).deletingLastPathComponent()
+    let retainedDirectory = URL(
+      fileURLWithPath: try fixture.registry.graphPath(for: personalID)
+    ).deletingLastPathComponent()
+
+    try session.deleteVault(temporary.id)
+
+    XCTAssertEqual(session.selectedVault.id, personalID)
+    XCTAssertFalse(FileManager.default.fileExists(atPath: removedDirectory.path))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: retainedDirectory.path))
+  }
+}
+
+private struct VaultSessionFixture {
+  let registry: VaultRegistry
+
+  init(testCase: XCTestCase) throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("VaultSessionTests-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    testCase.addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+    registry = try VaultRegistry(path: directory.appendingPathComponent("catalog.sqlite").path)
+  }
+}


### PR DESCRIPTION
## What changed

- define a graph-native ontology for nodes, typed facts, fixed Base Tags, multiple-inheritance Supertags, canonical directed edges, inverse backlinks, and all four relationship cardinalities
- project Automerge-owned knowledge into stable read-only SQLite `graph_*` views with bounded SQL execution, recursive traversal compilation, FTS, graph issues, and explicit max-one conflict resolution
- add native relationship, backlink, relation-definition, graph-query, and saved-query surfaces on macOS and iOS
- introduce independent vault databases, vault-scoped node identities, vault switching, cross-vault search, and explicit selected/default-capture behavior
- scope deep links, reminders, Spotlight, widgets, App Intents, share capture, CarPlay, assistant access, and CloudKit zones to the correct vault
- synchronize custom relationship definitions and saved graph queries with generation-safe acknowledgements and tombstones
- stabilize the built-in Personal vault identity so fresh devices address the same CloudKit zone
- document the semantic contract and the decision to use embedded SQLite SQL instead of introducing a second Cypher database authority

## Why

Supertags need to behave as a knowledge graph rather than isolated page metadata. Relationships must support backlinks, bidirectional naming, cardinality, inheritance, traversal, and merge-safe conflict handling while preserving Enchiridion's local-first Automerge and SQLite authority.

SQLite remains the execution engine because prose, graph projections, tasks, calendar data, FTS, and sync state can share one transactional database. The visual builder provides graph traversal ergonomics, while advanced SQL is restricted to one bounded read-only statement over stable public views.

## Impact

- graph knowledge is vault-local and every external identity carries its vault
- backlinks are inverse projections of one canonical source-owned edge, never independently mutable duplicates
- concurrent cardinality conflicts are preserved and surfaced for explicit resolution
- custom relationship schemas and saved graph queries follow the same per-vault sync lifecycle as graph content
- fixed Base Tags and system relationship definitions remain application-owned and are not uploaded

The custom-vault catalog remains local device configuration. The built-in Personal vault has a deterministic identity for cross-device sync; future catalog transfer/synchronization can add custom-vault discovery without changing graph identities.

## Validation

- `swift test --disable-sandbox` — 321 tests passed
- unsigned macOS Debug build passed
- unsigned iOS Simulator Debug build passed, including widget and extensions

## Follow-up acceptance

A signed build and physical devices are still required to create/deploy the new `GraphRelation` and `GraphQuery` CloudKit record types and verify Personal-vault synchronization in both directions.
