### PR TITLE
feat(kree): configure window raising

### DIFF
--- a/apps/kree/Package.swift
+++ b/apps/kree/Package.swift
@@ -20,6 +20,10 @@ let package = Package(
                 .unsafeFlags(["-framework", "ApplicationServices"]),
                 .unsafeFlags(["-framework", "Carbon"])
             ]
+        ),
+        .testTarget(
+            name: "KreeTests",
+            dependencies: ["Kree"]
         )
     ]
 )

--- a/apps/kree/Sources/Kree/AppState.swift
+++ b/apps/kree/Sources/Kree/AppState.swift
@@ -44,6 +44,13 @@ class AppState: ObservableObject {
             updateEngineConfig()
         }
     }
+
+    @Published var focusRaisePolicy: FocusRaisePolicy {
+        didSet {
+            UserDefaults.standard.set(focusRaisePolicy.rawValue, forKey: "focusRaisePolicy")
+            updateEngineConfig()
+        }
+    }
     
     @Published var isTrusted: Bool = AXIsProcessTrusted()
     
@@ -58,6 +65,10 @@ class AppState: ObservableObject {
         } else {
             self.disableModifier = .none
         }
+
+        self.focusRaisePolicy = FocusRaisePolicy.decode(
+            UserDefaults.standard.string(forKey: "focusRaisePolicy")
+        )
         
         focusEngine.onTrustChange = { [weak self] trusted in
             DispatchQueue.main.async {
@@ -72,7 +83,8 @@ class AppState: ObservableObject {
     private func updateEngineConfig() {
         focusEngine.setConfiguration(
             delay: focusDelay,
-            disableModifier: disableModifier.flags
+            disableModifier: disableModifier.flags,
+            raisePolicy: focusRaisePolicy
         )
     }
     

--- a/apps/kree/Sources/Kree/FocusEngine.swift
+++ b/apps/kree/Sources/Kree/FocusEngine.swift
@@ -2,75 +2,191 @@ import Cocoa
 import ApplicationServices
 import os.log
 
-class FocusEngine {
+/// Thread-safe lifecycle token shared by event ingress, the coordinator, and
+/// the focus mutation queue. A new input or lifecycle transition invalidates
+/// older focus transactions before they can mutate window state.
+final class FocusGeneration {
+    private let lock = NSLock()
+    private var value: UInt64 = 0
+    private var active = false
+
+    @discardableResult
+    func activate() -> UInt64 {
+        lock.lock()
+        defer { lock.unlock() }
+        value &+= 1
+        active = true
+        return value
+    }
+
+    @discardableResult
+    func invalidate() -> UInt64 {
+        lock.lock()
+        defer { lock.unlock() }
+        value &+= 1
+        return value
+    }
+
+    func deactivate() {
+        lock.lock()
+        value &+= 1
+        active = false
+        lock.unlock()
+    }
+
+    func isCurrent(_ token: UInt64) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return active && value == token
+    }
+
+    func isActive() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return active
+    }
+}
+
+/// Reserves focus-attempt time at the mutation boundary, not after a later
+/// asynchronous backend operation completes.
+final class FocusAttemptGate {
+    private let lock = NSLock()
+    private var lastAttemptAt: TimeInterval?
+
+    func remaining(after interval: TimeInterval, now: TimeInterval = CFAbsoluteTimeGetCurrent()) -> TimeInterval {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let lastAttemptAt else { return 0 }
+        return max(0, interval - (now - lastAttemptAt))
+    }
+
+    @discardableResult
+    func reserve(after interval: TimeInterval, now: TimeInterval = CFAbsoluteTimeGetCurrent()) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let lastAttemptAt, now - lastAttemptAt < interval {
+            return false
+        }
+
+        self.lastAttemptAt = now
+        return true
+    }
+}
+
+final class FocusEngine {
+    private enum WorkerState {
+        case stopped
+        case waitingForTrust
+        case monitoring
+    }
+
+    private struct MovementSample {
+        let point: CGPoint
+        let modifiers: NSEvent.ModifierFlags
+        let physicalMovement: Bool
+        let inputToken: UInt64
+    }
+
+    private let workerQueue = DispatchQueue(label: "com.rawkode.Kree.focus-worker")
+    private let focusMutationQueue = DispatchQueue(label: "com.rawkode.Kree.focus-mutation")
+    private let lifecycle = FocusGeneration()
+    private let focusAttemptGate = FocusAttemptGate()
+    private let hitTester = WindowHitTester()
+    private let skyLightFocus = SkyLightFocus()
+    private let configurationLock = NSLock()
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
     private var permissionTimer: Timer?
-    private var focusWorkItem: DispatchWorkItem?
     private var spaceChangeObserver: NSObjectProtocol?
-    
-    private let systemWideElement = AXUIElementCreateSystemWide()
-    private var lastFocusedWindowID: CGWindowID = 0
+    private var isRunning = false
+
     private let logger = Logger(subsystem: "com.rawkode.Kree", category: "FocusEngine")
-    
-    // Config
+
+    // All state below this line is owned by workerQueue. The event tap only
+    // packages movement and lifecycle signals before enqueueing them here.
+    private var workerState: WorkerState = .stopped
+    private var lifecycleGeneration: UInt64 = 0
+    private var candidateGeneration: UInt64 = 0
     private var focusDelay: TimeInterval = 0.0
     private var disableModifier: NSEvent.ModifierFlags?
+    private var focusRaisePolicy: FocusRaisePolicy = .automatic
+    private var lastProcessedAt = 0.0
+    private var latestSample: MovementSample?
+    private var trailingWorkItem: DispatchWorkItem?
+    private var pendingCandidate: WindowTarget?
+    private var pendingInputToken: UInt64 = 0
+    private var dwellWorkItem: DispatchWorkItem?
+    private var lastFocusedWindowID: CGWindowID = 0
+    private var lastFocusedOwnerPID: pid_t = 0
 
-    // State
-    private var pendingWindowID: CGWindowID = 0
-    
+    private let processMinInterval = 0.04
+    private let focusCooldown = 0.25
     var onTrustChange: ((Bool) -> Void)?
-    
-    func setConfiguration(delay: TimeInterval, disableModifier: NSEvent.ModifierFlags?) {
-        self.focusDelay = delay
-        self.disableModifier = disableModifier
+
+    func setConfiguration(
+        delay: TimeInterval,
+        disableModifier: NSEvent.ModifierFlags?,
+        raisePolicy: FocusRaisePolicy
+    ) {
+        lifecycle.invalidate()
+        workerQueue.async { [weak self] in
+            guard let self else { return }
+            self.focusDelay = max(0, delay)
+            self.configurationLock.lock()
+            self.disableModifier = disableModifier
+            self.configurationLock.unlock()
+            self.focusRaisePolicy = raisePolicy
+            self.invalidateLifecycle()
+        }
     }
-    
+
     func start() {
         stop()
-        
-        if !AXIsProcessTrusted() {
+
+        guard AXIsProcessTrusted() else {
+            workerQueue.async { [weak self] in
+                self?.workerState = .waitingForTrust
+                self?.lifecycleGeneration &+= 1
+            }
             onTrustChange?(false)
             logger.warning("Accessibility permissions not granted. Prompting user and waiting...")
+
             let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary
             AXIsProcessTrustedWithOptions(options)
-            
+
             permissionTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-                if AXIsProcessTrusted() {
-                    self?.logger.notice("Permissions granted! Starting engine.")
-                    self?.onTrustChange?(true)
-                    self?.permissionTimer?.invalidate()
-                    self?.permissionTimer = nil
-                    self?.start()
-                }
+                guard let self, AXIsProcessTrusted() else { return }
+                self.logger.notice("Permissions granted! Starting engine.")
+                self.permissionTimer?.invalidate()
+                self.permissionTimer = nil
+                self.onTrustChange?(true)
+                self.start()
             }
             return
         }
-        
-        onTrustChange?(true)
-        logger.notice("Starting FocusEngine (Event Driven)")
-        
-        // Create Event Tap
-        let eventMask = (1 << CGEventType.mouseMoved.rawValue)
-        guard let tap = CGEvent.tapCreate(
-            tap: .cghidEventTap,
-            place: .headInsertEventTap,
-            options: .listenOnly,
-            eventsOfInterest: CGEventMask(eventMask),
-            callback: eventTapCallback,
-            userInfo: UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
-        ) else {
+
+        guard installEventTap() else {
+            onTrustChange?(true)
             logger.error("Failed to create Event Tap")
             return
         }
-        
-        self.eventTap = tap
-        self.runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
-        CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, .commonModes)
-        CGEvent.tapEnable(tap: tap, enable: true)
 
-        // Listen for space changes
+        isRunning = true
+        lifecycle.activate()
+        onTrustChange?(true)
+        logger.notice("Starting FocusEngine (Event Driven)")
+
+        workerQueue.async { [weak self] in
+            guard let self else { return }
+            self.workerState = .monitoring
+            self.lifecycleGeneration &+= 1
+            self.resetCandidateState()
+        }
+
+        // Listen for space changes. The current pointer location is read in
+        // Quartz coordinates so multiple-display arrangements do not need the
+        // primary-screen height conversion previously used here.
         spaceChangeObserver = NSWorkspace.shared.notificationCenter.addObserver(
             forName: NSWorkspace.activeSpaceDidChangeNotification,
             object: nil,
@@ -79,17 +195,20 @@ class FocusEngine {
             self?.handleSpaceChange()
         }
     }
-    
+
     func stop() {
-        if let runLoopSource = runLoopSource {
+        isRunning = false
+        lifecycle.deactivate()
+
+        if let runLoopSource {
             CFRunLoopRemoveSource(CFRunLoopGetCurrent(), runLoopSource, .commonModes)
             self.runLoopSource = nil
         }
-        if eventTap != nil {
-            // CFMachPortInvalidate(eventTap) // Optional, usually releasing is enough
+        if let eventTap {
+            CFMachPortInvalidate(eventTap)
             self.eventTap = nil
         }
-        
+
         permissionTimer?.invalidate()
         permissionTimer = nil
 
@@ -98,193 +217,499 @@ class FocusEngine {
             spaceChangeObserver = nil
         }
 
-        cancelPendingFocus()
+        // Lifecycle invalidation above makes queued focus results no-ops. Keep the
+        // main thread non-blocking while the coordinator drains its state.
+        workerQueue.async {
+            self.workerState = .stopped
+            self.lifecycleGeneration &+= 1
+            self.resetCandidateState()
+        }
     }
-    
-    private func cancelPendingFocus() {
-        focusWorkItem?.cancel()
-        focusWorkItem = nil
-        pendingWindowID = 0
+
+    private func installEventTap() -> Bool {
+        let eventTypes: [CGEventType] = [
+            .mouseMoved,
+            .flagsChanged,
+            .leftMouseDown,
+            .leftMouseUp,
+            .rightMouseDown,
+            .rightMouseUp,
+            .otherMouseDown,
+            .otherMouseUp
+        ]
+        let eventMask = eventTypes.reduce(into: CGEventMask(0)) { mask, type in
+            mask |= CGEventMask(1 << type.rawValue)
+        }
+        guard let tap = CGEvent.tapCreate(
+            tap: .cghidEventTap,
+            place: .headInsertEventTap,
+            options: .listenOnly,
+            eventsOfInterest: eventMask,
+            callback: eventTapCallback,
+            userInfo: UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
+        ) else {
+            return false
+        }
+
+        eventTap = tap
+        runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        if let runLoopSource {
+            CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, .commonModes)
+        }
+        CGEvent.tapEnable(tap: tap, enable: true)
+        return true
+    }
+
+    private func recoverEventTap() {
+        guard isRunning, AXIsProcessTrusted(), let eventTap else { return }
+
+        // CGEvent.tapEnable is intentionally the only recovery operation. The
+        // existing tap and run-loop source remain owned by the main thread, so
+        // recovery cannot create duplicate taps or observers.
+        CGEvent.tapEnable(tap: eventTap, enable: true)
+        logger.notice("Requested recovery for disabled event tap")
+    }
+
+    // Called by the C callback. It performs no window or Accessibility work.
+    fileprivate func handleMouseMoved(event: CGEvent) {
+        let dx = event.getDoubleValueField(.mouseEventDeltaX)
+        let dy = event.getDoubleValueField(.mouseEventDeltaY)
+        guard dx != 0.0 || dy != 0.0 else {
+            return
+        }
+
+        let inputToken = lifecycle.invalidate()
+        let modifiers = NSEvent.ModifierFlags(rawValue: UInt(event.flags.rawValue))
+        enqueue(MovementSample(
+            point: event.location,
+            modifiers: modifiers,
+            physicalMovement: true,
+            inputToken: inputToken
+        ))
+    }
+
+    fileprivate func handleInputStateChanged() {
+        lifecycle.invalidate()
+        workerQueue.async { [weak self] in
+            guard let self else { return }
+            self.invalidateLifecycle()
+        }
+    }
+
+    fileprivate func handleEventTapDisabled(type: CGEventType) {
+        guard type == .tapDisabledByTimeout || type == .tapDisabledByUserInput else {
+            return
+        }
+
+        lifecycle.invalidate()
+        workerQueue.async { [weak self] in
+            guard let self else { return }
+            self.invalidateLifecycle()
+            self.logger.warning("Event tap disabled; invalidated pending focus work")
+        }
+
+        // Re-enable asynchronously so the callback returns promptly to
+        // WindowServer. Both timeout and user-input disablement use this path.
+        DispatchQueue.main.async { [weak self] in
+            self?.recoverEventTap()
+        }
     }
 
     private func handleSpaceChange() {
-        // Reset tracked window so checkFocus will re-focus on the new space
-        lastFocusedWindowID = 0
-        // Brief delay for space transition to let the AX tree settle
+        let spaceToken = lifecycle.invalidate()
+
+        workerQueue.async { [weak self] in
+            guard let self, self.workerState == .monitoring else { return }
+            self.lastFocusedWindowID = 0
+            self.lastFocusedOwnerPID = 0
+            self.invalidateCandidate()
+        }
+
+        // Preserve Kree's settle delay while still invalidating the old
+        // transaction immediately. The delayed sample is dropped if another
+        // movement, configuration change, stop, or restart occurs first.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
-            let mouseLocation = NSEvent.mouseLocation
-            // Convert from bottom-left origin (NSEvent) to top-left origin (CGEvent/AX)
-            if let screenHeight = NSScreen.main?.frame.height {
-                let point = CGPoint(x: mouseLocation.x, y: screenHeight - mouseLocation.y)
-                self?.checkFocus(at: point)
-            }
+            guard let self,
+                self.isRunning,
+                self.lifecycle.isCurrent(spaceToken),
+                let point = CGEvent(source: nil)?.location
+            else { return }
+
+            self.enqueue(MovementSample(
+                point: point,
+                modifiers: NSEvent.modifierFlags,
+                physicalMovement: false,
+                inputToken: spaceToken
+            ))
         }
     }
-    
-    // Named method to be called from the C-function callback
-    fileprivate func handleMouseMoved(event: CGEvent) {
-        // Ignore synthetic mouse-moved events (no physical mouse movement).
-        // macOS sends these when window content changes under the cursor,
-        // which causes unwanted re-focusing during e.g. tab creation.
-        let dx = event.getDoubleValueField(.mouseEventDeltaX)
-        let dy = event.getDoubleValueField(.mouseEventDeltaY)
-        if dx == 0.0 && dy == 0.0 {
-            return
-        }
 
-        // Check Modifier
-        if let modifier = disableModifier {
-             if NSEvent.modifierFlags.contains(modifier) {
-                 cancelPendingFocus()
-                 return
-             }
+    private func enqueue(_ sample: MovementSample) {
+        workerQueue.async { [weak self] in
+            guard let self, self.workerState == .monitoring else { return }
+            self.receive(sample)
         }
-
-        let point = event.location
-        checkFocus(at: point)
     }
-    
-    private func checkFocus(at point: CGPoint) {
-        // 1. Find element at mouse position
-        var element: AXUIElement?
-        let result = AXUIElementCopyElementAtPosition(systemWideElement, Float(point.x), Float(point.y), &element)
-        
-        guard result == .success, let foundElement = element else {
-            return
-        }
-        
-        // 2. Walk up to find the Window
-        guard let window = getWindow(from: foundElement) else {
-            // Mouse moved over something that isn't a window (e.g. desktop), cancel pending
-            if pendingWindowID != 0 { cancelPendingFocus() }
-            return 
-        }
-        
-        // 3. Get Window ID
-        var windowID: CGWindowID = 0
-        _ = _AXUIElementGetWindow(window, &windowID)
-        
-        // If already focused, ignore
-        if windowID == lastFocusedWindowID {
-            if pendingWindowID != 0 { cancelPendingFocus() }
+
+    private func receive(_ sample: MovementSample) {
+        guard workerState == .monitoring,
+            lifecycle.isCurrent(sample.inputToken)
+        else { return }
+
+        // A modifier/button transition must cancel existing work immediately;
+        // otherwise a throttled trailing callback could let an old dwell fire.
+        if isSuppressed(sample.modifiers) || mouseButtonIsDown() {
+            latestSample = nil
+            trailingWorkItem?.cancel()
+            trailingWorkItem = nil
+            invalidateCandidate()
             return
         }
 
-        // Always cancel and reschedule timer when mouse moves over a non-focused window.
-        // This ensures focus only fires when mouse has been stationary for the full delay.
-        cancelPendingFocus()
-        pendingWindowID = windowID
-        
-        // 4. Check Ignore List (Dock, etc.)
-        if shouldIgnore(window: window) {
-            pendingWindowID = 0
-            return
-        }
-        
-        // 5. Schedule Focus
-        if focusDelay > 0 {
-            let item = DispatchWorkItem { [weak self] in
-                self?.performFocus(window: window, id: windowID)
-            }
-            focusWorkItem = item
-            DispatchQueue.main.asyncAfter(deadline: .now() + focusDelay, execute: item)
+        if sample.physicalMovement {
+            // Kree retains its documented stationary-dwell behavior. A real
+            // movement always invalidates the prior dwell, even if its CG
+            // hit-test is deferred to the trailing edge.
+            invalidateCandidate()
         } else {
-            // Instant focus
-            performFocus(window: window, id: windowID)
-        }
-    }
-    
-    private func performFocus(window: AXUIElement, id: CGWindowID) {
-        // Final sanity check (modifier might have been pressed during delay)
-        if let modifier = disableModifier, NSEvent.modifierFlags.contains(modifier) {
+            trailingWorkItem?.cancel()
+            trailingWorkItem = nil
+            latestSample = nil
+            lastProcessedAt = CFAbsoluteTimeGetCurrent()
+            process(sample)
             return
         }
-        
-        var pid: pid_t = 0
-        AXUIElementGetPid(window, &pid)
-        
-        guard let app = NSRunningApplication(processIdentifier: pid) else { return }
-        
-        // Don't focus self
-        if app.processIdentifier == NSRunningApplication.current.processIdentifier { return }
-        
-        let error = AXUIElementSetAttributeValue(window, kAXMainAttribute as CFString, true as CFTypeRef)
-        if error == .success {
-             app.activate(options: [])
-            lastFocusedWindowID = id
-            pendingWindowID = 0
-            focusWorkItem = nil
+
+        let now = CFAbsoluteTimeGetCurrent()
+        let elapsed = now - lastProcessedAt
+        guard elapsed >= processMinInterval else {
+            latestSample = sample
+            guard trailingWorkItem == nil else { return }
+
+            let expectedLifecycle = lifecycleGeneration
+            let work = DispatchWorkItem { [weak self] in
+                guard let self,
+                    self.workerState == .monitoring,
+                    self.lifecycleGeneration == expectedLifecycle,
+                    self.lifecycle.isActive()
+                else { return }
+
+                self.trailingWorkItem = nil
+                guard let latestSample = self.latestSample else { return }
+                self.latestSample = nil
+                self.lastProcessedAt = CFAbsoluteTimeGetCurrent()
+                self.process(latestSample)
+            }
+            trailingWorkItem = work
+            workerQueue.asyncAfter(deadline: .now() + (processMinInterval - elapsed), execute: work)
+            return
+        }
+
+        trailingWorkItem?.cancel()
+        trailingWorkItem = nil
+        latestSample = nil
+        lastProcessedAt = now
+        process(sample)
+    }
+
+    private func process(_ sample: MovementSample) {
+        guard workerState == .monitoring,
+            lifecycle.isCurrent(sample.inputToken),
+            !isSuppressed(sample.modifiers),
+            !mouseButtonIsDown()
+        else {
+            invalidateCandidate()
+            return
+        }
+
+        switch hitTester.hitTest(at: sample.point) {
+        case .none, .blocked:
+            invalidateCandidate()
+
+        case .target(let target):
+            if shouldIgnore(target: target) || isAlreadyFocused(target: target) {
+                invalidateCandidate()
+                return
+            }
+
+            invalidateCandidate()
+            pendingCandidate = target
+            pendingInputToken = sample.inputToken
+            let expectedLifecycle = lifecycleGeneration
+            let expectedCandidate = candidateGeneration
+            let expectedInputToken = sample.inputToken
+
+            if focusDelay <= 0 {
+                confirmAndFocus(
+                    target: target,
+                    expectedLifecycle: expectedLifecycle,
+                    expectedCandidate: expectedCandidate,
+                    expectedInputToken: expectedInputToken
+                )
+                return
+            }
+
+            let work = DispatchWorkItem { [weak self] in
+                guard let self else { return }
+                self.confirmAndFocus(
+                    target: target,
+                    expectedLifecycle: expectedLifecycle,
+                    expectedCandidate: expectedCandidate,
+                    expectedInputToken: expectedInputToken
+                )
+            }
+            dwellWorkItem = work
+            workerQueue.asyncAfter(deadline: .now() + focusDelay, execute: work)
         }
     }
-    
-    private func getWindow(from element: AXUIElement) -> AXUIElement? {
-        var current = element
-        var count = 0
-        let maxDepth = 20
-        
-        while count < maxDepth {
-            var roleRef: CFTypeRef?
-            AXUIElementCopyAttributeValue(current, kAXRoleAttribute as CFString, &roleRef)
-            
-            if let role = roleRef as? String, role == kAXWindowRole as String {
-                return current
-            }
-            
-            var parentRef: CFTypeRef?
-            let err = AXUIElementCopyAttributeValue(current, kAXParentAttribute as CFString, &parentRef)
-            
-            if err != .success || parentRef == nil {
-                break
-            }
-            
-            if CFGetTypeID(parentRef!) == AXUIElementGetTypeID() {
-                current = (parentRef as! AXUIElement)
-            } else {
-                break
-            }
-            count += 1
+
+    private func confirmAndFocus(
+        target: WindowTarget,
+        expectedLifecycle: UInt64,
+        expectedCandidate: UInt64,
+        expectedInputToken: UInt64
+    ) {
+        guard workerState == .monitoring,
+            lifecycleGeneration == expectedLifecycle,
+            candidateGeneration == expectedCandidate,
+            pendingCandidate == target,
+            pendingInputToken == expectedInputToken,
+            lifecycle.isCurrent(expectedInputToken),
+            !isSuppressed(currentModifierFlags()),
+            !mouseButtonIsDown()
+        else {
+            return
         }
-        
-        return nil
+
+        // Re-hit-test at dwell completion. A window may have moved, closed,
+        // changed Space, or become covered without producing another event.
+        guard let point = CGEvent(source: nil)?.location,
+            case .target(let currentTarget) = hitTester.hitTest(at: point),
+            currentTarget == target,
+            !shouldIgnore(target: currentTarget)
+        else {
+            invalidateCandidate()
+            return
+        }
+
+        dwellWorkItem = nil
+        pendingCandidate = nil
+        pendingInputToken = 0
+        dispatchFocus(target: currentTarget, expectedInputToken: expectedInputToken)
     }
-    
-    private func shouldIgnore(window: AXUIElement) -> Bool {
-        var pid: pid_t = 0
-        AXUIElementGetPid(window, &pid)
-        
-        if let app = NSRunningApplication(processIdentifier: pid) {
-            if app.bundleIdentifier == "com.apple.dock" { return true }
-            if app.bundleIdentifier == "com.apple.finder" {
-                 // Finder is usually okay
-            }
+
+    private func dispatchFocus(target: WindowTarget, expectedInputToken: UInt64) {
+        guard workerState == .monitoring,
+            lifecycle.isCurrent(expectedInputToken),
+            !isSuppressed(currentModifierFlags()),
+            !mouseButtonIsDown()
+        else {
+            return
         }
-        return false
+
+        // Resolve the policy on workerQueue and pass an immutable decision to
+        // the serial mutation queue. Configuration changes invalidate the
+        // lifecycle before a queued transaction can pass its final preflight.
+        let raise = focusRaisePolicy.shouldRaise(for: target)
+        focusMutationQueue.async { [weak self] in
+            self?.resolveAndPrepareFocus(
+                target: target,
+                raise: raise,
+                expectedInputToken: expectedInputToken
+            )
+        }
+    }
+
+    private func resolveAndPrepareFocus(
+        target: WindowTarget,
+        raise: Bool,
+        expectedInputToken: UInt64
+    ) {
+        guard lifecycle.isCurrent(expectedInputToken) else { return }
+
+        // Window IDs are recyclable. Validate the owner before reserving an
+        // attempt; SkyLight repeats the exact (window ID, PID, bounds) check
+        // immediately before its first mutation.
+        guard isCurrentWindowTarget(target) else {
+            logger.debug("Window target \(target.windowID) is no longer owned by PID \(target.ownerPID)")
+            return
+        }
+
+        guard lifecycle.isCurrent(expectedInputToken),
+            !isSuppressed(currentModifierFlags()),
+            !mouseButtonIsDown()
+        else { return }
+
+        guard focusAttemptGate.reserve(after: focusCooldown) else {
+            let remaining = focusAttemptGate.remaining(after: focusCooldown)
+            workerQueue.async { [weak self] in
+                self?.retryFocusAfterCooldown(
+                    target: target,
+                    expectedInputToken: expectedInputToken,
+                    after: remaining
+                )
+            }
+            return
+        }
+
+        guard lifecycle.isCurrent(expectedInputToken),
+            !isSuppressed(currentModifierFlags()),
+            !mouseButtonIsDown(),
+            isCurrentWindowTarget(target)
+        else { return }
+
+        let outcome = skyLightFocus.activate(target: target, raise: raise)
+        switch outcome {
+        case .requestAccepted:
+            recordFocusedWindow(target: target, expectedInputToken: expectedInputToken)
+        case let .noMutation(reason):
+            logger.debug("SkyLight did not mutate window \(target.windowID): \(String(describing: reason))")
+        case let .setterFailed(status):
+            logger.debug("SkyLight setter failed for window \(target.windowID): status \(status)")
+        case let .recordFailures(first, second):
+            logger.debug(
+                "SkyLight records failed for window \(target.windowID): first \(String(describing: first)), second \(String(describing: second))"
+            )
+        }
+    }
+
+    private func recordFocusedWindow(target: WindowTarget, expectedInputToken: UInt64) {
+        workerQueue.async { [weak self] in
+            guard let self,
+                self.workerState == .monitoring,
+                self.lifecycle.isCurrent(expectedInputToken)
+            else { return }
+            self.lastFocusedWindowID = target.windowID
+            self.lastFocusedOwnerPID = target.ownerPID
+        }
+    }
+
+    private func retryFocusAfterCooldown(
+        target: WindowTarget,
+        expectedInputToken: UInt64,
+        after delay: TimeInterval
+    ) {
+        guard workerState == .monitoring,
+            lifecycle.isCurrent(expectedInputToken)
+        else { return }
+
+        workerQueue.asyncAfter(deadline: .now() + delay) { [weak self] in
+            guard let self,
+                self.workerState == .monitoring,
+                self.lifecycle.isCurrent(expectedInputToken),
+                let point = CGEvent(source: nil)?.location,
+                case .target(let currentTarget) = self.hitTester.hitTest(at: point),
+                currentTarget == target
+            else { return }
+
+            self.dispatchFocus(target: currentTarget, expectedInputToken: expectedInputToken)
+        }
+    }
+
+    private func isCurrentWindowTarget(_ target: WindowTarget) -> Bool {
+        let options: CGWindowListOption = [.optionIncludingWindow, .excludeDesktopElements]
+        guard let windows = CGWindowListCopyWindowInfo(options, target.windowID) as? [[String: Any]],
+            let info = windows.first,
+            let windowID = (info[kCGWindowNumber as String] as? NSNumber)?.uint32Value,
+            let ownerPID = (info[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value
+        else {
+            return false
+        }
+
+        return CGWindowID(windowID) == target.windowID && pid_t(ownerPID) == target.ownerPID
+    }
+
+    private func shouldIgnore(target: WindowTarget) -> Bool {
+        target.ownerName == "Dock"
+            || target.ownerPID == ProcessInfo.processInfo.processIdentifier
+    }
+
+    private func isAlreadyFocused(target: WindowTarget) -> Bool {
+        target.windowID == lastFocusedWindowID
+            && target.ownerPID == lastFocusedOwnerPID
+    }
+
+    private func isSuppressed(_ modifiers: NSEvent.ModifierFlags) -> Bool {
+        configurationLock.lock()
+        let disableModifier = self.disableModifier
+        configurationLock.unlock()
+        guard let disableModifier else { return false }
+        return modifiers.contains(disableModifier)
+    }
+
+    private func currentModifierFlags() -> NSEvent.ModifierFlags {
+        NSEvent.ModifierFlags(rawValue: UInt(
+            CGEventSource.flagsState(.combinedSessionState).rawValue
+        ))
+    }
+
+    private func mouseButtonIsDown() -> Bool {
+        CGEventSource.buttonState(.combinedSessionState, button: .left)
+            || CGEventSource.buttonState(.combinedSessionState, button: .right)
+            || CGEventSource.buttonState(.combinedSessionState, button: .center)
+    }
+
+    private func invalidateCandidate() {
+        candidateGeneration &+= 1
+        dwellWorkItem?.cancel()
+        dwellWorkItem = nil
+        pendingCandidate = nil
+        pendingInputToken = 0
+    }
+
+    private func resetCandidateState() {
+        lifecycleGeneration &+= 1
+        candidateGeneration &+= 1
+        latestSample = nil
+        trailingWorkItem?.cancel()
+        trailingWorkItem = nil
+        dwellWorkItem?.cancel()
+        dwellWorkItem = nil
+        pendingCandidate = nil
+        pendingInputToken = 0
+        lastProcessedAt = 0
+        lastFocusedWindowID = 0
+        lastFocusedOwnerPID = 0
+    }
+
+    private func invalidateLifecycle() {
+        lifecycleGeneration &+= 1
+        latestSample = nil
+        trailingWorkItem?.cancel()
+        trailingWorkItem = nil
+        invalidateCandidate()
     }
 }
 
-// C-Function Callback for Event Tap
-func eventTapCallback(proxy: CGEventTapProxy, type: CGEventType, event: CGEvent, refcon: UnsafeMutableRawPointer?) -> Unmanaged<CGEvent>? {
-    if type == .tapDisabledByTimeout {
-        // Re-enable? Or just ignore.
-        // Ideally we should re-enable, but for now we let it be or the engine handle it.
-        // To strictly handle it:
-        // let engine = Unmanaged<FocusEngine>.fromOpaque(refcon!).takeUnretainedValue()
-        // engine.restartTap()
+// C-function callback for the listen-only event tap. Returning the event keeps
+// the tap transparent to the rest of the system.
+func eventTapCallback(
+    proxy: CGEventTapProxy,
+    type: CGEventType,
+    event: CGEvent,
+    refcon: UnsafeMutableRawPointer?
+) -> Unmanaged<CGEvent>? {
+    guard let refcon else {
         return Unmanaged.passUnretained(event)
     }
-    
-    if type == .mouseMoved {
-        if let refcon = refcon {
-            let engine = Unmanaged<FocusEngine>.fromOpaque(refcon).takeUnretainedValue()
-            engine.handleMouseMoved(event: event)
-        }
+
+    let engine = Unmanaged<FocusEngine>.fromOpaque(refcon).takeUnretainedValue()
+    switch type {
+    case .mouseMoved:
+        engine.handleMouseMoved(event: event)
+    case .flagsChanged,
+        .leftMouseDown,
+        .leftMouseUp,
+        .rightMouseDown,
+        .rightMouseUp,
+        .otherMouseDown,
+        .otherMouseUp:
+        engine.handleInputStateChanged()
+    case .tapDisabledByTimeout, .tapDisabledByUserInput:
+        engine.handleEventTapDisabled(type: type)
+    default:
+        break
     }
-    
-    // We are .listenOnly, so returning the event is required to pass it through? 
-    // Actually for listenOnly the return value is ignored by the system, but we must return the event.
+
     return Unmanaged.passUnretained(event)
 }
-
-// Private API
-@_silgen_name("_AXUIElementGetWindow")
-func _AXUIElementGetWindow(_ element: AXUIElement, _ id: UnsafeMutablePointer<CGWindowID>) -> AXError

--- a/apps/kree/Sources/Kree/FocusEngine.swift
+++ b/apps/kree/Sources/Kree/FocusEngine.swift
@@ -252,10 +252,13 @@ final class FocusEngine {
         }
 
         eventTap = tap
-        runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
-        if let runLoopSource {
-            CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, .commonModes)
+        guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
+            CFMachPortInvalidate(tap)
+            eventTap = nil
+            return false
         }
+        runLoopSource = source
+        CFRunLoopAddSource(CFRunLoopGetCurrent(), source, .commonModes)
         CGEvent.tapEnable(tap: tap, enable: true)
         return true
     }
@@ -528,7 +531,7 @@ final class FocusEngine {
         guard lifecycle.isCurrent(expectedInputToken) else { return }
 
         // Window IDs are recyclable. Validate the owner before reserving an
-        // attempt; SkyLight repeats the exact (window ID, PID, bounds) check
+        // attempt; SkyLight repeats the (window ID, PID) identity check
         // immediately before its first mutation.
         guard isCurrentWindowTarget(target) else {
             logger.debug("Window target \(target.windowID) is no longer owned by PID \(target.ownerPID)")
@@ -599,9 +602,13 @@ final class FocusEngine {
                 self.lifecycle.isCurrent(expectedInputToken),
                 let point = CGEvent(source: nil)?.location,
                 case .target(let currentTarget) = self.hitTester.hitTest(at: point),
-                currentTarget == target
+                currentTarget.hasSameIdentity(as: target),
+                !self.isAlreadyFocused(target: currentTarget)
             else { return }
 
+            // The window may have moved or its coverage may have changed during
+            // the cooldown. Dispatch the fresh target so the raise decision
+            // reflects the current window stack.
             self.dispatchFocus(target: currentTarget, expectedInputToken: expectedInputToken)
         }
     }

--- a/apps/kree/Sources/Kree/FocusRaisePolicy.swift
+++ b/apps/kree/Sources/Kree/FocusRaisePolicy.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+internal enum FocusRaisePolicy: String, CaseIterable, Identifiable {
+    case automatic
+    case always
+    case never
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .automatic: return "Automatic"
+        case .always: return "Always"
+        case .never: return "Never"
+        }
+    }
+
+    func shouldRaise(for target: WindowTarget) -> Bool {
+        switch self {
+        case .automatic: return !target.requiresNoRaise
+        case .always: return true
+        case .never: return false
+        }
+    }
+
+    static func decode(_ rawValue: String?) -> Self {
+        guard let rawValue, let policy = Self(rawValue: rawValue) else {
+            return .automatic
+        }
+        return policy
+    }
+}

--- a/apps/kree/Sources/Kree/SettingsView.swift
+++ b/apps/kree/Sources/Kree/SettingsView.swift
@@ -42,6 +42,18 @@ struct SettingsView: View {
                     }
                 }
                 .padding(.vertical, 4)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Picker("Raise focused windows", selection: $appState.focusRaisePolicy) {
+                        ForEach(FocusRaisePolicy.allCases) { policy in
+                            Text(policy.displayName).tag(policy)
+                        }
+                    }
+                    Text("Choose whether focusing may move a window above overlapping windows.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.vertical, 4)
             }
         }
         .padding()

--- a/apps/kree/Sources/Kree/SkyLightFocus.swift
+++ b/apps/kree/Sources/Kree/SkyLightFocus.swift
@@ -1,0 +1,225 @@
+import CoreGraphics
+import Darwin
+import Foundation
+
+internal struct SkyLightProcessSerialNumber: Equatable {
+    internal var high: UInt32
+    internal var low: UInt32
+    internal init(high: UInt32, low: UInt32) { self.high = high; self.low = low }
+}
+
+internal struct SkyLightWindowSnapshot: Equatable {
+    internal let windowID: CGWindowID
+    internal let ownerPID: pid_t
+    internal let bounds: CGRect
+}
+
+internal enum SkyLightRecordKind: Equatable { case first, second }
+
+internal enum SkyLightOperationError: Error, Equatable {
+    case unavailable(String)
+    case failed(step: String, status: Int32)
+}
+
+internal enum SkyLightNoMutationReason: Equatable {
+    case unavailable(String)
+    case staleTarget
+    case resolutionFailed(String)
+}
+
+internal struct SkyLightRecordFailure: Equatable {
+    internal let kind: SkyLightRecordKind
+    internal let status: Int32
+}
+
+internal enum SkyLightFocusOutcome: Equatable {
+    case noMutation(reason: SkyLightNoMutationReason)
+    case setterFailed(status: Int32)
+    case recordFailures(SkyLightRecordFailure?, SkyLightRecordFailure?)
+    case requestAccepted
+}
+
+internal protocol SkyLightOperations: AnyObject {
+    var missingSymbols: [String] { get }
+    func windowSnapshot(for windowID: CGWindowID) -> Result<SkyLightWindowSnapshot, SkyLightOperationError>
+    func processPSN(for pid: pid_t) -> Result<SkyLightProcessSerialNumber, SkyLightOperationError>
+    func setFrontProcess(
+        _ process: SkyLightProcessSerialNumber,
+        windowID: CGWindowID,
+        options: UInt32
+    ) -> Result<Void, SkyLightOperationError>
+    func postEventRecord(to process: SkyLightProcessSerialNumber, record: [UInt8]) -> Result<Void, SkyLightOperationError>
+}
+
+internal final class SkyLightFocus {
+    private let operations: SkyLightOperations
+
+    internal init(operations: SkyLightOperations? = nil) { self.operations = operations ?? DynamicSkyLightOperations() }
+    internal var isAvailable: Bool { operations.missingSymbols.isEmpty }
+    internal var missingSymbols: [String] { operations.missingSymbols }
+
+    internal static func makeRecord(windowID: CGWindowID, kind: SkyLightRecordKind) -> [UInt8] {
+        var record = [UInt8](repeating: 0, count: 248)
+        record[0x04] = 0xf8
+        record[0x3a] = 0x10
+        record.replaceSubrange(0x20..<0x30, with: repeatElement(0xff, count: 16))
+        let windowBytes = withUnsafeBytes(of: windowID.littleEndian) { Array($0) }
+        record.replaceSubrange(0x3c..<0x40, with: windowBytes)
+        record[0x08] = kind == .first ? 0x01 : 0x02
+        return record
+    }
+
+    /// Accepts only the setter and the two ordered record posts. There is no
+    /// AX/AppKit fallback and no postcondition or front-process verification.
+    internal func activate(target: WindowTarget, raise: Bool) -> SkyLightFocusOutcome {
+        guard isAvailable else {
+            return .noMutation(reason: .unavailable(missingSymbols.joined(separator: ", ")))
+        }
+
+        let targetProcess: SkyLightProcessSerialNumber
+        switch operations.processPSN(for: target.ownerPID) {
+        case let .success(process): targetProcess = process
+        case let .failure(error): return .noMutation(reason: .resolutionFailed(error.description))
+        }
+
+        // The last operation before mutation is an exact identity check.
+        guard case let .success(snapshot) = operations.windowSnapshot(for: target.windowID),
+              Self.matches(snapshot: snapshot, target: target)
+        else { return .noMutation(reason: .staleTarget) }
+
+        let options: UInt32 = raise ? 0x200 : 0x600
+        switch operations.setFrontProcess(targetProcess, windowID: target.windowID, options: options) {
+        case let .failure(error): return .setterFailed(status: error.statusCode)
+        case .success: break
+        }
+
+        let records = [
+            (SkyLightRecordKind.first, Self.makeRecord(windowID: target.windowID, kind: .first)),
+            (SkyLightRecordKind.second, Self.makeRecord(windowID: target.windowID, kind: .second))
+        ]
+        var firstFailure: SkyLightRecordFailure?
+        var secondFailure: SkyLightRecordFailure?
+        // Once the setter succeeds, always attempt both posts in this order.
+        for (kind, record) in records {
+            if case let .failure(error) = operations.postEventRecord(to: targetProcess, record: record) {
+                let failure = SkyLightRecordFailure(kind: kind, status: error.statusCode)
+                switch kind {
+                case .first: firstFailure = failure
+                case .second: secondFailure = failure
+                }
+            }
+        }
+        return firstFailure == nil && secondFailure == nil
+            ? .requestAccepted
+            : .recordFailures(firstFailure, secondFailure)
+    }
+
+    private static func matches(snapshot: SkyLightWindowSnapshot, target: WindowTarget) -> Bool {
+        snapshot.windowID == target.windowID && snapshot.ownerPID == target.ownerPID
+            && snapshot.bounds == target.bounds
+    }
+}
+
+private extension SkyLightOperationError {
+    var description: String {
+        switch self {
+        case let .unavailable(reason): return reason
+        case let .failed(step, status): return "\(step) (status \(status))"
+        }
+    }
+    var statusCode: Int32 { if case let .failed(_, status) = self { return status }; return -1 }
+}
+
+private final class DynamicSkyLightOperations: SkyLightOperations {
+    private typealias GetProcessForPID = @convention(c) (pid_t, UnsafeMutableRawPointer?) -> Int32
+    private typealias SetFrontProcessWithOptions = @convention(c) (UnsafeMutableRawPointer?, UInt32, UInt32) -> Int32
+    private typealias PostEventRecordTo = @convention(c) (UnsafeMutableRawPointer?, UnsafePointer<UInt8>?) -> Int32
+    private static let frameworkPath = "/System/Library/PrivateFrameworks/SkyLight.framework/SkyLight"
+    private static let applicationServicesPath = "/System/Library/Frameworks/ApplicationServices.framework/ApplicationServices"
+    private let handle: UnsafeMutableRawPointer?
+    private let applicationServicesHandle: UnsafeMutableRawPointer?
+    private let processForPID: GetProcessForPID?
+    private let setFront: SetFrontProcessWithOptions?
+    private let setFrontSymbol: String?
+    private let postRecord: PostEventRecordTo?
+
+    internal init() {
+        handle = dlopen(Self.frameworkPath, RTLD_LAZY | RTLD_LOCAL)
+        applicationServicesHandle = dlopen(Self.applicationServicesPath, RTLD_LAZY | RTLD_LOCAL)
+        processForPID = Self.load(GetProcessForPID.self, handle, "GetProcessForPID")
+            ?? Self.load(GetProcessForPID.self, applicationServicesHandle, "GetProcessForPID")
+        if let primary = Self.load(SetFrontProcessWithOptions.self, handle, "SLPSSetFrontProcessWithOptions") {
+            setFront = primary; setFrontSymbol = "SLPSSetFrontProcessWithOptions"
+        } else {
+            setFront = Self.load(SetFrontProcessWithOptions.self, handle, "_SLPSSetFrontProcessWithOptions")
+            setFrontSymbol = setFront == nil ? nil : "_SLPSSetFrontProcessWithOptions"
+        }
+        postRecord = Self.load(PostEventRecordTo.self, handle, "SLPSPostEventRecordTo")
+    }
+
+    deinit {
+        if let handle { dlclose(handle) }
+        if let applicationServicesHandle { dlclose(applicationServicesHandle) }
+    }
+
+    var missingSymbols: [String] {
+        var missing: [String] = []
+        if !Self.isSupportedOperatingSystem { missing.append("macOS 14+") }
+        if handle == nil { missing.append("SkyLight.framework") }
+        if processForPID == nil { missing.append("GetProcessForPID") }
+        if postRecord == nil { missing.append("SLPSPostEventRecordTo") }
+        if setFrontSymbol == nil { missing.append("SLPSSetFrontProcessWithOptions/_SLPSSetFrontProcessWithOptions") }
+        return missing
+    }
+
+    private static var isSupportedOperatingSystem: Bool {
+        if #available(macOS 14.0, *) { return true }
+        return false
+    }
+
+    func windowSnapshot(for windowID: CGWindowID) -> Result<SkyLightWindowSnapshot, SkyLightOperationError> {
+        let options: CGWindowListOption = [.optionIncludingWindow, .excludeDesktopElements]
+        guard let windows = CGWindowListCopyWindowInfo(options, windowID) as? [[String: Any]],
+              let info = windows.first,
+              let returnedID = (info[kCGWindowNumber as String] as? NSNumber)?.uint32Value,
+              let ownerPID = (info[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value,
+              let bounds = info[kCGWindowBounds as String] as? NSDictionary,
+              let rect = CGRect(dictionaryRepresentation: bounds as CFDictionary)
+        else { return .failure(.unavailable("window snapshot")) }
+        return .success(SkyLightWindowSnapshot(windowID: returnedID, ownerPID: pid_t(ownerPID), bounds: rect))
+    }
+
+    func processPSN(for pid: pid_t) -> Result<SkyLightProcessSerialNumber, SkyLightOperationError> {
+        guard let processForPID else { return .failure(.unavailable("GetProcessForPID")) }
+        var process = SkyLightProcessSerialNumber(high: 0, low: 0)
+        let status = withUnsafeMutablePointer(to: &process) { processForPID(pid, UnsafeMutableRawPointer($0)) }
+        return status == 0 ? .success(process) : .failure(.failed(step: "PID PSN", status: status))
+    }
+
+    func setFrontProcess(
+        _ process: SkyLightProcessSerialNumber,
+        windowID: CGWindowID,
+        options: UInt32
+    ) -> Result<Void, SkyLightOperationError> {
+        guard let setFront else { return .failure(.unavailable("front process setter")) }
+        var process = process
+        let status = withUnsafeMutablePointer(to: &process) {
+            setFront(UnsafeMutableRawPointer($0), windowID, options)
+        }
+        return status == 0 ? .success(()) : .failure(.failed(step: "set front process", status: status))
+    }
+
+    func postEventRecord(to process: SkyLightProcessSerialNumber, record: [UInt8]) -> Result<Void, SkyLightOperationError> {
+        guard let postRecord else { return .failure(.unavailable("SLPSPostEventRecordTo")) }
+        var process = process
+        let status = record.withUnsafeBufferPointer { bytes in
+            withUnsafeMutablePointer(to: &process) { postRecord(UnsafeMutableRawPointer($0), bytes.baseAddress) }
+        }
+        return status == 0 ? .success(()) : .failure(.failed(step: "post event record", status: status))
+    }
+
+    private static func load<T>(_ type: T.Type, _ handle: UnsafeMutableRawPointer?, _ name: String) -> T? {
+        guard let handle, let symbol = dlsym(handle, name) else { return nil }
+        return unsafeBitCast(symbol, to: T.self)
+    }
+}

--- a/apps/kree/Sources/Kree/SkyLightFocus.swift
+++ b/apps/kree/Sources/Kree/SkyLightFocus.swift
@@ -114,9 +114,12 @@ internal final class SkyLightFocus {
             : .recordFailures(firstFailure, secondFailure)
     }
 
+    // Identity is (window ID, owner PID). Bounds are deliberately not compared:
+    // a window that moved or resized since the hit test is still the same
+    // window, and rejecting it here would drop focus until the next pointer
+    // move.
     private static func matches(snapshot: SkyLightWindowSnapshot, target: WindowTarget) -> Bool {
         snapshot.windowID == target.windowID && snapshot.ownerPID == target.ownerPID
-            && snapshot.bounds == target.bounds
     }
 }
 

--- a/apps/kree/Sources/Kree/WindowHitTester.swift
+++ b/apps/kree/Sources/Kree/WindowHitTester.swift
@@ -1,0 +1,234 @@
+import CoreGraphics
+import Foundation
+
+/// The window selected by the public CoreGraphics hit tester.
+internal struct WindowTarget: Equatable {
+    let windowID: CGWindowID
+    let ownerPID: pid_t
+    let bounds: CGRect
+    let ownerName: String
+    /// A higher window overlaps this target, so focusing it must not raise it
+    /// above the covering window. This mirrors the policy used by the
+    /// SkyLight-backed path: preserve the visible stack while changing the
+    /// focused window.
+    let requiresNoRaise: Bool
+
+    init(
+        windowID: CGWindowID,
+        ownerPID: pid_t,
+        bounds: CGRect,
+        ownerName: String,
+        requiresNoRaise: Bool = false
+    ) {
+        self.windowID = windowID
+        self.ownerPID = ownerPID
+        self.bounds = bounds
+        self.ownerName = ownerName
+        self.requiresNoRaise = requiresNoRaise
+    }
+}
+
+/// The result of testing the window stack at a screen point.
+internal enum WindowHitResult: Equatable {
+    case target(WindowTarget)
+    case blocked
+    case none
+}
+
+/// A normalized window-list entry. The same value is used by the live and
+/// synthetic hit-test paths so the selection policy stays deterministic.
+internal struct WindowCandidate: Equatable {
+    let windowID: CGWindowID
+    let ownerPID: pid_t
+    let layer: Int
+    let bounds: CGRect
+    let ownerName: String
+
+    init(
+        windowID: CGWindowID,
+        ownerPID: pid_t,
+        layer: Int,
+        bounds: CGRect,
+        ownerName: String
+    ) {
+        self.windowID = windowID
+        self.ownerPID = ownerPID
+        self.layer = layer
+        self.bounds = bounds
+        self.ownerName = ownerName
+    }
+
+    var isWindowServer: Bool {
+        ownerName == "Window Server"
+    }
+}
+
+/// Selects the frontmost eligible CoreGraphics window at a point.
+internal struct WindowHitTester {
+    private static let minimumVisibleFraction: CGFloat = 0.30
+
+    /// Reads the on-screen window list in the order supplied by WindowServer.
+    /// `CGWindowListCopyWindowInfo` returns front-to-back entries for this
+    /// option set, so the pure overload can apply the same ordering policy.
+    func hitTest(at point: CGPoint) -> WindowHitResult {
+        let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+        guard let info = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] else {
+            return .none
+        }
+
+        var displayIDs = [CGDirectDisplayID](repeating: 0, count: 16)
+        var displayCount: UInt32 = 0
+        let displayResult = CGGetActiveDisplayList(UInt32(displayIDs.count), &displayIDs, &displayCount)
+        guard displayResult == .success else {
+            return .none
+        }
+
+        let displayRects = displayIDs.prefix(Int(displayCount)).map(CGDisplayBounds)
+        let candidates = info.compactMap(Self.candidate(from:))
+        return Self.hitTest(point: point, candidates: candidates, displayRects: displayRects)
+    }
+
+    /// Pure selection policy for tests and callers that already have a
+    /// normalized CoreGraphics window snapshot.
+    static func hitTest(
+        point: CGPoint,
+        candidates: [WindowCandidate],
+        displayRects: [CGRect]
+    ) -> WindowHitResult {
+        for (index, candidate) in candidates.enumerated() {
+            guard candidate.bounds.contains(point) else {
+                continue
+            }
+
+            // Window Server entries describe infrastructure rather than an
+            // application window and must never become blockers or targets.
+            if candidate.isWindowServer {
+                continue
+            }
+
+            // A visible positive-layer window is a blocker even when most of
+            // its frame is parked offscreen. Applying the target visibility
+            // threshold first would tunnel through a small visible portion of
+            // a password prompt or floating panel.
+            if candidate.layer > 0 {
+                return .blocked
+            }
+
+            guard candidate.layer == 0,
+                isEligible(candidate, displayRects: displayRects)
+            else { continue }
+
+            return .target(WindowTarget(
+                windowID: candidate.windowID,
+                ownerPID: candidate.ownerPID,
+                bounds: candidate.bounds,
+                ownerName: candidate.ownerName,
+                requiresNoRaise: isCovered(
+                    candidate,
+                    by: candidates[..<index]
+                )
+            ))
+        }
+
+        return .none
+    }
+
+    private static func candidate(from info: [String: Any]) -> WindowCandidate? {
+        guard
+            let windowID = (info[kCGWindowNumber as String] as? NSNumber).map({ CGWindowID($0.uint32Value) }),
+            let ownerPID = (info[kCGWindowOwnerPID as String] as? NSNumber).map({ pid_t($0.int32Value) }),
+            let layer = (info[kCGWindowLayer as String] as? NSNumber)?.intValue,
+            let bounds = info[kCGWindowBounds as String] as? NSDictionary,
+            let rect = CGRect(dictionaryRepresentation: bounds as CFDictionary)
+        else {
+            return nil
+        }
+
+        return WindowCandidate(
+            windowID: windowID,
+            ownerPID: ownerPID,
+            layer: layer,
+            bounds: rect,
+            ownerName: info[kCGWindowOwnerName as String] as? String ?? ""
+        )
+    }
+
+    private static func isEligible(_ candidate: WindowCandidate, displayRects: [CGRect]) -> Bool {
+        let bounds = candidate.bounds
+        guard bounds.width > 0, bounds.height > 0 else {
+            return false
+        }
+
+        let windowArea = bounds.width * bounds.height
+        guard windowArea > 0 else {
+            return false
+        }
+
+        let visibleRects = displayRects.compactMap { displayRect -> CGRect? in
+            let intersection = bounds.intersection(displayRect)
+            guard intersection.width > 0, intersection.height > 0 else {
+                return nil
+            }
+            return intersection
+        }
+
+        return unionArea(of: visibleRects) / windowArea >= minimumVisibleFraction
+    }
+
+    private static func isCovered(
+        _ candidate: WindowCandidate,
+        by priorCandidates: ArraySlice<WindowCandidate>
+    ) -> Bool {
+        priorCandidates.contains { prior in
+            guard !prior.isWindowServer else { return false }
+            let overlap = prior.bounds.intersection(candidate.bounds)
+            return overlap.width > 4 && overlap.height > 4
+        }
+    }
+
+    /// Computes rectangle union area with a vertical sweep. This avoids
+    /// double-counting overlapping displays and also handles negative screen
+    /// coordinates without assuming a primary-display origin.
+    private static func unionArea(of rects: [CGRect]) -> CGFloat {
+        let validRects = rects.filter { $0.width > 0 && $0.height > 0 }
+        let xCoordinates = Set(validRects.flatMap { [$0.minX, $0.maxX] }).sorted()
+        guard xCoordinates.count > 1 else {
+            return 0
+        }
+
+        var area: CGFloat = 0
+        for pair in zip(xCoordinates, xCoordinates.dropFirst()) {
+            let xStart = pair.0
+            let xEnd = pair.1
+            let width = xEnd - xStart
+            guard width > 0 else { continue }
+
+            let yIntervals = validRects.compactMap { rect -> (CGFloat, CGFloat)? in
+                guard rect.minX < xEnd, rect.maxX > xStart else { return nil }
+                return (rect.minY, rect.maxY)
+            }.sorted { $0.0 < $1.0 }
+
+            var coveredHeight: CGFloat = 0
+            var currentInterval: (CGFloat, CGFloat)?
+            for interval in yIntervals {
+                guard let current = currentInterval else {
+                    currentInterval = interval
+                    continue
+                }
+
+                if interval.0 <= current.1 {
+                    currentInterval = (current.0, max(current.1, interval.1))
+                } else {
+                    coveredHeight += current.1 - current.0
+                    currentInterval = interval
+                }
+            }
+            if let current = currentInterval {
+                coveredHeight += current.1 - current.0
+            }
+
+            area += width * coveredHeight
+        }
+        return area
+    }
+}

--- a/apps/kree/Sources/Kree/WindowHitTester.swift
+++ b/apps/kree/Sources/Kree/WindowHitTester.swift
@@ -13,6 +13,12 @@ internal struct WindowTarget: Equatable {
     /// focused window.
     let requiresNoRaise: Bool
 
+    /// Window identity is the (window ID, owner PID) pair. Bounds and coverage
+    /// describe the window's current state, not which window it is.
+    func hasSameIdentity(as other: WindowTarget) -> Bool {
+        windowID == other.windowID && ownerPID == other.ownerPID
+    }
+
     init(
         windowID: CGWindowID,
         ownerPID: pid_t,

--- a/apps/kree/Tests/KreeTests/FocusAttemptGateTests.swift
+++ b/apps/kree/Tests/KreeTests/FocusAttemptGateTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+@testable import Kree
+
+final class FocusAttemptGateTests: XCTestCase {
+    func testReservesOnlyAfterCooldown() {
+        let gate = FocusAttemptGate()
+
+        XCTAssertTrue(gate.reserve(after: 0.25, now: 10.0))
+        XCTAssertEqual(gate.remaining(after: 0.25, now: 10.1), 0.15, accuracy: 0.000_001)
+        XCTAssertFalse(gate.reserve(after: 0.25, now: 10.1))
+        XCTAssertTrue(gate.reserve(after: 0.25, now: 10.26))
+    }
+}

--- a/apps/kree/Tests/KreeTests/FocusGenerationTests.swift
+++ b/apps/kree/Tests/KreeTests/FocusGenerationTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import Kree
+
+final class FocusGenerationTests: XCTestCase {
+    func testInvalidationMakesEarlierTokenStale() {
+        let generation = FocusGeneration()
+        let first = generation.activate()
+
+        XCTAssertTrue(generation.isCurrent(first))
+
+        let second = generation.invalidate()
+
+        XCTAssertFalse(generation.isCurrent(first))
+        XCTAssertTrue(generation.isCurrent(second))
+    }
+
+    func testDeactivationInvalidatesTokenAndStopsActivity() {
+        let generation = FocusGeneration()
+        let token = generation.activate()
+
+        generation.deactivate()
+
+        XCTAssertFalse(generation.isActive())
+        XCTAssertFalse(generation.isCurrent(token))
+    }
+}

--- a/apps/kree/Tests/KreeTests/FocusRaisePolicyTests.swift
+++ b/apps/kree/Tests/KreeTests/FocusRaisePolicyTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import Kree
+
+final class FocusRaisePolicyTests: XCTestCase {
+    func testRawValuesAreStable() {
+        XCTAssertEqual(FocusRaisePolicy.allCases.map(\.rawValue), ["automatic", "always", "never"])
+        XCTAssertEqual(FocusRaisePolicy.allCases.map(\.displayName), ["Automatic", "Always", "Never"])
+    }
+
+    func testShouldRaiseMapping() {
+        let target = WindowTarget(
+            windowID: 1,
+            ownerPID: 2,
+            bounds: .zero,
+            ownerName: "Test"
+        )
+        let coveredTarget = WindowTarget(
+            windowID: 3,
+            ownerPID: 4,
+            bounds: .zero,
+            ownerName: "Test",
+            requiresNoRaise: true
+        )
+
+        XCTAssertTrue(FocusRaisePolicy.automatic.shouldRaise(for: target))
+        XCTAssertFalse(FocusRaisePolicy.automatic.shouldRaise(for: coveredTarget))
+        XCTAssertTrue(FocusRaisePolicy.always.shouldRaise(for: coveredTarget))
+        XCTAssertFalse(FocusRaisePolicy.never.shouldRaise(for: target))
+    }
+
+    func testDecodeDefaultsMissingAndUnknownValuesToAutomatic() {
+        XCTAssertEqual(FocusRaisePolicy.decode(nil), .automatic)
+        XCTAssertEqual(FocusRaisePolicy.decode("unexpected"), .automatic)
+        XCTAssertEqual(FocusRaisePolicy.decode("always"), .always)
+    }
+}

--- a/apps/kree/Tests/KreeTests/SkyLightFocusTests.swift
+++ b/apps/kree/Tests/KreeTests/SkyLightFocusTests.swift
@@ -1,0 +1,169 @@
+import CoreGraphics
+import XCTest
+@testable import Kree
+
+final class SkyLightFocusTests: XCTestCase {
+    func testRecordLayoutAndOrderedMarkers() {
+        let first = SkyLightFocus.makeRecord(windowID: 0x11223344, kind: .first)
+        let second = SkyLightFocus.makeRecord(windowID: 0x11223344, kind: .second)
+
+        XCTAssertEqual(first.count, 248)
+        XCTAssertEqual(first[0x04], 0xf8)
+        XCTAssertEqual(first[0x3a], 0x10)
+        XCTAssertEqual(Array(first[0x20..<0x30]), Array(repeating: 0xff, count: 16))
+        XCTAssertEqual(Array(first[0x3c..<0x40]), [0x44, 0x33, 0x22, 0x11])
+        XCTAssertEqual(first[0x08], 0x01)
+        XCTAssertEqual(second[0x08], 0x02)
+    }
+
+    func testMissingCapabilityFailsClosedWithoutMutation() {
+        let fake = configuredFake()
+        fake.missingSymbols = ["SLPSSetFrontProcessWithOptions/_SLPSSetFrontProcessWithOptions"]
+
+        let outcome = SkyLightFocus(operations: fake).activate(target: makeTarget(), raise: false)
+
+        XCTAssertEqual(outcome, .noMutation(reason: .unavailable(fake.missingSymbols[0])))
+        XCTAssertTrue(fake.calls.isEmpty)
+    }
+
+    func testRaiseAndNoRaiseUseExactSetterOptions() {
+        let fake = configuredFake()
+        XCTAssertEqual(SkyLightFocus(operations: fake).activate(target: makeTarget(), raise: true), .requestAccepted)
+        XCTAssertEqual(fake.setterOptions, [0x200])
+        XCTAssertEqual(fake.setterWindowIDs, [123])
+
+        let noRaise = configuredFake()
+        XCTAssertEqual(SkyLightFocus(operations: noRaise).activate(target: makeTarget(), raise: false), .requestAccepted)
+        XCTAssertEqual(noRaise.setterOptions, [0x600])
+        XCTAssertEqual(noRaise.setterWindowIDs, [123])
+    }
+
+    func testTransactionUsesPIDPSNFinalSnapshotTargetPSNAndCallOrder() {
+        let fake = configuredFake()
+        let target = makeTarget()
+
+        XCTAssertEqual(SkyLightFocus(operations: fake).activate(target: target, raise: false), .requestAccepted)
+        XCTAssertEqual(fake.calls, ["pid-psn", "snapshot", "setter", "post-1", "post-2"])
+        XCTAssertEqual(fake.setterProcess, .init(high: 3, low: 4))
+        XCTAssertEqual(fake.setterWindowID, 123)
+        XCTAssertEqual(fake.postProcesses, [.init(high: 3, low: 4), .init(high: 3, low: 4)])
+        XCTAssertEqual(fake.records.map { $0[0x08] }, [0x01, 0x02])
+    }
+
+    func testBothSetterSpellingsAreRepresentedByInjectedOperation() {
+        for spelling in ["SLPSSetFrontProcessWithOptions", "_SLPSSetFrontProcessWithOptions"] {
+            let fake = configuredFake()
+            fake.setterSpelling = spelling
+            XCTAssertEqual(SkyLightFocus(operations: fake).activate(target: makeTarget(), raise: true), .requestAccepted)
+            XCTAssertEqual(fake.usedSetterSpelling, spelling)
+        }
+    }
+
+    func testSetterFailurePostsNoRecords() {
+        let fake = configuredFake()
+        fake.setterResult = .failure(.failed(step: "setter", status: 17))
+
+        XCTAssertEqual(SkyLightFocus(operations: fake).activate(target: makeTarget(), raise: false), .setterFailed(status: 17))
+        XCTAssertEqual(fake.calls, ["pid-psn", "snapshot", "setter"])
+    }
+
+    func testBothRecordFailuresAreReportedAndBothAreAttempted() {
+        let fake = configuredFake()
+        fake.postResults = [
+            .failure(.failed(step: "first", status: 21)),
+            .failure(.failed(step: "second", status: 22))
+        ]
+
+        XCTAssertEqual(
+            SkyLightFocus(operations: fake).activate(target: makeTarget(), raise: false),
+            .recordFailures(
+                SkyLightRecordFailure(kind: .first, status: 21),
+                SkyLightRecordFailure(kind: .second, status: 22)
+            )
+        )
+        XCTAssertEqual(fake.calls.suffix(2), ["post-1", "post-2"])
+    }
+
+    func testSecondRecordFailureKeepsItsPositionalSlot() {
+        let fake = configuredFake()
+        fake.postResults = [
+            .success(()),
+            .failure(.failed(step: "second", status: 22))
+        ]
+
+        XCTAssertEqual(
+            SkyLightFocus(operations: fake).activate(target: makeTarget(), raise: false),
+            .recordFailures(
+                nil,
+                SkyLightRecordFailure(kind: .second, status: 22)
+            )
+        )
+    }
+
+    func testRejectsRecycledWindowIDOwnerMismatchAndBoundsMismatch() {
+        let ownerMismatch = configuredFake()
+        ownerMismatch.snapshot = .success(SkyLightWindowSnapshot(windowID: 123, ownerPID: 99, bounds: makeTarget().bounds))
+        XCTAssertEqual(SkyLightFocus(operations: ownerMismatch).activate(target: makeTarget(), raise: false), .noMutation(reason: .staleTarget))
+        XCTAssertFalse(ownerMismatch.calls.contains("setter"))
+
+        let boundsMismatch = configuredFake()
+        boundsMismatch.snapshot = .success(SkyLightWindowSnapshot(windowID: 123, ownerPID: 42, bounds: CGRect(x: 0, y: 0, width: 80.25, height: 80)))
+        XCTAssertEqual(SkyLightFocus(operations: boundsMismatch).activate(target: makeTarget(), raise: false), .noMutation(reason: .staleTarget))
+        XCTAssertFalse(boundsMismatch.calls.contains("setter"))
+    }
+
+    private func makeTarget() -> WindowTarget {
+        WindowTarget(windowID: 123, ownerPID: 42, bounds: CGRect(x: 0, y: 0, width: 80, height: 80), ownerName: "Test")
+    }
+
+    private func configuredFake() -> FakeSkyLightOperations {
+        let fake = FakeSkyLightOperations()
+        fake.snapshot = .success(SkyLightWindowSnapshot(windowID: 123, ownerPID: 42, bounds: makeTarget().bounds))
+        fake.pidProcess = .success(.init(high: 3, low: 4))
+        return fake
+    }
+}
+
+private final class FakeSkyLightOperations: SkyLightOperations {
+    var missingSymbols: [String] = []
+    var snapshot: Result<SkyLightWindowSnapshot, SkyLightOperationError> = .failure(.unavailable("snapshot"))
+    var pidProcess: Result<SkyLightProcessSerialNumber, SkyLightOperationError> = .failure(.unavailable("PID PSN"))
+    var setterResult: Result<Void, SkyLightOperationError> = .success(())
+    var postResults: [Result<Void, SkyLightOperationError>] = [.success(()), .success(())]
+    var setterOptions: [UInt32] = []
+    var setterWindowIDs: [CGWindowID] = []
+    var setterWindowID: CGWindowID?
+    var setterProcess: SkyLightProcessSerialNumber?
+    var postProcesses: [SkyLightProcessSerialNumber] = []
+    var records: [[UInt8]] = []
+    var setterSpelling = "SLPSSetFrontProcessWithOptions"
+    var usedSetterSpelling: String?
+    var calls: [String] = []
+
+    func windowSnapshot(for windowID: CGWindowID) -> Result<SkyLightWindowSnapshot, SkyLightOperationError> {
+        calls.append("snapshot")
+        return snapshot
+    }
+
+    func processPSN(for pid: pid_t) -> Result<SkyLightProcessSerialNumber, SkyLightOperationError> {
+        calls.append("pid-psn")
+        return pidProcess
+    }
+
+    func setFrontProcess(_ process: SkyLightProcessSerialNumber, windowID: CGWindowID, options: UInt32) -> Result<Void, SkyLightOperationError> {
+        calls.append("setter")
+        setterOptions.append(options)
+        setterWindowIDs.append(windowID)
+        setterWindowID = windowID
+        setterProcess = process
+        usedSetterSpelling = setterSpelling
+        return setterResult
+    }
+
+    func postEventRecord(to process: SkyLightProcessSerialNumber, record: [UInt8]) -> Result<Void, SkyLightOperationError> {
+        calls.append(record[0x08] == 0x01 ? "post-1" : "post-2")
+        postProcesses.append(process)
+        records.append(record)
+        return postResults.removeFirst()
+    }
+}

--- a/apps/kree/Tests/KreeTests/SkyLightFocusTests.swift
+++ b/apps/kree/Tests/KreeTests/SkyLightFocusTests.swift
@@ -50,15 +50,6 @@ final class SkyLightFocusTests: XCTestCase {
         XCTAssertEqual(fake.records.map { $0[0x08] }, [0x01, 0x02])
     }
 
-    func testBothSetterSpellingsAreRepresentedByInjectedOperation() {
-        for spelling in ["SLPSSetFrontProcessWithOptions", "_SLPSSetFrontProcessWithOptions"] {
-            let fake = configuredFake()
-            fake.setterSpelling = spelling
-            XCTAssertEqual(SkyLightFocus(operations: fake).activate(target: makeTarget(), raise: true), .requestAccepted)
-            XCTAssertEqual(fake.usedSetterSpelling, spelling)
-        }
-    }
-
     func testSetterFailurePostsNoRecords() {
         let fake = configuredFake()
         fake.setterResult = .failure(.failed(step: "setter", status: 17))
@@ -100,16 +91,18 @@ final class SkyLightFocusTests: XCTestCase {
         )
     }
 
-    func testRejectsRecycledWindowIDOwnerMismatchAndBoundsMismatch() {
+    func testRejectsRecycledWindowIDOwnerMismatch() {
         let ownerMismatch = configuredFake()
         ownerMismatch.snapshot = .success(SkyLightWindowSnapshot(windowID: 123, ownerPID: 99, bounds: makeTarget().bounds))
         XCTAssertEqual(SkyLightFocus(operations: ownerMismatch).activate(target: makeTarget(), raise: false), .noMutation(reason: .staleTarget))
         XCTAssertFalse(ownerMismatch.calls.contains("setter"))
+    }
 
-        let boundsMismatch = configuredFake()
-        boundsMismatch.snapshot = .success(SkyLightWindowSnapshot(windowID: 123, ownerPID: 42, bounds: CGRect(x: 0, y: 0, width: 80.25, height: 80)))
-        XCTAssertEqual(SkyLightFocus(operations: boundsMismatch).activate(target: makeTarget(), raise: false), .noMutation(reason: .staleTarget))
-        XCTAssertFalse(boundsMismatch.calls.contains("setter"))
+    func testMovedWindowWithSameIdentityIsStillActivated() {
+        let moved = configuredFake()
+        moved.snapshot = .success(SkyLightWindowSnapshot(windowID: 123, ownerPID: 42, bounds: CGRect(x: 10, y: 20, width: 80.25, height: 80)))
+        XCTAssertEqual(SkyLightFocus(operations: moved).activate(target: makeTarget(), raise: false), .requestAccepted)
+        XCTAssertTrue(moved.calls.contains("setter"))
     }
 
     private func makeTarget() -> WindowTarget {
@@ -136,8 +129,6 @@ private final class FakeSkyLightOperations: SkyLightOperations {
     var setterProcess: SkyLightProcessSerialNumber?
     var postProcesses: [SkyLightProcessSerialNumber] = []
     var records: [[UInt8]] = []
-    var setterSpelling = "SLPSSetFrontProcessWithOptions"
-    var usedSetterSpelling: String?
     var calls: [String] = []
 
     func windowSnapshot(for windowID: CGWindowID) -> Result<SkyLightWindowSnapshot, SkyLightOperationError> {
@@ -156,7 +147,6 @@ private final class FakeSkyLightOperations: SkyLightOperations {
         setterWindowIDs.append(windowID)
         setterWindowID = windowID
         setterProcess = process
-        usedSetterSpelling = setterSpelling
         return setterResult
     }
 

--- a/apps/kree/Tests/KreeTests/WindowHitTesterTests.swift
+++ b/apps/kree/Tests/KreeTests/WindowHitTesterTests.swift
@@ -1,0 +1,157 @@
+import CoreGraphics
+import XCTest
+@testable import Kree
+
+final class WindowHitTesterTests: XCTestCase {
+    private let display = CGRect(x: 0, y: 0, width: 1000, height: 800)
+
+    func testSelectsFirstContainingLayerZeroWindow() {
+        let result = hitTest([
+            candidate(id: 1, bounds: CGRect(x: 0, y: 0, width: 1000, height: 800)),
+            candidate(id: 2, bounds: CGRect(x: 100, y: 100, width: 400, height: 400))
+        ], at: CGPoint(x: 200, y: 200))
+
+        XCTAssertEqual(result, .target(WindowTarget(
+            windowID: 1,
+            ownerPID: 10,
+            bounds: display,
+            ownerName: "Example"
+        )))
+    }
+
+    func testPositiveLayerContainingPointBlocksLowerWindow() {
+        let result = hitTest([
+            candidate(id: 1, layer: 1, bounds: CGRect(x: 100, y: 100, width: 300, height: 300)),
+            candidate(id: 2, bounds: display)
+        ], at: CGPoint(x: 200, y: 200))
+
+        XCTAssertEqual(result, .blocked)
+    }
+
+    func testMostlyOffscreenPositiveLayerStillBlocksUnderlyingWindow() {
+        let result = hitTest([
+            candidate(id: 1, layer: 1, bounds: CGRect(x: 950, y: 0, width: 1000, height: 800)),
+            candidate(id: 2, bounds: display)
+        ], at: CGPoint(x: 975, y: 100))
+
+        XCTAssertEqual(result, .blocked)
+    }
+
+    func testWindowServerIsSkippedAndDoesNotBlock() {
+        let result = hitTest([
+            candidate(id: 1, layer: 2, ownerName: "Window Server", bounds: display),
+            candidate(id: 2, bounds: display)
+        ], at: CGPoint(x: 10, y: 10))
+
+        XCTAssertEqual(result, .target(WindowTarget(
+            windowID: 2,
+            ownerPID: 10,
+            bounds: display,
+            ownerName: "Example"
+        )))
+    }
+
+    func testOverlappingHigherWindowRequiresNoRaise() {
+        let result = hitTest([
+            candidate(id: 1, bounds: CGRect(x: 100, y: 100, width: 200, height: 200)),
+            candidate(id: 2, bounds: display)
+        ], at: CGPoint(x: 20, y: 20))
+
+        XCTAssertEqual(result, .target(WindowTarget(
+            windowID: 2,
+            ownerPID: 10,
+            bounds: display,
+            ownerName: "Example",
+            requiresNoRaise: true
+        )))
+    }
+
+    func testWindowServerDoesNotMakeTargetRequireNoRaise() {
+        let result = hitTest([
+            candidate(id: 1, layer: 2, ownerName: "Window Server", bounds: CGRect(x: 100, y: 100, width: 200, height: 200)),
+            candidate(id: 2, bounds: display)
+        ], at: CGPoint(x: 20, y: 20))
+
+        XCTAssertEqual(result, .target(WindowTarget(
+            windowID: 2,
+            ownerPID: 10,
+            bounds: display,
+            ownerName: "Example"
+        )))
+    }
+
+    func testRejectsNegativeAndZeroAreaCandidates() {
+        let result = hitTest([
+            candidate(id: 1, bounds: CGRect(x: 0, y: 0, width: 0, height: 100)),
+            candidate(id: 2, bounds: CGRect(x: 0, y: 0, width: -10, height: 100)),
+            candidate(id: 3, bounds: display)
+        ], at: CGPoint(x: 10, y: 10))
+
+        XCTAssertEqual(result, .target(WindowTarget(
+            windowID: 3,
+            ownerPID: 10,
+            bounds: display,
+            ownerName: "Example"
+        )))
+    }
+
+    func testRejectsOffscreenSliver() {
+        let result = hitTest([
+            candidate(id: 1, bounds: CGRect(x: 950, y: 0, width: 1000, height: 800))
+        ], at: CGPoint(x: 975, y: 100))
+
+        XCTAssertEqual(result, .none)
+    }
+
+    func testUnionsOverlappingDisplaysWithNegativeCoordinates() {
+        let displays = [
+            CGRect(x: -1000, y: 0, width: 1000, height: 800),
+            CGRect(x: -500, y: 0, width: 1000, height: 800)
+        ]
+        let result = hitTest([
+            candidate(id: 1, bounds: CGRect(x: -1000, y: 0, width: 1500, height: 800))
+        ], displays: displays, at: CGPoint(x: -750, y: 200))
+
+        XCTAssertEqual(result, .target(WindowTarget(
+            windowID: 1,
+            ownerPID: 10,
+            bounds: CGRect(x: -1000, y: 0, width: 1500, height: 800),
+            ownerName: "Example"
+        )))
+    }
+
+    func testReturnsNoResultWhenNothingContainsPoint() {
+        let result = hitTest([
+            candidate(id: 1, bounds: CGRect(x: 0, y: 0, width: 100, height: 100))
+        ], at: CGPoint(x: 500, y: 500))
+
+        XCTAssertEqual(result, .none)
+    }
+
+    private func hitTest(
+        _ candidates: [WindowCandidate],
+        displays: [CGRect]? = nil,
+        at point: CGPoint
+    ) -> WindowHitResult {
+        WindowHitTester.hitTest(
+            point: point,
+            candidates: candidates,
+            displayRects: displays ?? [display]
+        )
+    }
+
+    private func candidate(
+        id: CGWindowID,
+        layer: Int = 0,
+        ownerName: String = "Example",
+        bounds: CGRect
+    ) -> WindowCandidate {
+        WindowCandidate(
+            windowID: id,
+            ownerPID: 10,
+            layer: layer,
+            bounds: bounds,
+            ownerName: ownerName
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Add a persisted Automatic, Always, or Never window-raising setting.
- Route focus through SkyLight with configurable raise/no-raise options.
- Remove AX/AppKit focus fallback and focus postcondition verification.
- Add transaction, stale-window, policy, and window-hit tests.

## Verification

- 25 Kree tests passed.
- Release Swift build passed.
- Nix package build passed.

## Notes

SkyLight is private macOS SPI, so live runtime behavior still needs a macOS UI smoke test. Existing SwiftPM warnings remain for the missing Resources directory and unhandled Info.plist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a setting to control whether focused windows are automatically raised, always raised, or never raised.
  * Improved focus targeting across overlapping windows and multiple displays.
  * Added more reliable window activation and recovery when input interactions are interrupted.

* **Bug Fixes**
  * Prevented stale or repeated focus attempts from overriding newer interactions.

* **Tests**
  * Added comprehensive coverage for focus behavior, window targeting, activation, and raise-policy settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->